### PR TITLE
Feature - patient birthtime extension added

### DIFF
--- a/pages/_includes/au-patient-intro.md
+++ b/pages/_includes/au-patient-intro.md
@@ -79,6 +79,12 @@ An extension to hold the indication of registration to the Close the Gap co-paym
 Measure improves access to PBS medicines for eligible Aboriginal and Torres Strait Islanders living with, or at risk of, 
 chronic disease.
 
+* __Birth Time__
+
+[Standard STU3 extension](http://hl7.org/fhir/STU3/extension-patient-birthtime.html)
+
+An extension to record the time of day that the Patient was born. This includes the date to ensure that the timezone information can be communicated effectively.
+
 #### Examples
 
 [Patient with IHI, Medicare Number, and Health Care Card](Patient-example0.html)

--- a/pages/_includes/au-patient-summary.md
+++ b/pages/_includes/au-patient-summary.md
@@ -11,5 +11,6 @@ Australian Patient Profile contains:
 	* Choice (Identifier.type) - Health Care Card, Pensioner Concession Card, Commonwealth Seniors Health Card
 1. Optional Indigenous Status (as Extension)
 1. Optional Close the Gap Registration (as Extension)
+1. Optional Birth Time (as extension)
 1. Exclusion: Patient.animal (BackboneElement) - human only
 

--- a/resources/au-patient.xml
+++ b/resources/au-patient.xml
@@ -2,7 +2,7 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="au-patient" />
   <meta>
-    <lastUpdated value="2017-09-28T14:25:57.788+10:00" />
+    <lastUpdated value="2017-09-28T14:47:17.995+10:00" />
   </meta>
   <text>
     <status value="generated" /><div xmlns="http://www.w3.org/1999/xhtml" /></text>
@@ -63,17 +63,18 @@
         <profile value="http://hl7.org.au/fhir/StructureDefinition/close-the-gap-registration" />
       </type>
     </element>
-    <element id="Patient.extension:birthPlace">
+    <element id="Patient.extension:birthTime">
       <path value="Patient.extension" />
-      <sliceName value="birthPlace" />
-      <short value="Birth place extension" />
-      <definition value="The registered place of birth of the patient. A sytem may use the address.text if they don't store the birthPlace address in discrete elements." />
-      <requirements value="Allows for the recording of a patient's time of birth which is useful in a paediatrics context." />
+      <sliceName value="birthTime" />
+      <short value="Patient birth time extension" />
+      <definition value="The time of day that the Patient was born. This includes the date to ensure that the timezone information can be communicated effectively." />
+      <comment value="This extension provides the ability to record the time of day the patient was born." />
+      <requirements value="Allows for the recording of a patient's time of birth (as well as their date of birth), which is useful in a paediatrics context." />
       <min value="0" />
       <max value="1" />
       <type>
         <code value="Extension" />
-        <profile value="http://hl7.org/fhir/StructureDefinition/birthPlace" />
+        <profile value="http://hl7.org/fhir/StructureDefinition/patient-birthTime" />
       </type>
     </element>
     <element id="Patient.identifier.slicing">

--- a/resources/au-patient.xml
+++ b/resources/au-patient.xml
@@ -2,7 +2,7 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="au-patient" />
   <meta>
-    <lastUpdated value="2017-09-27T11:08:30.724+10:00" />
+    <lastUpdated value="2017-09-28T14:25:57.788+10:00" />
   </meta>
   <text>
     <status value="generated" /><div xmlns="http://www.w3.org/1999/xhtml" /></text>
@@ -61,6 +61,19 @@
       <type>
         <code value="Extension" />
         <profile value="http://hl7.org.au/fhir/StructureDefinition/close-the-gap-registration" />
+      </type>
+    </element>
+    <element id="Patient.extension:birthPlace">
+      <path value="Patient.extension" />
+      <sliceName value="birthPlace" />
+      <short value="Birth place extension" />
+      <definition value="The registered place of birth of the patient. A sytem may use the address.text if they don't store the birthPlace address in discrete elements." />
+      <requirements value="Allows for the recording of a patient's time of birth which is useful in a paediatrics context." />
+      <min value="0" />
+      <max value="1" />
+      <type>
+        <code value="Extension" />
+        <profile value="http://hl7.org/fhir/StructureDefinition/birthPlace" />
       </type>
     </element>
     <element id="Patient.identifier.slicing">


### PR DESCRIPTION
Hi Brett, 

The Agency has added the STU3 standard extension for [birthTime](http://hl7.org/fhir/STU3/extension-patient-birthtime.html) into our profile derived from the HL7 AU patient profile. Recently though I understand that you have indicated an interest to have this extension in the HL7 AU patient profile, which would then be inherited by the Agency derived profile.
This pull request modifies the base au-patient profile to include this extension. It has been given the following attributes:
- cardinality: 0..1
- URL as the STU3 URL
- and various strings such as slice name, short description, definition, comment and reason for inclusion.

The au-patient markdown files have also been updated to align with the above changes, which builds successfully with the IG publisher.

