### PR TITLE
Patient Birth Date Accuracy Indicator extension for au-patient

### DIFF
--- a/examples/patient-BirthDateAccuracyIndicatorAAAexample0.xml
+++ b/examples/patient-BirthDateAccuracyIndicatorAAAexample0.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<Patient xmlns="http://hl7.org/fhir">
+
+    <id value="patientBirthDateAccuracyIndicatorAAA"/>
+
+    <text>
+        <status value="additional"/>
+        <div xmlns="http://www.w3.org/1999/xhtml">
+            <p>This example demonstrates how an accurate date of birth would be represented.</p>
+            <p>This is a valid FHIR date.</p>
+            <ul>
+                <li>A structured date of birth: "1956-08-23"</li>
+                <li>A date of birth accuracy indicator of "AAA" indicating all components are
+                    accurate</li>
+                <li>The same date of birth value is also respresented as a string: "1956-08-23"</li>
+            </ul>
+        </div>
+    </text>
+
+    <extension
+        url="http://www.digitalhealth.gov.au/fhir/StructureDefinition/dh-extension-patient-birth-date-accuracy-indicator">
+
+        <!-- this part of the extension states that the date of birth is fully accurate -->
+        <extension url="dateAccuracyCoding">
+            <valueCoding>
+                <system value="http://meteor.aihw.gov.au/content/index.phtml/itemId/289952"/>
+                <code value="AAA"/>
+                <display value="Day, month and year are accurate"/>
+            </valueCoding>
+        </extension>
+
+        <!-- this part of the extension includes a string representation of the date of birth -->
+        <extension url="dateString">
+            <valueString value="1956-08-23"/>
+        </extension>
+    </extension>
+
+    <name>
+        <use value="official"/>
+        <family value="Erickson"/>
+        <given value="Milton"/>
+    </name>
+
+    <!-- the structured date of birth value -->
+    <birthDate value="1956-08-23"/>
+
+</Patient>

--- a/examples/patient-BirthDateAccuracyIndicatorAAUexample1.xml
+++ b/examples/patient-BirthDateAccuracyIndicatorAAUexample1.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<Patient xmlns="http://hl7.org/fhir">
+
+    <id value="patientBirthDateAccuracyIndicatorAAU"/>
+
+    <text>
+        <status value="additional"/>
+        <div xmlns="http://www.w3.org/1999/xhtml">
+            <p>This example demonstrates how a date of birth with an unknown year would be
+                represented.</p>
+            <p>Note that this is NOT a valid FHIR date and therefore a value in the
+                Patient.birthDate element would not be given.</p>
+            <ul>
+                <li>No structured date of birth</li>
+                <li>A date of birth accuracy indicator of "AAU" indicating the day and month
+                    components are accurate but the year is unknown</li>
+                <li>The date of birth value is respresented as a string, with "0000" representing
+                    the year: "0000-08-23"</li>
+            </ul>
+        </div>
+    </text>
+
+    <extension
+        url="http://hl7.org.au/fhir/StructureDefinition/patient-birth-date-accuracy-indicator">
+
+        <!-- this part of the extension states that the date of birth is partially accurate -->
+        <extension url="dateAccuracyCoding">
+            <valueCoding>
+                <system value="http://meteor.aihw.gov.au/content/index.phtml/itemId/289952"/>
+                <code value="AAU"/>
+                <display value="Day and month are accurate, year is unknown"/>
+            </valueCoding>
+        </extension>
+
+        <!-- this part of the extension includes a string representation of the date of birth -->
+        <extension url="dateString">
+            <valueString value="0000-08-23"/>
+        </extension>
+    </extension>
+
+    <name>
+        <use value="official"/>
+        <family value="Erickson"/>
+        <given value="Milton"/>
+    </name>
+
+    <!-- the structured date of birth value 
+    Not provided as unknown year is invalid -->
+    <!-- 
+    <birthDate value=""/>
+    -->
+
+</Patient>

--- a/examples/patient-BirthDateAccuracyIndicatorUAAexample2.xml
+++ b/examples/patient-BirthDateAccuracyIndicatorUAAexample2.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<Patient xmlns="http://hl7.org/fhir">
+
+    <id value="patientBirthDateAccuracyIndicatorUAA"/>
+
+    <text>
+        <status value="additional"/>
+        <div xmlns="http://www.w3.org/1999/xhtml">
+            <p>This example demonstrates how a date of birth with an unknown day would be
+                represented.</p>
+            <p>Note that this is a valid FHIR date and therefore a value in the Patient.birthDate
+                element would be given.</p>
+            <ul>
+                <li>The structured date of birth, without a day value: "1978-08"</li>
+                <li>A date of birth accuracy indicator of "UAA" indicating the year and month
+                    components are accurate but the day is unknown</li>
+                <li>The date of birth value is respresented as a string, with "00" representing the
+                    day: "1978-08-00"</li>
+            </ul>
+        </div>
+    </text>
+
+    <extension
+        url="http://hl7.org.au/fhir/StructureDefinition/patient-birth-date-accuracy-indicator">
+
+        <!-- this part of the extension states that the date of birth is partially accurate -->
+        <extension url="dateAccuracyCoding">
+            <valueCoding>
+                <system value="http://meteor.aihw.gov.au/content/index.phtml/itemId/289952"/>
+                <code value="UAA"/>
+                <display value="Day is unknown, month and year are accurate"/>
+            </valueCoding>
+        </extension>
+
+        <!-- this part of the extension includes a string representation of the date of birth -->
+        <extension url="dateString">
+            <valueString value="1978-08-00"/>
+        </extension>
+    </extension>
+
+    <name>
+        <use value="official"/>
+        <family value="Bandler"/>
+        <given value="Richard"/>
+    </name>
+
+    <!-- the structured date of birth value -->
+    <birthDate value="1978-08"/>
+
+</Patient>

--- a/examples/patient-BirthDateAccuracyIndicatorUEAexample3.xml
+++ b/examples/patient-BirthDateAccuracyIndicatorUEAexample3.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<Patient xmlns="http://hl7.org/fhir">
+
+    <id value="patientBirthDateAccuracyIndicatorUEA"/>
+
+    <text>
+        <status value="additional"/>
+        <div xmlns="http://www.w3.org/1999/xhtml">
+            <p>This example demonstrates how a date of birth with estimated month and unknown day
+                would be represented.</p>
+            <p>Note that this is a valid FHIR date and therefore a value in the Patient.birthDate
+                element would be given.</p>
+            <ul>
+                <li>The structured date of birth, without a day value: "2004-06"</li>
+                <li>A date of birth accuracy indicator of "UEA" indicating the year component is
+                    accurate, the month is an estimate and the day is unknown</li>
+                <li>The date of birth value is respresented as a string: "2004-06-00"</li>
+            </ul>
+        </div>
+    </text>
+
+    <extension
+        url="http://hl7.org.au/fhir/StructureDefinition/patient-birth-date-accuracy-indicator">
+
+        <!-- this part of the extension states that the date of birth is partially accurate -->
+        <extension url="dateAccuracyCoding">
+            <valueCoding>
+                <system value="http://meteor.aihw.gov.au/content/index.phtml/itemId/289952"/>
+                <code value="UEA"/>
+                <display value="Day is unknown, month is estimated, year is accurate"/>
+            </valueCoding>
+        </extension>
+
+        <!-- this part of the extension includes a string representation of the date of birth -->
+        <extension url="dateString">
+            <valueString value="2004-06-00"/>
+        </extension>
+    </extension>
+
+    <name>
+        <use value="official"/>
+        <family value="Erickson"/>
+        <given value="Milton"/>
+    </name>
+
+    <!-- the structured date of birth value -->
+    <birthDate value="2004-06"/>
+
+</Patient>

--- a/examples/patient-BirthDateAccuracyIndicatorUUUexample4.xml
+++ b/examples/patient-BirthDateAccuracyIndicatorUUUexample4.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<Patient xmlns="http://hl7.org/fhir">
+
+    <id value="patientBirthDateAccuracyIndicatorUUU"/>
+
+    <text>
+        <status value="additional"/>
+        <div xmlns="http://www.w3.org/1999/xhtml">
+            <p>This example demonstrates how an unknown date of birth would be represented.</p>
+            <p>Note that this is NOT a valid FHIR date and therefore a value in the
+                Patient.birthDate element would not be given.</p>
+            <ul>
+                <li>No structured date of birth</li>
+                <li>A date of birth accuracy indicator of "UUU" indicating that all date components
+                    are unknown</li>
+                <li>The date of birth value is respresented as a string: "0000-00-00"</li>
+            </ul>
+        </div>
+    </text>
+
+    <extension
+        url="http://hl7.org.au/fhir/StructureDefinition/patient-birth-date-accuracy-indicator">
+
+        <!-- this part of the extension states that the date of birth is unknown -->
+        <extension url="dateAccuracyCoding">
+            <valueCoding>
+                <system value="http://meteor.aihw.gov.au/content/index.phtml/itemId/289952"/>
+                <code value="UUU"/>
+                <display value="Day, month and year are unknown"/>
+            </valueCoding>
+        </extension>
+
+        <!-- this part of the extension includes a string representation of the date of birth -->
+        <extension url="dateString">
+            <valueString value="0000-00-00"/>
+        </extension>
+    </extension>
+
+    <name>
+        <use value="official"/>
+        <family value="Erickson"/>
+        <given value="Milton"/>
+    </name>
+
+    <!-- the structured date of birth value 
+    Not provided as unknown year is invalid -->
+    <!-- 
+    <birthDate value=""/>
+    -->
+
+</Patient>

--- a/ig.json
+++ b/ig.json
@@ -183,6 +183,9 @@
 	},
 	  "StructureDefinition/au-device": {
 	  "base": "StructureDefinition-au-device.html"
+	},
+	  "StructureDefinition/patient-birth-date-accuracy-indicator": {
+	  "base": "StructureDefinition-patient-birth-date-accuracy-indicator.html"
 	}
   }
 }

--- a/pages/_includes/patient-birth-date-accuracy-indicator-intro.md
+++ b/pages/_includes/patient-birth-date-accuracy-indicator-intro.md
@@ -3,6 +3,11 @@ Patient Birth Date Accuracy Indicator Profile for Australian Use
 This profile provided for use in an Australian context where some constraint on content is desirable to guarantee the quality of a local extension of Patient Birth Date Accuracy Indicator. 
 
 #### Examples
+1. [Patient with a date of birth accuracy indicator of "AAA" indicating all components are accurate](Patient-patientBirthDateAccuracyIndicatorAAA.html)
+1. [Patient with a date of birth accuracy indicator of "AAU" indicating the day and month components are accurate but the year is unknown](Patient-patientBirthDateAccuracyIndicatorAAU.html)
+1. [Patient with a date of birth accuracy indicator of "UAA" indicating the year and month components are accurate but the day is unknown](Patient-patientBirthDateAccuracyIndicatorUAA.html)
+1. [Patient with a date of birth accuracy indicator of "UEA" indicating the year component is accurate, the month is an estimate and the day is unknown](Patient-patientBirthDateAccuracyIndicatorUEA.html)
+1. [Patient with a date of birth accuracy indicator of "UUU" indicating that all date components are unknown](Patient-patientBirthDateAccuracyIndicatorUUU.html)
 
 
 

--- a/pages/_includes/patient-birth-date-accuracy-indicator-intro.md
+++ b/pages/_includes/patient-birth-date-accuracy-indicator-intro.md
@@ -1,0 +1,8 @@
+Patient Birth Date Accuracy Indicator Profile for Australian Use
+
+This profile provided for use in an Australian context where some constraint on content is desirable to guarantee the quality of a local extension of Patient Birth Date Accuracy Indicator. 
+
+#### Examples
+
+
+

--- a/pages/_includes/patient-birth-date-accuracy-indicator-search.md
+++ b/pages/_includes/patient-birth-date-accuracy-indicator-search.md
@@ -1,0 +1,2 @@
+none defined
+

--- a/pages/_includes/patient-birth-date-accuracy-indicator-summary.md
+++ b/pages/_includes/patient-birth-date-accuracy-indicator-summary.md
@@ -1,0 +1,9 @@
+Australian extension for Patient Birth Date Accuracy Indicator contains the following constraints on Patient message where an extension of Patient Birth Date Accuracy Indicator is provided.
+
+1. The string representation of the date of birth should be in a recognisable date format.
+1. Where the accuracy indicator states that a day is unknown, the string representation of the date would have "00" for the day.
+1. Where the accuracy indicator states that a month is unknown, the string representation of the date would have "00" for the month
+1. Where the accuracy indicator states that a year is unknown, the string representation of the date would have "0000" for the year
+1. Where the accuracy indicator states that a day is estimated or accurate, the string representation of the date would not have "00" for the day.
+1. Where the accuracy indicator states that a month is estimated or accurate, the string representation of the date would not have "00" for the month.
+1. Where the accuracy indicator states that a year is estimated or accurate, the string representation of the date would not have "0000" for the year.

--- a/resources/au-patient.xml
+++ b/resources/au-patient.xml
@@ -1,8 +1,8 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="au-patient" />
   <meta>
-    <lastUpdated value="2017-10-02T23:18:41.267+11:00" />
+    <lastUpdated value="2017-10-06T12:04:33.266+10:00" />
   </meta>
   <text>
     <status value="generated" /><div xmlns="http://www.w3.org/1999/xhtml" /></text>
@@ -48,7 +48,6 @@
       <label value="indigenous status" />
       <short value="Australian Indigenous Status" />
       <definition value="Administrative Australian indigenous status coding" />
-      <max value="1" />
       <type>
         <code value="Extension" />
         <profile value="http://hl7.org.au/fhir/StructureDefinition/indigenous-status" />
@@ -59,7 +58,6 @@
       <sliceName value="closethegapregistration" />
       <label value="close the gap registration" />
       <definition value="Administrative indication that the patient has been registered for the close the gap benefit" />
-      <max value="1" />
       <type>
         <code value="Extension" />
         <profile value="http://hl7.org.au/fhir/StructureDefinition/close-the-gap-registration" />
@@ -71,13 +69,22 @@
       <short value="Patient birth time extension" />
       <comment value="This extension provides the ability to record the time of day the patient was born." />
       <requirements value="Allows for the recording of a patient's time of birth (as well as their date of birth), which is useful in a paediatrics context." />
-      <max value="1" />
       <type>
         <code value="Extension" />
         <profile value="http://hl7.org/fhir/StructureDefinition/patient-birthTime" />
       </type>
     </element>
-    <element id="Patient.identifier.slicing">
+    <element id="Patient.extension:patientBirthDateAccuracyIndicator">
+      <path value="Patient.extension" />
+      <sliceName value="patientBirthDateAccuracyIndicator" />
+      <definition value="An extension to support the addition of birth date accuracy indicator data to the `Patient` resource, as well as the recording of invalid FHIR date of birth data" />
+      <max value="1" />
+      <type>
+        <code value="Extension" />
+        <profile value="http://hl7.org.au/fhir/StructureDefinition/patient-birth-date-accuracy-indicator" />
+      </type>
+    </element>
+    <element id="Patient.identifier">
       <path value="Patient.identifier" />
       <slicing>
         <discriminator>
@@ -124,7 +131,6 @@
     <element id="Patient.identifier:ihinumber.extension:ihistatus">
       <path value="Patient.identifier.extension" />
       <sliceName value="ihistatus" />
-      <max value="1" />
       <type>
         <code value="Extension" />
         <profile value="http://hl7.org.au/fhir/StructureDefinition/ihi-status" />
@@ -138,7 +144,6 @@
       <path value="Patient.identifier.extension" />
       <sliceName value="ihirecordstatus" />
       <definition value="IHI value record status associated with an IHI identifier" />
-      <max value="1" />
       <type>
         <code value="Extension" />
         <profile value="http://hl7.org.au/fhir/StructureDefinition/ihi-record-status" />

--- a/resources/ig.xml
+++ b/resources/ig.xml
@@ -81,6 +81,12 @@
 		<resource>
 			<example value="false"/>
 			<sourceReference>
+				<reference value="StructureDefinition/patient-birth-date-accuracy-indicator"/>
+			</sourceReference>
+		</resource>
+		<resource>
+			<example value="false"/>
+			<sourceReference>
 				<reference value="ValueSet/valueset-au-indigenous-status"/>
 			</sourceReference>
 		</resource>

--- a/resources/ig.xml
+++ b/resources/ig.xml
@@ -236,6 +236,46 @@
 			</sourceReference>
 		</resource>
 		<resource>
+			<example value="true"/>
+			<name value="Patient Birth Date Accuracy Indicator with AAA"/>
+			<description value="Shows a typical Patient Birth Date Accuracy Indicator extension Accurate Year, Accurate Month and Accurate Date"/>
+			<sourceReference>
+				<reference value="Patient/BirthDateAccuracyIndicatorAAAexample0"/>
+			</sourceReference>
+		</resource>
+		<resource>
+			<example value="true"/>
+			<name value="Patient Birth Date Accuracy Indicator with AAU"/>
+			<description value="Shows a typical Patient Birth Date Accuracy Indicator extension Accurate Year, Accurate Month and Unknown Date"/>
+			<sourceReference>
+				<reference value="Patient/BirthDateAccuracyIndicatorAAUexample1"/>
+			</sourceReference>
+		</resource>		
+		<resource>
+			<example value="true"/>
+			<name value="Patient Birth Date Accuracy Indicator with UAA"/>
+			<description value="Shows a typical Patient Birth Date Accuracy Indicator extension Unknown Year, Accurate Month and Accurate Date"/>
+			<sourceReference>
+				<reference value="Patient/BirthDateAccuracyIndicatorUAAexample2"/>
+			</sourceReference>
+		</resource>
+		<resource>
+			<example value="true"/>
+			<name value="Patient Birth Date Accuracy Indicator with UEA"/>
+			<description value="Shows a typical Patient Birth Date Accuracy Indicator extension Unknown Year, Estimated Month and Accurate Date"/>
+			<sourceReference>
+				<reference value="Patient/BirthDateAccuracyIndicatorUEAexample3"/>
+			</sourceReference>
+		</resource>
+		<resource>
+			<example value="true"/>
+			<name value="Patient Birth Date Accuracy Indicator with UUU"/>
+			<description value="Shows a typical Patient Birth Date Accuracy Indicator extension Unknown Year, Unknown Month and Unknown Date"/>
+			<sourceReference>
+				<reference value="Patient/BirthDateAccuracyIndicatorUUUexample4"/>
+			</sourceReference>
+		</resource>	
+		<resource>
 			<example value="false"/>
 			<sourceReference>
 				<reference value="StructureDefinition/au-medication"/>

--- a/resources/patient-birth-date-accuracy-indicator.xml
+++ b/resources/patient-birth-date-accuracy-indicator.xml
@@ -1,0 +1,250 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="patient-birth-date-accuracy-indicator" />
+  <meta>
+    <lastUpdated value="2017-10-06T12:01:45.786+10:00" />
+  </meta>
+  <url value="http://hl7.org.au/fhir/StructureDefinition/patient-birth-date-accuracy-indicator" />
+  <name value="Patient Birth Date Accuracy Indicator" />
+  <status value="draft" />
+  <date value="2017-07-27T14:05:18.1900405+10:00" />
+  <publisher value="Health Level Seven Australia (Patient Administration)" />
+  <contact>
+    <telecom>
+      <system value="url" />
+      <value value="http://hl7.org.au/fhir" />
+    </telecom>
+  </contact>
+  <description value="Patient Birth Date Accuracy Indicator." />
+  <purpose value="To allow 'Patient' resources in Australia to carry birth date accuracy indicator data." />
+  <fhirVersion value="3.0.1" />
+  <kind value="resource" />
+  <abstract value="false" />
+  <contextType value="extension" />
+  <context value="Patient" />
+  <type value="Extension" />
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Extension" />
+  <derivation value="constraint" />
+  <differential>
+    <element id="Extension">
+      <path value="Extension" />
+      <short value="Patient Birth Date Accuracy Indicator extension." />
+      <definition value="An extension to support the addition of birth date accuracy indicator data to the `Patient` resource, as well as the recording of invalid FHIR date of birth data." />
+      <comment value="In some circumstances, systems may only have date of birth data that is not technically a valid FHIR date, such as an unknown year. This extension allows for the recording of such a date value." />
+      <constraint>
+        <key value="dobai-01" />
+        <severity value="error" />
+        <human value="The string representation of the date of birth should be in a recognisable date format." />
+        <expression value="extension.where(url='http://hl7.org.au/fhir/StructureDefinition/patient-birth-date-accuracy-indicator').extension.where(url='dateString').first().value.matches('^[0-9]{4}(-(0[0-9]|1[0-2])(-([0-2][0-9]|3[0-1])))$')" />
+      </constraint>
+      <constraint>
+        <key value="dobai-02" />
+        <severity value="error" />
+        <human value="Where the accuracy indicator states that a day is unknown, the string representation of the date would have &quot;00&quot; for the day." />
+        <expression value="extension.where(url='http://hl7.org.au/fhir/StructureDefinition/patient-birth-date-accuracy-indicator').extension.where(url='dateAccuracyCoding').first().value.code.substring(0,1)='U' implies Patient.extension.where(url='http://hl7.org.au/fhir/StructureDefinition/patient-birth-date-accuracy-indicator').extension.where(url='dateString').first().value.matches('^[0-9]{4}(-(0[0-9]|1[0-2])(-00))$')" />
+      </constraint>
+      <constraint>
+        <key value="dobai-03" />
+        <severity value="error" />
+        <human value="Where the accuracy indicator states that a month is unknown, the string representation of the date would have &quot;00&quot; for the month" />
+        <expression value="extension.where(url='http://hl7.org.au/fhir/StructureDefinition/patient-birth-date-accuracy-indicator').extension.where(url='dateAccuracyCoding').first().value.code.substring(1,1)='U' implies Patient.extension.where(url='http://hl7.org.au/fhir/StructureDefinition/patient-birth-date-accuracy-indicator').extension.where(url='dateString').first().value.matches('^[0-9]{4}(-00)(-([0-2][0-9]|3[0-1]))$')" />
+      </constraint>
+      <constraint>
+        <key value="dobai-04" />
+        <severity value="error" />
+        <human value="Where the accuracy indicator states that a year is unknown, the string representation of the date would have &quot;0000&quot; for the year" />
+        <expression value="extension.where(url='http://hl7.org.au/fhir/StructureDefinition/patient-birth-date-accuracy-indicator').extension.where(url='dateAccuracyCoding').first().value.code.substring(2,1)='U' implies Patient.extension.where(url='http://hl7.org.au/fhir/StructureDefinition/patient-birth-date-accuracy-indicator').extension.where(url='dateString').first().value.matches('^0000(-(0[0-9]|1[0-2])(-([0-2][0-9]|3[0-1])))$')" />
+      </constraint>
+      <constraint>
+        <key value="dobai-05" />
+        <severity value="error" />
+        <human value="Where the accuracy indicator states that a day is estimated or accurate, the string representation of the date would not have &quot;00&quot; for the day." />
+        <expression value="tbd" />
+      </constraint>
+      <constraint>
+        <key value="dobai-06" />
+        <severity value="error" />
+        <human value="Where the accuracy indicator states that a month is estimated or accurate, the string representation of the date would not have &quot;00&quot; for the month." />
+        <expression value="tbd" />
+      </constraint>
+      <constraint>
+        <key value="dobai-07" />
+        <severity value="error" />
+        <human value="Where the accuracy indicator states that a year is estimated or accurate, the string representation of the date would not have &quot;0000&quot; for the year." />
+        <expression value="tbd" />
+      </constraint>
+    </element>
+    <element id="Extension.extension">
+      <path value="Extension.extension" />
+      <slicing>
+        <discriminator>
+          <type value="value" />
+          <path value="url" />
+        </discriminator>
+        <rules value="open" />
+      </slicing>
+    </element>
+    <element id="Extension.extension:dateAccuracyCoding">
+      <path value="Extension.extension" />
+      <sliceName value="dateAccuracyCoding" />
+      <min value="1" />
+      <max value="1" />
+    </element>
+    <element id="Extension.extension:dateAccuracyCoding.url">
+      <path value="Extension.extension.url" />
+      <fixedUri value="dateAccuracyCoding" />
+    </element>
+    <element id="Extension.extension:dateAccuracyCoding.value[x]:valueCoding">
+      <path value="Extension.extension.valueCoding" />
+      <sliceName value="valueCoding" />
+      <min value="1" />
+      <type>
+        <code value="Coding" />
+      </type>
+      <binding>
+        <strength value="required" />
+        <description value="blah" />
+        <valueSetReference>
+          <reference value="https://example.com/healthterminologies.gov.au/fhir/ValueSet/date-accuracy-indicator-1" />
+        </valueSetReference>
+      </binding>
+    </element>
+    <element id="Extension.extension:dateString">
+      <path value="Extension.extension" />
+      <sliceName value="dateString" />
+      <min value="1" />
+      <max value="1" />
+    </element>
+    <element id="Extension.extension:dateString.url">
+      <path value="Extension.extension.url" />
+      <fixedUri value="dateString" />
+    </element>
+    <element id="Extension.extension:dateString.value[x]:valueString">
+      <path value="Extension.extension.valueString" />
+      <sliceName value="valueString" />
+      <min value="1" />
+      <type>
+        <code value="string" />
+      </type>
+    </element>
+    <element id="Extension.url">
+      <path value="Extension.url" />
+      <fixedUri value="http://hl7.org.au/fhir/StructureDefinition/patient-birth-date-accuracy-indicator" />
+    </element>
+    <element id="Extension.value[x]">
+      <path value="Extension.value[x]" />
+      <max value="0" />
+      <type>
+        <code value="base64Binary" />
+      </type>
+      <type>
+        <code value="boolean" />
+      </type>
+      <type>
+        <code value="code" />
+      </type>
+      <type>
+        <code value="date" />
+      </type>
+      <type>
+        <code value="dateTime" />
+      </type>
+      <type>
+        <code value="decimal" />
+      </type>
+      <type>
+        <code value="id" />
+      </type>
+      <type>
+        <code value="instant" />
+      </type>
+      <type>
+        <code value="integer" />
+      </type>
+      <type>
+        <code value="markdown" />
+      </type>
+      <type>
+        <code value="oid" />
+      </type>
+      <type>
+        <code value="positiveInt" />
+      </type>
+      <type>
+        <code value="string" />
+      </type>
+      <type>
+        <code value="time" />
+      </type>
+      <type>
+        <code value="unsignedInt" />
+      </type>
+      <type>
+        <code value="uri" />
+      </type>
+      <type>
+        <code value="Address" />
+      </type>
+      <type>
+        <code value="Age" />
+      </type>
+      <type>
+        <code value="Annotation" />
+      </type>
+      <type>
+        <code value="Attachment" />
+      </type>
+      <type>
+        <code value="CodeableConcept" />
+      </type>
+      <type>
+        <code value="Coding" />
+      </type>
+      <type>
+        <code value="ContactPoint" />
+      </type>
+      <type>
+        <code value="Count" />
+      </type>
+      <type>
+        <code value="Distance" />
+      </type>
+      <type>
+        <code value="Duration" />
+      </type>
+      <type>
+        <code value="HumanName" />
+      </type>
+      <type>
+        <code value="Identifier" />
+      </type>
+      <type>
+        <code value="Money" />
+      </type>
+      <type>
+        <code value="Period" />
+      </type>
+      <type>
+        <code value="Quantity" />
+      </type>
+      <type>
+        <code value="Range" />
+      </type>
+      <type>
+        <code value="Ratio" />
+      </type>
+      <type>
+        <code value="Reference" />
+      </type>
+      <type>
+        <code value="SampledData" />
+      </type>
+      <type>
+        <code value="Signature" />
+      </type>
+      <type>
+        <code value="Timing" />
+      </type>
+    </element>
+  </differential>
+</StructureDefinition>


### PR DESCRIPTION
Hello Brett, 

As requested please find the pull request for Patient Birth Date Accuracy Indicator extension for au-patient profile which works with FHIR IG Publisher with no issues.

Note that below three constraints FHIR Path expressions are still under construction (TBD)-
- Where the accuracy indicator states that a day is estimated or accurate, the string representation of the date would not have "00" for the day.
- Where the accuracy indicator states that a month is estimated or accurate, the string representation of the date would not have "00" for the month.
- Where the accuracy indicator states that a year is estimated or accurate, the string representation of the date would not have "0000" for the year.

Also note the the NCTS ValueSet (https://example.com/healthterminologies.gov.au/fhir/ValueSet/date-accuracy-indicator-1) does not have a resolvable end point for terminology.

Best Regards, 
Uday