### PR TITLE
Feature - added AHPRA number constraint

### DIFF
--- a/examples/practitioner-example0.xml
+++ b/examples/practitioner-example0.xml
@@ -24,6 +24,17 @@
 		<system value="http://ns.electronichealth.net.au/id/prescriber-number"/>
 		<value value="453221"/>
 	</identifier>
+	<identifier>
+		<type>
+			<coding>
+				<system value="http://hl7.org.au/fhir/v2/0203"/>
+				<code value="AHPRA"/>
+				<display value="Australian Health Practitioner Regulation Agency Registration Number"/>
+			</coding>
+			<text value="Australian Health Practitioner Regulation Agency Registration Number"/>
+		</type>
+		<value value="MED0000932945"/>
+	</identifier>
 	<active value="true"/>
 	<name>
 		<family value="Mayo"/>

--- a/pages/_includes/au-practitioner-intro.md
+++ b/pages/_includes/au-practitioner-intro.md
@@ -17,8 +17,13 @@ The Healthcare provider identifier—individual (HPI-I) is the numerical identif
 
 A unique numeric identifier for the prescriber of the Pharmaceutical Benefits Scheme (PBS) item for which the PBS benefit is being claimed.
 
+* __Australian Health Practitioner Regulation Agency Registration Number__
+
+[AHPRA description](https://www.ahpra.gov.au/Support/Glossary.aspx#Registration%20Number){:target="_blank"}
+
+Since March 2012, practitioners have been allocated one unique registration number for each profession in which they are registered. This number stays with the practitioner for life, even if they have periods when they are not registered. Practitioners registered in more than one profession have one registration number for each profession.
 
 #### Examples
 
-[Practitioner with HPI-I and Prescriber Number](Practitioner-example0.html)
+[Practitioner with HPI-I, Prescriber Number and AHPRA Registration Number](Practitioner-example0.html)
 

--- a/resources/au-practitioner.xml
+++ b/resources/au-practitioner.xml
@@ -195,6 +195,12 @@
     <element id="Practitioner.identifier:ahpraNumber.value">
       <path value="Practitioner.identifier.value" />
       <min value="1" />
+      <constraint>
+        <key value="inv-ahpra-0" />
+        <severity value="error" />
+        <human value="The value shall start with 3 uppercase letters, followed by 10 digits." />
+        <expression value="matches('^[A-Z]{3}[0-9]{10}$')" />
+      </constraint>
     </element>
   </differential>
 </StructureDefinition>

--- a/resources/au-practitioner.xml
+++ b/resources/au-practitioner.xml
@@ -190,7 +190,7 @@
       </extension>
       <path value="Practitioner.identifier.type.text" />
       <min value="1" />
-      <fixedString value="Australian Health Practitioner Regulation Agency Number" />
+      <fixedString value="Australian Health Practitioner Regulation Agency Registration Number" />
     </element>
     <element id="Practitioner.identifier:ahpraNumber.value">
       <path value="Practitioner.identifier.value" />

--- a/resources/codesystem-au-hl7v2-0203.xml
+++ b/resources/codesystem-au-hl7v2-0203.xml
@@ -25,7 +25,7 @@
 	<content value="complete"/>
 	<concept>
 		<code value="AHPRA"/>
-		<display value="Australian Health Practitioner Regulation Agency"/>
+		<display value="Australian Health Practitioner Regulation Agency Registration Number"/>
 		<definition value="Australian Health Practitioner Regulation Agency allocated registration number"/>
 	</concept>
 	<concept>


### PR DESCRIPTION
Hi Brett, this PR adds the AHPRA registration number value format constraint, as discussed.
There are a few supporting changes as well:
- updated the extended v2-0203 table entry to align with other identifier entries (add "Registration Number")
- updated the `Practitioner.identifier.type.text` fixed value to align with the above
- added an identifier node with an AHPRA example to the example practitioner file
- updated the narrative intro of the practitioner profile with AHPRA content

Note that the IG builds as expected with the IG publisher with no errors generated for the above content.

Refer to issue   #11 
 