### PR TITLE
Added Extension.url to IHI-related extensions

### DIFF
--- a/resources/ihi-record-status.xml
+++ b/resources/ihi-record-status.xml
@@ -39,6 +39,10 @@
 			<max value="1"/>
 			<isModifier value="false"/>
 		</element>
+		<element id="Extension.url">
+			<path value="Extension.url" />
+			<fixedUri value="http://hl7.org.au/fhir/StructureDefinition/ihi-record-status" />
+		</element>
 		<element id="Extension.value[x]">
 			<path value="Extension.valueCoding"/>
 			<short value="IHI Record Status Code"/>

--- a/resources/ihi-status.xml
+++ b/resources/ihi-status.xml
@@ -39,6 +39,10 @@
 			<max value="1"/>
 			<isModifier value="false"/>
 		</element>
+		<element id="Extension.url">
+			<path value="Extension.url" />
+			<fixedUri value="http://hl7.org.au/fhir/StructureDefinition/ihi-status" />
+		</element>
 		<element id="Element.valueCoding">
 			<path value="Extension.valueCoding"/>
 			<short value="IHI Number Status Code"/>

--- a/resources/indigenous-status.xml
+++ b/resources/indigenous-status.xml
@@ -37,12 +37,6 @@
 		</element>
 		<element id="Extension.url">
 			<path value="Extension.url"/>
-			<definition value="Indigenous status fixed url"/>
-			<min value="1"/>
-			<max value="1"/>
-			<type>
-				<code value="uri"/>
-			</type>
 			<fixedUri value="http://hl7.org.au/fhir/StructureDefinition/indigenous-status"/>
 		</element>
 		<element id="Extension.valueCoding">


### PR DESCRIPTION
The two IHI-related extensions ([IHI status](http://build.fhir.org/ig/hl7au/au-fhir-base/StructureDefinition-ihi-status.html) and [IHI record status](http://build.fhir.org/ig/hl7au/au-fhir-base/StructureDefinition-ihi-record-status.html)) were missing the `Extension.url` node - these were added.
As Forge now automatically prepopulates this node, presumably this was missing as an earlier version of Forge (that created these extensions) did not automate this. Or the extension was created manually outside of Forge. Note that as this node is autopopulated in Forge, there was no frontend mechanism in Forge to make this setting; therefore the changes were made directly to the xml.

Another extension ([indigenous-status](http://build.fhir.org/ig/hl7au/au-fhir-base/StructureDefinition-indigenous-status.html)) did have this `Extension.url` node but had [content in the node](https://github.com/hl7au/au-fhir-base/blob/master/resources/indigenous-status.xml#L40-L45) that appeared to be redundant (and inconsistent with all other comparable nodes). This was removed.

All changes were verified via IG publisher build - renders as expected and no new errors/warnings were generated in the QA report.