### PR TITLE
Added context of use to narrative of 2 IHI-related extensions

### DIFF
--- a/pages/_includes/ihi-record-status-intro.md
+++ b/pages/_includes/ihi-record-status-intro.md
@@ -1,1 +1,4 @@
 Extension: Australian IHI Record Status
+
+##### **Context of Use**
+[Identifier datatype](http://hl7.org/fhir/datatypes.html#identifier)

--- a/pages/_includes/ihi-status-intro.md
+++ b/pages/_includes/ihi-status-intro.md
@@ -1,1 +1,4 @@
 Extension: Australian IHI Status
+
+##### **Context of Use**
+[Identifier datatype](http://hl7.org/fhir/datatypes.html#identifier)


### PR DESCRIPTION
The 2 IHI-related extensions ([ihi-record-status](https://github.com/hl7au/au-fhir-base/blob/master/resources/ihi-record-status.xml#L30) and [ihi-status](https://github.com/hl7au/au-fhir-base/blob/master/resources/ihi-status.xml#L29)) have a context of use of 'Identifier' set in their respective profiles. 

In order to make this clearer This content was added to the intro narrative markdown pages for the 2 extensions.

The content builds as expected with the IG publisher and there are no new QA report errors or warnings.