### PR TITLE
Close the gap extension - narrative updates

### DIFF
--- a/pages/_includes/close-the-gap-registration-intro.md
+++ b/pages/_includes/close-the-gap-registration-intro.md
@@ -1,1 +1,3 @@
 Extension: Close the Gap Registration
+
+This extension applies to the Patient resource and provides  an indicator of whether the patient is eligible for a Closing the Gap (CTG) co-payment.

--- a/pages/_includes/close-the-gap-registration-summary.md
+++ b/pages/_includes/close-the-gap-registration-summary.md
@@ -1,3 +1,3 @@
 Extension: Close the Gap Registration
 
-1. Close the Gap Registration Status
+1. Required Close The Gap Registration (as boolean)

--- a/resources/structuredefinition-close-the-gap-registration.xml
+++ b/resources/structuredefinition-close-the-gap-registration.xml
@@ -21,7 +21,7 @@
     </telecom>
   </contact>
   <description value="Indicator flag for close the gap registration eligibility for an Australian patient." />
-  <purpose value="indicaiton of close the gap registration for a patient" />
+  <purpose value="Indicator flag for close the gap registration eligibility for an Australian patient." />
   <fhirVersion value="3.0.1" />
   <kind value="complex-type" />
   <abstract value="false" />
@@ -34,7 +34,7 @@
     <element id="Extension">
       <path value="Extension" />
       <short value="Close the Gap Registration" />
-      <definition value="Close the Gap registration indicator for a patient" />
+      <definition value="Close the Gap registration indicator for an Australian patient." />
       <max value="1" />
       <isModifier value="false" />
     </element>

--- a/resources/structuredefinition-close-the-gap-registration.xml
+++ b/resources/structuredefinition-close-the-gap-registration.xml
@@ -20,7 +20,7 @@
       <value value="http://hl7.org.au" />
     </telecom>
   </contact>
-  <description value="indicaiton of close the gap registration for a patient" />
+  <description value="Indicator flag for close the gap registration eligibility for an Australian patient." />
   <purpose value="indicaiton of close the gap registration for a patient" />
   <fhirVersion value="3.0.1" />
   <kind value="complex-type" />


### PR DESCRIPTION
Hi Brett; this PR makes some minor changes to the narrative content for the CTG extension:
- added a description in the intro markdown page
- updated the summary markdown file to mention the datatype boolean
- minor updates to the profile's description, purpose and extension definition

The updated content builds as expected with the IG publisher with no new QA report errors/warnings.