### PR TITLE
No fixed address extension - narrative updates

### DIFF
--- a/examples/addressAustralianNoFixedAddressexample6.xml
+++ b/examples/addressAustralianNoFixedAddressexample6.xml
@@ -6,8 +6,7 @@
     <text>
         <status value="additional"/>
         <div xmlns="http://www.w3.org/1999/xhtml">
-            <p>This sample XML is an example for the use case of no fixed australian address.</p>
-            <p>This sample XML contains Patient as a parent element since the address complex datatype does not contain neither .xsd nor .sch files to validate the structure of the XML.</p>
+            <p>This example demonstrates how an address within Australia can be represented as a 'no fixed address'.</p>
         </div>
     </text>
     

--- a/examples/addressInternationalNoFixedAddressexample7.xml
+++ b/examples/addressInternationalNoFixedAddressexample7.xml
@@ -4,20 +4,19 @@
     
     <text>
         <status value="additional"/>
-        <div xmlns="http://www.w3.org/1999/xhtml">            
-            <p>This sample XML is an example for the use case of no fixed international address.</p>
-            <p>This sample XML contains Patient as a parent element since the address complex datatype does not contain neither .xsd nor .sch files to validate the structure of the XML.</p>
+        <div xmlns="http://www.w3.org/1999/xhtml">
+            <p>This example demonstrates how an address outside of Australia can be represented as a 'no fixed address'.</p>
         </div>
     </text> 
     
     <address>        
         <extension url="http://hl7.org.au/fhir/StructureDefinition/no-fixed-address">
-            <valueBoolean value="true"/>
             <!-- this part of the extension states that address is no fixed address -->
+            <valueBoolean value="true"/>
         </extension>      
-        <use value="work"/>
+        <use value="home"/>
         <type value="physical"/>
-        <text value="NO FIXED ADDRESS Auckalnd, North Island 5000"/>        
+        <text value="NO FIXED ADDRESS Auckland, North Island 5000"/>
         <country value="NZ"/>
         <period>
             <start value="2013-06-08T10:57:34+01:00"/>

--- a/pages/_includes/no-fixed-address-intro.md
+++ b/pages/_includes/no-fixed-address-intro.md
@@ -1,3 +1,7 @@
 Extension: No Fixed Address
 
 This extension applies to the Address datatype and indicates that there is an assertion that there is no fixed address.
+
+#### Examples
+1. [Patient with 'no fixed' Australian address.](Patient-addressAustralianNoFixedAddressexample6.html)
+1. [Patient with 'no fixed' International address.](Patient-addressInternationalNoFixedAddressexample7.html)

--- a/pages/_includes/no-fixed-address-intro.md
+++ b/pages/_includes/no-fixed-address-intro.md
@@ -1,3 +1,3 @@
 Extension: No Fixed Address
 
-This extension applies to the Address datatype and indicates that there is and assertion that there is no fixed address.
+This extension applies to the Address datatype and indicates that there is an assertion that there is no fixed address.

--- a/pages/_includes/no-fixed-address-summary.md
+++ b/pages/_includes/no-fixed-address-summary.md
@@ -1,3 +1,3 @@
 Extension: No Fixed Address
 
-1. Required No Fixed Address Flag (as Boolean)
+1. Required No Fixed Address Flag (as boolean)

--- a/resources/structuredefinition-no-fixed-address.xml
+++ b/resources/structuredefinition-no-fixed-address.xml
@@ -20,8 +20,8 @@
       <value value="http://hl7.org.au" />
     </telecom>
   </contact>
-  <description value="indicator flag for no fixed address" />
-  <purpose value="no fixed address indicator" />
+  <description value="Indicator flag for no fixed address." />
+  <purpose value="To allow recording a no fixed address indicator." />
   <fhirVersion value="3.0.1" />
   <kind value="complex-type" />
   <abstract value="false" />


### PR DESCRIPTION
Hi Brett; this PR makes some minor changes to the narrative content for the no fixed address extension:
- corrected a typo in the extension intro markdown narrative
- added 2 links to the intro markdown file for the 2 examples demonstrating no fixed address
- reworded the 2 example narratives
- updated the example for international no fixed address (typo and couple of other minor edits)
- added the datatype (boolean) to the extension summary
- reworded the profile's description and purpose

The updated content builds as expected with the IG publisher with no new QA report errors/warnings.

Note - we had some discussion whether it was worthwhile adding some narrative guidance for using this flag; ie only can assert positively that there is no fixed address. Rather than suggesting some content, will leave it up to you whether this is worthwhile.