### PR TITLE
Date Accuracy Indicator, IHI Status and IHI Record Status - narrative updates.

### DIFF
--- a/examples/patient-example1.xml
+++ b/examples/patient-example1.xml
@@ -19,8 +19,8 @@
 		<extension url="http://hl7.org.au/fhir/StructureDefinition/ihi-record-status">
 			<valueCoding>
 				<system value="https://healthterminologies.gov.au/fhir/CodeSystem/ihi-record-status-1"/>
-				<code value="Verified"/>
-				<display value="Verified"/>
+				<code value="Unverified"/>
+				<display value="Unverified"/>
 			</valueCoding>
 		</extension>
 		<type>

--- a/examples/patient-example1.xml
+++ b/examples/patient-example1.xml
@@ -12,8 +12,8 @@
 		<extension url="http://hl7.org.au/fhir/StructureDefinition/ihi-status">
 			<valueCoding>
 				<system value="https://healthterminologies.gov.au/fhir/CodeSystem/ihi-status-1"/>
-				<code value="Active"/>
-				<display value="Active"/>
+				<code value="Expired"/>
+				<display value="Expired"/>
 			</valueCoding>
 		</extension>
 		<extension url="http://hl7.org.au/fhir/StructureDefinition/ihi-record-status">

--- a/pages/_includes/extensions.md
+++ b/pages/_includes/extensions.md
@@ -1,4 +1,13 @@
 # {{ page.title }}
 
 These extensions have been defined for this implementation guide.
-{% include list-simple-extensions.xhtml %}
+
+* [NoFixedAddress](StructureDefinition-no-fixed-address.html)
+* [MedicationType](StructureDefinition-medication-type.html)
+* [AustralianIndigenousStatus](StructureDefinition-indigenous-status.html)
+* [CloseTheGapRegistration](StructureDefinition-close-the-gap-registration.html)
+* [GroundsForConcurrentSupplyOfMedication](StructureDefinition-grounds-for-concurrent-supply.html)
+* [IHIStatus](StructureDefinition-ihi-status.html)
+* [IHIRecordStatus](StructureDefinition-ihi-record-status.html)
+* [DateAccuracyIndicator](StructureDefinition-date-accuracy-indicator.html)
+* [HealthcareServiceEligibilityDetail](StructureDefinition-healthcareservice-eligibility-detail.html)

--- a/pages/_includes/ihi-record-status-intro.md
+++ b/pages/_includes/ihi-record-status-intro.md
@@ -5,6 +5,6 @@ This extension applies to the [Identifier datatype](http://hl7.org/fhir/datatype
 This IHI record status extension describes whether verification of the individual identifier has occurred and is based on the evidence available for a person’s identity.
 
 #### Examples
-1. [Patient with Individual Healthcare Identifier Record Status (IHI Record Status) of "Verified" .](Patient-example0.html)
-1. [Patient with Individual Healthcare Identifier Record Status (IHI Record Status) of "Unverified" .](Patient-example1.html)
+1. [Patient with Individual Healthcare Identifier Record Status (IHI Record Status) of "Verified".](Patient-example0.html)
+1. [Patient with Individual Healthcare Identifier Record Status (IHI Record Status) of "Unverified".](Patient-example1.html)
 

--- a/pages/_includes/ihi-record-status-intro.md
+++ b/pages/_includes/ihi-record-status-intro.md
@@ -1,6 +1,10 @@
-Extension: Australian IHI Record Status
+Extension: IHI Record Status
 
 This extension applies to the [Identifier datatype](http://hl7.org/fhir/datatypes.html#identifier) 
 
-This is the IHI value record status and describes whether verification of the identifier of the individual has occurred and is based on the evidence available of a person's identity.
+This IHI record status extension describes whether verification of the individual identifier has occurred and is based on the evidence available for a person’s identity.
+
+#### Examples
+1. [Patient with Individual Healthcare Identifier Record Status (IHI Record Status) of "Verified" .](Patient-example0.html)
+1. [Patient with Individual Healthcare Identifier Record Status (IHI Record Status) of "Unverified" .](Patient-example1.html)
 

--- a/pages/_includes/ihi-record-status-summary.md
+++ b/pages/_includes/ihi-record-status-summary.md
@@ -1,3 +1,3 @@
 Extension: IHI Record Status
 
-1. Required IHI status (as Coding)
+1. Required IHI Record status (as Coding)

--- a/pages/_includes/ihi-status-intro.md
+++ b/pages/_includes/ihi-status-intro.md
@@ -2,4 +2,8 @@ Extension: IHI Status
 
 This extension applies to the [Identifier datatype](http://hl7.org/fhir/datatypes.html#identifier) 
 
-This is the status of the associated IHI identifier and indicates whether the status of the identifier is active or otherwise.
+This IHI status extension describes the status of the associated IHI identifier and also indicates whether the status of the identifier is active or otherwise.
+
+#### Examples
+1. [Patient with Individual Healthcare Identifier Status (IHI Status) of "Active" .](Patient-example0.html)
+1. [Patient with Individual Healthcare Identifier Status (IHI Status) of "Expired" .](Patient-example1.html)

--- a/pages/_includes/ihi-status-intro.md
+++ b/pages/_includes/ihi-status-intro.md
@@ -5,5 +5,5 @@ This extension applies to the [Identifier datatype](http://hl7.org/fhir/datatype
 This IHI status extension describes the status of the associated IHI identifier and also indicates whether the status of the identifier is active or otherwise.
 
 #### Examples
-1. [Patient with Individual Healthcare Identifier Status (IHI Status) of "Active" .](Patient-example0.html)
-1. [Patient with Individual Healthcare Identifier Status (IHI Status) of "Expired" .](Patient-example1.html)
+1. [Patient with Individual Healthcare Identifier Status (IHI Status) of "Active".](Patient-example0.html)
+1. [Patient with Individual Healthcare Identifier Status (IHI Status) of "Expired".](Patient-example1.html)

--- a/pages/_includes/ihi-status-summary.md
+++ b/pages/_includes/ihi-status-summary.md
@@ -1,4 +1,4 @@
-Extension: Australian IHI Status
+Extension: IHI Status
 
 1. Required IHI status (as Coding)
 

--- a/resources/structuredefinition-date-accuracy-indicator.xml
+++ b/resources/structuredefinition-date-accuracy-indicator.xml
@@ -2,7 +2,7 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="date-accuracy-indicator" />
   <meta>
-    <lastUpdated value="2018-03-02T17:26:10.4+11:00" />
+    <lastUpdated value="2018-03-26T14:49:50.305+10:00" />
   </meta>
   <url value="http://hl7.org.au/fhir/StructureDefinition/date-accuracy-indicator" />
   <name value="DateAccuracyIndicator" />
@@ -16,7 +16,7 @@
     </telecom>
   </contact>
   <description value="Coded date accuracy indicator for estimated and unknown date content." />
-  <purpose value="Date accuracy indicator extension." />
+  <purpose value="Date accuracy indicator." />
   <fhirVersion value="3.0.1" />
   <kind value="primitive-type" />
   <abstract value="false" />
@@ -29,9 +29,9 @@
   <differential>
     <element id="Extension">
       <path value="Extension" />
-      <short value="Date Accuracy Indicator extension." />
+      <short value="Date Accuracy Indicator." />
       <definition value="General date accuracy indicator coding." />
-      <comment value="In some circumstances, systems may only date or datetime data that has unknown or estimated parts.  This coding establises the acuraccy of the day, month and year parts." />
+      <comment value="In some circumstances, systems may only capture date or datetime data that has unknown or estimated parts. This coding establishes the accuracy of the day, month and year parts." />
       <max value="1" />
     </element>
     <element id="Extension.url">

--- a/resources/structuredefinition-ihi-record-status.xml
+++ b/resources/structuredefinition-ihi-record-status.xml
@@ -2,7 +2,7 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="ihi-record-status" />
   <meta>
-    <lastUpdated value="2018-03-03T10:46:25.59+11:00" />
+    <lastUpdated value="2018-03-27T00:34:21.659+10:00" />
   </meta>
   <text>
     <status value="generated" /><div xmlns="http://www.w3.org/1999/xhtml">
@@ -19,8 +19,8 @@
       <value value="http://hl7.org.au" />
     </telecom>
   </contact>
-  <description value="IHI number record status extension" />
-  <purpose value="Coded record status associated with an IHI number instance" />
+  <description value="IHI record status extension." />
+  <purpose value="Coded record status associated with an IHI number instance." />
   <fhirVersion value="3.0.1" />
   <kind value="complex-type" />
   <abstract value="false" />
@@ -33,7 +33,7 @@
     <element id="Extension">
       <path value="Extension" />
       <short value="IHI Record Status" />
-      <definition value="Known IHI value record status associated with an IHI identifier" />
+      <definition value="Known IHI record status associated with an IHI identifier." />
       <max value="1" />
       <isModifier value="false" />
     </element>
@@ -45,7 +45,7 @@
       <path value="Extension.valueCoding" />
       <sliceName value="valueCoding" />
       <short value="IHI Record Status Code" />
-      <definition value="Coded IHI Record Status" />
+      <definition value="Coded IHI Record Status." />
       <min value="1" />
       <type>
         <code value="Coding" />

--- a/resources/structuredefinition-ihi-status.xml
+++ b/resources/structuredefinition-ihi-status.xml
@@ -2,7 +2,7 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="ihi-status" />
   <meta>
-    <lastUpdated value="2018-03-03T10:46:17.742+11:00" />
+    <lastUpdated value="2018-03-26T22:41:42.277+10:00" />
   </meta>
   <text>
     <status value="generated" /><div xmlns="http://www.w3.org/1999/xhtml">
@@ -19,8 +19,8 @@
       <value value="http://hl7.org.au" />
     </telecom>
   </contact>
-  <description value="IHI number status extension" />
-  <purpose value="Coded status associated with an IHI number instance" />
+  <description value="IHI number status extension." />
+  <purpose value="Coded status associated with an IHI number instance." />
   <fhirVersion value="3.0.1" />
   <kind value="complex-type" />
   <abstract value="false" />
@@ -33,7 +33,7 @@
     <element id="Extension">
       <path value="Extension" />
       <short value="IHI Status" />
-      <definition value="IHI value status associated with an IHI identifier" />
+      <definition value="IHI number status associated with an IHI identifier." />
       <max value="1" />
       <isModifier value="false" />
     </element>
@@ -45,7 +45,7 @@
       <path value="Extension.valueCoding" />
       <sliceName value="valueCoding" />
       <short value="IHI Number Status Code" />
-      <definition value="IHI value status associated with an IHI identifier" />
+      <definition value="IHI number status associated with an IHI identifier." />
       <min value="1" />
       <type>
         <code value="Coding" />


### PR DESCRIPTION
Hi Brett; this Pull Request makes very minor changes to the narrative content for the Date Accuracy Indicator, IHI Status and IHI Record Status extensions:
Minor updates to the profile's description, purpose, extension definition and intro.md files.
The updated content builds as expected with the IG publisher with no new QA report errors/warnings.