### PR TITLE
Indigenous Status extension - narrative updates

### DIFF
--- a/pages/_includes/indigenous-status-intro.md
+++ b/pages/_includes/indigenous-status-intro.md
@@ -1,3 +1,7 @@
 Extension: Indigenous Status
 
 This extension applies to the Patient resource and provides a coding for Australian indigenous status of the patient.
+
+#### Examples
+1. [Patient with indigenous status of '_Not stated/inadequately described_'.](Patient-example0.html)
+1. [Patient with indigenous status of '_Both Aboriginal and Torres Strait Islander origin_'.](Patient-example1.html)

--- a/resources/structuredefinition-indigenous-status.xml
+++ b/resources/structuredefinition-indigenous-status.xml
@@ -16,8 +16,8 @@
       <value value="http://hl7.org.au" />
     </telecom>
   </contact>
-  <description value="Administrative indigenous status for an Australian patient" />
-  <purpose value="Details of a practitioner" />
+  <description value="Administrative indigenous status for an Australian patient." />
+  <purpose value="Recording an indigenous status for an Australian patient." />
   <fhirVersion value="3.0.1" />
   <kind value="complex-type" />
   <abstract value="false" />
@@ -30,7 +30,7 @@
     <element id="Extension">
       <path value="Extension" />
       <short value="Indigenous status" />
-      <definition value="NHDD based indigenous status for a patient" />
+      <definition value="National Health Data Dictionary (NHDD) based indigenous status for a patient." />
       <max value="1" />
       <isModifier value="false" />
     </element>
@@ -42,7 +42,7 @@
       <path value="Extension.valueCoding" />
       <sliceName value="valueCoding" />
       <short value="Indigenous status code" />
-      <definition value="NHDD based indigenous status code" />
+      <definition value="NHDD based indigenous status code." />
       <min value="1" />
       <type>
         <code value="Coding" />


### PR DESCRIPTION
Hi Brett, this PR includes a couple of minor updates to the narrative content of the Indigenous Status extension, including:
- adding links for the 2 patient examples in the extension's intro markdown file
- fixed typo in profile's description
- replaced profile's purpose text
- fully spelled-out 'NHDD' in extension's definition

The content builds as expected with the IG publisher and there are no new QA report errors/warnings.

Thanks