### PR TITLE
Extension :: composition-author-role

### DIFF
--- a/ig.json
+++ b/ig.json
@@ -159,6 +159,9 @@
 	"StructureDefinition/au-relatedperson": {
 	  "base": "StructureDefinition-au-relatedperson.html"
 	},
+	"StructureDefinition/composition-author-role": {
+	  "base": "StructureDefinition-composition-author-role.html"
+	},
 	"CodeSystem/medication-type": {
 	  "base": "CodeSystem-medication-type.html"
 	},

--- a/pages/_includes/composition-author-role-intro.md
+++ b/pages/_includes/composition-author-role-intro.md
@@ -1,0 +1,3 @@
+Extension: Authoring PractitionerRole
+
+This extension applies to a practitioner role that authored this composition. This is not to be confused with who typed in the information.

--- a/pages/_includes/composition-author-role-search.md
+++ b/pages/_includes/composition-author-role-search.md
@@ -1,0 +1,1 @@
+none defined

--- a/pages/_includes/composition-author-role-summary.md
+++ b/pages/_includes/composition-author-role-summary.md
@@ -1,0 +1,4 @@
+Extension: Attester as a RelatedPerson
+
+1. Required valueReference [FHIR STU3 PractitionerRole](http://hl7.org/fhir/practitionerrole.html)
+

--- a/pages/_includes/composition-author-role-summary.md
+++ b/pages/_includes/composition-author-role-summary.md
@@ -1,4 +1,4 @@
-Extension: Attester as a RelatedPerson
+Extension: Authoring PractitionerRole
 
 1. Required valueReference [FHIR STU3 PractitionerRole](http://hl7.org/fhir/practitionerrole.html)
 

--- a/pages/_includes/extensions.md
+++ b/pages/_includes/extensions.md
@@ -14,3 +14,4 @@ These extensions have been defined for this implementation guide.
 * [AttesterRelatedParty](StructureDefinition-attester-related-party.html)
 * [SectionAuthor](StructureDefinition-section-author.html)
 * [InformationRecipient](Structuredefinition-information-recipient.html)
+* [CompositionAuthorRole](Structuredefinition-composition-author-role.html)

--- a/resources/ig.xml
+++ b/resources/ig.xml
@@ -189,6 +189,12 @@
     <resource>
       <example value="false"/>
       <sourceReference>
+        <reference value="StructureDefinition/composition-author-role"/>
+      </sourceReference>
+    </resource>    
+    <resource>
+      <example value="false"/>
+      <sourceReference>
         <reference value="ValueSet/snomed-healthcareservice-role"/>
       </sourceReference>
     </resource>

--- a/resources/structuredefinition-composition-author-role.xml
+++ b/resources/structuredefinition-composition-author-role.xml
@@ -1,0 +1,45 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="composition-author-role"/>
+  <url value="http://hl7.org.au/fhir/StructureDefinition/composition-author-role"/>
+  <name value="CompositionAuthorRole"/>
+  <title value="Authoring PractitionerRole"/>
+  <status value="draft"/>
+  <publisher value="Health Level Seven Australia (Patient Administration)"/>
+  <contact>
+    <telecom>
+      <system value="url"/>
+      <value value="http://hl7.org.au"/>
+    </telecom>
+  </contact>
+  <description
+    value="A practitioner role that authored this composition. This is not to be confused with who typed in the information."/>
+  <fhirVersion value="3.0.1"/>
+  <kind value="complex-type"/>
+  <abstract value="false"/>
+  <contextType value="resource"/>
+  <context value="Composition"/>
+  <type value="Extension"/>
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Extension"/>
+  <derivation value="constraint"/>
+  <differential>
+    <element id="Extension">
+      <path value="Extension"/>
+      <min value="0"/>
+      <max value="1"/>
+    </element>
+    <element id="Extension.url">
+      <path value="Extension.url"/>
+      <fixedUri value="http://hl7.org.au/fhir/StructureDefinition/composition-author-role"/>
+    </element>
+    <element id="Extension.value[x]:valueReference">
+      <path value="Extension.valueReference"/>
+      <sliceName value="valueReference"/>
+      <min value="1"/>
+      <type>
+        <code value="Reference"/>
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/PractitionerRole"/>
+      </type>
+    </element>
+  </differential>
+</StructureDefinition>

--- a/resources/structuredefinition-composition-author-role.xml
+++ b/resources/structuredefinition-composition-author-role.xml
@@ -26,7 +26,8 @@
     <element id="Extension">
       <path value="Extension"/>
       <min value="0"/>
-      <max value="1"/>
+      <max value="*"/>
+      <short value="Authoring PractitionerRole"/> 
     </element>
     <element id="Extension.url">
       <path value="Extension.url"/>


### PR DESCRIPTION
Hi Brett,
Please accept the pull request for composition-author-role.

**Summary of changes:**
**Extension Cardinality**:: 0..*
**Name**:: CompositionAuthorRole
**Title**:: Authoring PractitionerRole
**Short Description**:: Authoring PractitionerRole
**ContextOfUse**:: Composition
**Description**:: A practitioner role that authored this composition. This is not to be confused with who typed in the information.
**Extension, profiled**::
- **url**:: 1..1 "http://hl7.org.au/fhir/StructureDefinition/composition-author-role"
- **valueReference**:: 1..1 Reference (PractitionerRole)

Thanks,
Vikas