### PR TITLE
au-composition :: examples to display Information Recipient, Composition Author role and Section Author

### DIFF
--- a/examples/composition-different-authors.xml
+++ b/examples/composition-different-authors.xml
@@ -5,68 +5,99 @@
         <lastUpdated value="2013-05-28T22:12:21Z"/>
     </meta>
     <text>
-        <status value="extensions"/>
-        <div xmlns="http://www.w3.org/1999/xhtml">           
-            <p>
-                <b> id</b> : multiple information recipients and author role</p>
-            <p>
-                <b> meta</b> : </p>
-            <p>
-                <b> status</b> : final</p>
-            <p>
-                <b> type</b> : Discharge Summary Note <span> (Details : {LOINC
-                    code '18842-5' = 'Discharge Summarization Note)</span>
+        <status value="generated"/>
+        <div xmlns="http://www.w3.org/1999/xhtml">
+            <p><b>Generated Narrative with Details</b></p>
+            <p><b>id</b>: composition-different-authors</p>            
+            <p><b>status</b>: final</p>
+            <p><b>type</b>: Discharge Summarization Note <span
+                    style="background: LightGoldenRodYellow">(Details : {LOINC code '18842-5' =
+                    'Discharge summary)</span></p>
+            <p><b>date</b>: 03/06/2018 12:30:02 PM</p>
+            <p><b>author</b>: <a href="Practitioner-example0.html">Doctor Mayo. Generated Summary:
+                    id: example0; HPI-I = 8003610833334085, Prescriber Number = 453221, Australian
+                    Health Practitioner Regulation Agency Registration Number = MED0000932945;
+                    active; Helen Mayo ; helen.mayo@downunderhospital.com.au(WORK)</a></p>
+            <p><b>title</b>: Discharge Summary</p>
+            <p><b>Extension:</b>The Reason for admission section content has been authored by practitioner:<a
+                href="Practitioner-example0.html">Dr. Mayo</a>
             </p>
-            
-            <p>
-                <b> date</b> : June 3, 2018 12:30:02 PM</p>
-            <p>
-                <b> author</b> :<a href="Practitioner-example0.html">Dr. Mayo</a>
+            <p><b>Extension:</b>The Medications on Discharge section content has been authored by practitionerRole:<a
+                href="PractitionerRole-example0.html">Cardiologist</a>
             </p>
-            <p>
-                <b> Extension: patient as section author</b> :<a href="Patient-example0.html">Stella Franklin</a>
-            </p>
-            <p>
-                <b> Extension: patient as section author</b> :<a href="Practitioner-example0.html">Dr. Mayo</a>
-            </p>
-            <p>
-                <b> title</b> : Discharge Summary</p>
-            
         </div>
     </text>
-    
-    <extension url="http://hl7.org.au/fhir/StructureDefinition/section-author">
-        <valueReference>
-            <reference value="Patient/example0"/>
-            <display value="Franklin"/>            
-        </valueReference>
-    </extension>
-    
-    <extension url="http://hl7.org.au/fhir/StructureDefinition/section-author">
-        <valueReference>
-            <reference value="Practitioner/example0"/>
-            <display value="Doctor Mayo"/>           
-        </valueReference>
-    </extension>
-    
+
     <status value="final"/>
     <type>
         <coding>
             <system value="http://loinc.org"/>
             <code value="18842-5"/>
         </coding>
-        <text value="Discharge Summarozation Note"/>
+        <text value="Discharge Summarization Note"/>
     </type>
     <subject>
         <reference value="Patient/example0"/>
         <display value="Franklin"/>
     </subject>
-    
+
     <date value="2018-06-03T12:30:02Z"/>
     <author>
         <reference value="Practitioner/example0"/>
         <display value="Doctor Mayo"/>
     </author>
     <title value="Discharge Summary"/>
-    
+
+    <section>
+        <extension url="http://hl7.org.au/fhir/StructureDefinition/section-author">
+            <valueReference>
+                <reference value="Practitioner/example0"/>
+                <display value="Doctor Mayo"/>
+            </valueReference>
+        </extension>
+        <title value="Reason for admission"/>
+        <code>
+            <coding>
+                <system value="http://loinc.org"/>
+                <code value="29299-5"/>
+                <display value="Reason for visit Narrative"/>
+            </coding>
+        </code>
+        <text>
+            <status value="extensions"/>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+                <p> This section content has been authored by practitioner:<a
+                        href="Practitioner-example0.html">Dr. Mayo</a>
+                </p>
+            </div>
+        </text>
+
+    </section>
+
+    <section>
+        <extension url="http://hl7.org.au/fhir/StructureDefinition/section-author">
+            <valueReference>
+                <reference value="PractitionerRole/example0"/>
+                <display value="Cardiologist"/>
+            </valueReference>
+        </extension>
+        <title value="Medications on Discharge"/> 
+        <code> 
+            <coding> 
+                <system value="http://loinc.org"/> 
+                <code value="10183-2"/> 
+                <display value="Hospital discharge medications Narrative"/> 
+            </coding> 
+        </code> 
+        <text>
+            <status value="extensions"/>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+                <p> This section content has been authored by practitionerRole:<a
+                        href="PractitionerRole-example0.html">Cardiologist</a>
+                </p>
+            </div>
+        </text>
+
+    </section>
+
 </Composition>

--- a/examples/composition-different-authors.xml
+++ b/examples/composition-different-authors.xml
@@ -27,6 +27,9 @@
                 <b> Extension: patient as section author</b> :<a href="Patient-example0.html">Stella Franklin</a>
             </p>
             <p>
+                <b> Extension: patient as section author</b> :<a href="Practitioner-example0.html">Dr. Mayo</a>
+            </p>
+            <p>
                 <b> title</b> : Discharge Summary</p>
             
         </div>
@@ -36,6 +39,13 @@
         <valueReference>
             <reference value="Patient/example0"/>
             <display value="Franklin"/>            
+        </valueReference>
+    </extension>
+    
+    <extension url="http://hl7.org.au/fhir/StructureDefinition/section-author">
+        <valueReference>
+            <reference value="Practitioner/example0"/>
+            <display value="Doctor Mayo"/>           
         </valueReference>
     </extension>
     

--- a/examples/composition-different-authors.xml
+++ b/examples/composition-different-authors.xml
@@ -7,17 +7,14 @@
     <text>
         <status value="generated"/>
         <div xmlns="http://www.w3.org/1999/xhtml">
-            <p><b>Generated Narrative with Details</b></p>
-            <p><b>id</b>: composition-different-authors</p>            
+            <p><b>Narrative details</b></p>
+            <p><b>id</b>: composition-different-authors</p>                            
             <p><b>status</b>: final</p>
             <p><b>type</b>: Discharge Summarization Note <span
                     style="background: LightGoldenRodYellow">(Details : {LOINC code '18842-5' =
-                    'Discharge summary)</span></p>
-            <p><b>date</b>: 03/06/2018 12:30:02 PM</p>
-            <p><b>author</b>: <a href="Practitioner-example0.html">Doctor Mayo. Generated Summary:
-                    id: example0; HPI-I = 8003610833334085, Prescriber Number = 453221, Australian
-                    Health Practitioner Regulation Agency Registration Number = MED0000932945;
-                    active; Helen Mayo ; helen.mayo@downunderhospital.com.au(WORK)</a></p>
+                'Discharge Summarization Note)</span></p>
+            <p><b> date</b> : June 3, 2018 12:30:02 PM</p>
+            <p><b>author</b>: <a href="Practitioner-example0.html">Doctor Mayo</a></p>
             <p><b>title</b>: Discharge Summary</p>
             <p><b>Extension:</b>The Reason for admission section content has been authored by practitioner:<a
                 href="Practitioner-example0.html">Dr. Mayo</a>
@@ -25,6 +22,7 @@
             <p><b>Extension:</b>The Medications on Discharge section content has been authored by practitionerRole:<a
                 href="PractitionerRole-example0.html">Cardiologist</a>
             </p>
+            
         </div>
     </text>
 

--- a/examples/composition-different-authors.xml
+++ b/examples/composition-different-authors.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composition xmlns="http://hl7.org/fhir">
+    <id value="composition-different-authors"/>
+    <meta>
+        <lastUpdated value="2013-05-28T22:12:21Z"/>
+    </meta>
+    <text>
+        <status value="extensions"/>
+        <div xmlns="http://www.w3.org/1999/xhtml">           
+            <p>
+                <b> id</b> : multiple information recipients and author role</p>
+            <p>
+                <b> meta</b> : </p>
+            <p>
+                <b> status</b> : final</p>
+            <p>
+                <b> type</b> : Discharge Summary Note <span> (Details : {LOINC
+                    code '18842-5' = 'Discharge Summarization Note)</span>
+            </p>
+            
+            <p>
+                <b> date</b> : June 3, 2018 12:30:02 PM</p>
+            <p>
+                <b> author</b> :<a href="Practitioner-example0.html">Dr. Mayo</a>
+            </p>
+            <p>
+                <b> Extension: patient as section author</b> :<a href="Patient-example0.html">Stella Franklin</a>
+            </p>
+            <p>
+                <b> title</b> : Discharge Summary</p>
+            
+        </div>
+    </text>
+    
+    <extension url="http://hl7.org.au/fhir/StructureDefinition/section-author">
+        <valueReference>
+            <reference value="Patient/example0"/>
+            <display value="Franklin"/>            
+        </valueReference>
+    </extension>
+    
+    <status value="final"/>
+    <type>
+        <coding>
+            <system value="http://loinc.org"/>
+            <code value="18842-5"/>
+        </coding>
+        <text value="Discharge Summarozation Note"/>
+    </type>
+    <subject>
+        <reference value="Patient/example0"/>
+        <display value="Franklin"/>
+    </subject>
+    
+    <date value="2018-06-03T12:30:02Z"/>
+    <author>
+        <reference value="Practitioner/example0"/>
+        <display value="Doctor Mayo"/>
+    </author>
+    <title value="Discharge Summary"/>
+    
+</Composition>

--- a/examples/composition-different-authors.xml
+++ b/examples/composition-different-authors.xml
@@ -4,28 +4,7 @@
     <meta>
         <lastUpdated value="2013-05-28T22:12:21Z"/>
     </meta>
-    <text>
-        <status value="generated"/>
-        <div xmlns="http://www.w3.org/1999/xhtml">
-            <p><b>Narrative details</b></p>
-            <p><b>id</b>: composition-different-authors</p>                            
-            <p><b>status</b>: final</p>
-            <p><b>type</b>: Discharge Summarization Note <span
-                    style="background: LightGoldenRodYellow">(Details : {LOINC code '18842-5' =
-                'Discharge Summarization Note)</span></p>
-            <p><b> date</b> : June 3, 2018 12:30:02 PM</p>
-            <p><b>author</b>: <a href="Practitioner-example0.html">Doctor Mayo</a></p>
-            <p><b>title</b>: Discharge Summary</p>
-            <p><b>Extension:</b>The Reason for admission section content has been authored by practitioner:<a
-                href="Practitioner-example0.html">Dr. Mayo</a>
-            </p>
-            <p><b>Extension:</b>The Medications on Discharge section content has been authored by practitionerRole:<a
-                href="PractitionerRole-example0.html">Cardiologist</a>
-            </p>
-            
-        </div>
-    </text>
-
+   
     <status value="final"/>
     <type>
         <coding>

--- a/examples/composition-multiple-information-recipients-and-author-role.xml
+++ b/examples/composition-multiple-information-recipients-and-author-role.xml
@@ -11,7 +11,7 @@
                 <b> Generated Narrative with Details</b>
             </p>
             <p>
-                <b> id</b> : multiple information recipients and author role</p>
+                <b> id</b> : multiple-information-recipients-and-author-role</p>
             <p>
                 <b> meta</b> : </p>
             <p>

--- a/examples/composition-multiple-information-recipients-and-author-role.xml
+++ b/examples/composition-multiple-information-recipients-and-author-role.xml
@@ -8,24 +8,10 @@
         <status value="extensions"/>
         <div xmlns="http://www.w3.org/1999/xhtml">           
             <p>
-                <b> Generated Narrative with Details</b>
+                <b>Narrative details</b>
             </p>
             <p>
-                <b> id</b> : multiple-information-recipients-and-author-role</p>
-            <p>
-                <b> meta</b> : </p>
-            <p>
-                <b> status</b> : final</p>
-            <p>
-                <b> type</b> : Discharge Summary Note <span> (Details : {LOINC
-                    code '18842-5' = 'Discharge Summarization Note)</span>
-            </p>
-            
-            <p>
-                <b> date</b> : June 3, 2018 12:30:02 PM</p>
-            <p>
-                <b> author</b> :<a href="Practitioner-example0.html">Dr. Mayo</a>
-            </p>
+                <b> id</b> : multiple-information-recipients-and-author-role</p>     
             <p>
                 <b> Extension:</b> practitioner role as composition author role:<a href="PractitionerRole-example0.html">Cardiologist</a>
             </p>
@@ -38,6 +24,19 @@
             <p>
                 <b> Extension:</b> organization as information recipient:<a href="Organization-example0.html">Downunder Hospital</a>
             </p>
+                        
+            <p>
+                <b> status</b> : final</p>
+            <p><b>type</b>: Discharge Summarization Note <span
+                style="background: LightGoldenRodYellow">(Details : {LOINC code '18842-5' =
+                'Discharge Summarization Note)</span></p>
+            
+            <p>
+                <b> date</b> : June 3, 2018 12:30:02 PM</p>
+            <p>
+                <b> author</b> :<a href="Practitioner-example0.html">Dr. Mayo</a>
+            </p>
+           
             <p>
                 <b> title</b> : Discharge Summary</p>
             

--- a/examples/composition-multiple-information-recipients-and-author-role.xml
+++ b/examples/composition-multiple-information-recipients-and-author-role.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composition xmlns="http://hl7.org/fhir">
+    <id value="multiple-information-recipients-and-author-role"/>
+    <meta>
+        <lastUpdated value="2013-05-28T22:12:21Z"/>
+    </meta>
+    <text>
+        <status value="extensions"/>
+        <div xmlns="http://www.w3.org/1999/xhtml">           
+            <p>
+                <b> Generated Narrative with Details</b>
+            </p>
+            <p>
+                <b> id</b> : multiple information recipients and author role</p>
+            <p>
+                <b> meta</b> : </p>
+            <p>
+                <b> status</b> : final</p>
+            <p>
+                <b> type</b> : Discharge Summary Note <span> (Details : {LOINC
+                    code '18842-5' = 'Discharge Summarization Note)</span>
+            </p>
+            
+            <p>
+                <b> date</b> : June 3, 2018 12:30:02 PM</p>
+            <p>
+                <b> author</b> :<a href="Practitioner-example0.html">Dr. Mayo</a>
+            </p>
+            <p>
+                <b> Extension: practitioner role as composition author role</b> :<a href="PractitionerRole-example0.html">Cardiologist</a>
+            </p>
+            <p>
+                <b> Extension: patient as information recipient</b> :<a href="Patient-example0.html">Stella Franklin</a>
+            </p>
+            <p>
+                <b> Extension: practitioner as information recipient</b> :<a href="Practitioner-example0.html">Dr. Mayo</a>
+            </p>
+            <p>
+                <b> title</b> : Discharge Summary</p>
+            
+        </div>
+    </text>
+    
+    
+    
+    <!--composition-author-role-->    
+    <extension url="http://hl7.org.au/fhir/StructureDefinition/composition-author-role">
+        <valueReference>
+            <reference value="PractitionerRole/example0"/>
+            <display value="Doctor Mayo"/> 
+        </valueReference>
+    </extension>
+    
+    <!--Multiple information-recipients of different resource type-->  
+    <extension url="http://hl7.org.au/fhir/StructureDefinition/information-recipient">
+        <valueReference>
+            <reference value="Patient/example0"/>
+            <display value="Franklin"/>            
+        </valueReference>
+    </extension>    
+    
+    <extension url="http://hl7.org.au/fhir/StructureDefinition/information-recipient">
+        <valueReference>
+            <reference value="Practitioner/example0"/>
+            <display value="Doctor Mayo"/>            
+        </valueReference>
+    </extension>
+    
+    <extension url="http://hl7.org.au/fhir/StructureDefinition/information-recipient">
+        <valueReference>
+            <reference value="http://snomed.info/sct"/>
+            <display value="Electrocardiographic monitor and recorder"/>    
+        </valueReference>
+    </extension>
+    
+    <status value="final"/>
+    <type>
+        <coding>
+            <system value="http://loinc.org"/>
+            <code value="18842-5"/>
+        </coding>
+        <text value="Discharge Summarization Note"/>
+    </type>
+    <subject>
+        <reference value="Patient/example0"/>
+        <display value="Franklin"/>
+    </subject>
+   
+    <date value="2018-06-03T12:30:02Z"/>
+    <author>
+        <reference value="Practitioner/example0"/>
+        <display value="Doctor Mayo"/>
+    </author>
+    <title value="Discharge Summary"/>
+    
+</Composition>

--- a/examples/composition-multiple-information-recipients-and-author-role.xml
+++ b/examples/composition-multiple-information-recipients-and-author-role.xml
@@ -27,13 +27,16 @@
                 <b> author</b> :<a href="Practitioner-example0.html">Dr. Mayo</a>
             </p>
             <p>
-                <b> Extension: practitioner role as composition author role</b> :<a href="PractitionerRole-example0.html">Cardiologist</a>
+                <b> Extension:</b> practitioner role as composition author role:<a href="PractitionerRole-example0.html">Cardiologist</a>
             </p>
             <p>
-                <b> Extension: patient as information recipient</b> :<a href="Patient-example0.html">Stella Franklin</a>
+                <b> Extension:</b> patient as information recipient:<a href="Patient-example0.html">Stella Franklin</a>
             </p>
             <p>
-                <b> Extension: practitioner as information recipient</b> :<a href="Practitioner-example0.html">Dr. Mayo</a>
+                <b> Extension:</b> practitioner as information recipient:<a href="Practitioner-example0.html">Dr. Mayo</a>
+            </p>
+            <p>
+                <b> Extension:</b> organization as information recipient:<a href="Organization-example0.html">Downunder Hospital</a>
             </p>
             <p>
                 <b> title</b> : Discharge Summary</p>
@@ -47,7 +50,7 @@
     <extension url="http://hl7.org.au/fhir/StructureDefinition/composition-author-role">
         <valueReference>
             <reference value="PractitionerRole/example0"/>
-            <display value="Doctor Mayo"/> 
+            <display value="Cardiologist"/> 
         </valueReference>
     </extension>
     
@@ -68,8 +71,8 @@
     
     <extension url="http://hl7.org.au/fhir/StructureDefinition/information-recipient">
         <valueReference>
-            <reference value="http://snomed.info/sct"/>
-            <display value="Electrocardiographic monitor and recorder"/>    
+            <reference value="Organization/example0"/>
+            <display value="Downunder Hospital"/>    
         </valueReference>
     </extension>
     

--- a/examples/composition-multiple-information-recipients-and-author-role.xml
+++ b/examples/composition-multiple-information-recipients-and-author-role.xml
@@ -4,46 +4,6 @@
     <meta>
         <lastUpdated value="2013-05-28T22:12:21Z"/>
     </meta>
-    <text>
-        <status value="extensions"/>
-        <div xmlns="http://www.w3.org/1999/xhtml">           
-            <p>
-                <b>Narrative details</b>
-            </p>
-            <p>
-                <b> id</b> : multiple-information-recipients-and-author-role</p>     
-            <p>
-                <b> Extension:</b> practitioner role as composition author role:<a href="PractitionerRole-example0.html">Cardiologist</a>
-            </p>
-            <p>
-                <b> Extension:</b> patient as information recipient:<a href="Patient-example0.html">Stella Franklin</a>
-            </p>
-            <p>
-                <b> Extension:</b> practitioner as information recipient:<a href="Practitioner-example0.html">Dr. Mayo</a>
-            </p>
-            <p>
-                <b> Extension:</b> organization as information recipient:<a href="Organization-example0.html">Downunder Hospital</a>
-            </p>
-                        
-            <p>
-                <b> status</b> : final</p>
-            <p><b>type</b>: Discharge Summarization Note <span
-                style="background: LightGoldenRodYellow">(Details : {LOINC code '18842-5' =
-                'Discharge Summarization Note)</span></p>
-            
-            <p>
-                <b> date</b> : June 3, 2018 12:30:02 PM</p>
-            <p>
-                <b> author</b> :<a href="Practitioner-example0.html">Dr. Mayo</a>
-            </p>
-           
-            <p>
-                <b> title</b> : Discharge Summary</p>
-            
-        </div>
-    </text>
-    
-    
     
     <!--composition-author-role-->    
     <extension url="http://hl7.org.au/fhir/StructureDefinition/composition-author-role">

--- a/pages/_includes/au-composition-intro.md
+++ b/pages/_includes/au-composition-intro.md
@@ -4,6 +4,6 @@ This Composition profile provided for use in an Australian context.
 
 **Examples**
 
-[Composition with multiple information recipients and author role](Composition-multiple-information-recipients-and-author-role.html)
+[Composition with multiple information recipients and one author role](Composition-multiple-information-recipients-and-author-role.html)
 
-[Composition with composition different authors](Composition-composition-different-authors.html)
+[Composition with some sections having a different section author to the composition author](Composition-composition-different-authors.html)

--- a/pages/_includes/au-composition-intro.md
+++ b/pages/_includes/au-composition-intro.md
@@ -2,3 +2,8 @@
 
 This Composition profile provided for use in an Australian context.
 
+**Examples**
+
+[Composition with multiple information recipients and author role](Composition-multiple-information-recipients-and-author-role.html)
+
+[Composition with composition different authors](Composition-composition-different-authors.html)

--- a/resources/ig.xml
+++ b/resources/ig.xml
@@ -526,6 +526,22 @@
       </sourceReference>
     </resource>
     <resource>
+      <example value="true"/>
+      <name value="composition-multiple-information-recipients-and-author-role"/>
+      <description value="Shows a typical example of a composition author role and multiple information recipients of different resource type"/>
+      <sourceReference>
+        <reference value="Composition/multiple-information-recipients-and-author-role"/>
+      </sourceReference>
+    </resource>
+    <resource>
+      <example value="true"/>
+      <name value="composition-different-authors"/>
+      <description value="Shows a typical composition with different authors"/>
+      <sourceReference>
+        <reference value="Composition/composition-different-authors"/>
+      </sourceReference>
+    </resource>
+    <resource>
       <example value="false"/>
       <sourceReference>
         <reference value="StructureDefinition/au-medication"/>


### PR DESCRIPTION
Hi Brett, 

Can you please accept the pull request which consists examples for au-composition with below details.

1. First example with some sections have a different section-author to the Composition.author
2. Second with a composition-author-role, and multiple information-recipients of different resource type

Thanks and Kind Regards, 
Uday