### PR TITLE
au-composition :: examples to display related person as attester party (updated)

### DIFF
--- a/examples/composition-WithAttesterRelatedParty.xml
+++ b/examples/composition-WithAttesterRelatedParty.xml
@@ -9,8 +9,8 @@
     <coding>
       <system value="http://loinc.org"/>
       <code value="81337-8"/>
+      <display value="Patient Goals, preferences, and priorities upon death"/>
     </coding>
-    <text value="Patient Goals, preferences, and priorities upon death"/>
   </type>
 
   <subject>
@@ -27,16 +27,15 @@
 
   <title value="Stella's Final Wishes"/>
 
-  <!--       Attester Related Party      -->
-  <attester id="attester001">
-    <extension url="http://hl7.org.au/fhir/StructureDefinition/attester-related-party"
-      id="RelatedParty1">
+  <!-- Related Person as Attester Party -->
+  <attester>
+    <extension url="http://hl7.org.au/fhir/StructureDefinition/attester-related-party">
       <valueReference>
         <reference value="RelatedPerson/example0"/>
       </valueReference>
     </extension>
     <mode value="personal"/>
-    <time value="2012-01-04T09:10:14Z"/>
+    <time value="2018-03-04T12:30:02Z"/>
   </attester>
 
   <section>
@@ -51,8 +50,7 @@
         <p><b>Goals, Preferences and Priorities</b>: The washing of the body should be carried out by someone of the same sex.</p>        
       </div>
     </text>
-
-    <mode value="changes"/>
+    
   </section>
 
 </Composition>

--- a/examples/composition-WithAttesterRelatedParty.xml
+++ b/examples/composition-WithAttesterRelatedParty.xml
@@ -3,64 +3,6 @@
 
   <id value="WithAttesterRelatedParty"/>
 
-  <text>
-    <status value="additional"/>
-    <div xmlns="http://www.w3.org/1999/xhtml">
-      <p><b>Subject</b>: Stella Franklin</p>
-      <p>
-        <b>Additional Narrative with Details</b>
-      </p>
-      <p><b>id</b>: WithAttesterRelatedParty</p>
-      <p><b>status</b>: final</p>
-      <p><b>type</b>: Patient Goals, preferences, and priorities upon death <span
-          style="background: LightGoldenRodYellow">(Details : {LOINC code '81337-8' = 'Patient
-          Goals, preferences, and priorities upon death)</span></p>
-      <p><b>date</b>: 01/02/2018 12:30:02 PM</p>
-      <p><b>author</b>: <a href="Practitioner-example0.html">Dr. Helen Mayo. Generated Summary: id:
-          example0; HPI-I = 8003610833334085, Prescriber Number = 453221, Australian Health
-          Practitioner Regulation Agency Registration Number = MED0000932945; active; Helen Mayo ;
-          helen.mayo@downunderhospital.com.au(WORK)</a></p>
-      <p><b>title</b>: Composition with related person as attester party</p>
-      <p><b>confidentiality</b>: N</p>
-      <h3>Attesters</h3>
-      <table class="grid">
-        <tr>
-          <td>-</td>
-          <td>
-            <b>Id</b>
-          </td>
-          <td>
-            <b>Extension: Related Person as Attester Party</b>
-          </td>
-          <td>
-            <b>Mode</b>
-          </td>
-          <td>
-            <b>Time</b>
-          </td>
-        </tr>
-        <tr>
-          <td>*</td>
-          <td>attester001</td>
-          <td>
-            <a href="RelatedPerson-example0.html">Benedicte du Marche. Generated Summary: id:
-              example0; WIFE; +33 (237) 998327; female; 43, Place du Marche Sainte Catherine Paris
-              75004 FRA; BeDu.KiMa@someemail.com(home)</a>
-          </td>
-          <td>personal</td>
-          <td>04/01/2012 9:10:14 AM</td>
-        </tr>
-      </table>
-      <p/>
-      <h3>Patient goals and priorities upon death</h3>
-      <p><b>Goals</b>: Patient wants to remain as pain free as possible.</p>
-      <p><b>Preferences</b>: Patient wants a social life and does not want aggressive treatment that
-        would prevent her from being social. Patient does not want to be resuscitated.</p>
-      <p><b>Priorities</b>: Remaining pain free as much as possible is a priority over not being
-        resuscitated.</p>
-    </div>
-  </text>
-
   <status value="final"/>
 
   <type>
@@ -76,16 +18,14 @@
     <display value="Stella Franklin"/>
   </subject>
 
-  <date value="2018-02-01T12:30:02Z"/>
+  <date value="2018-03-04T12:30:02Z"/>
 
   <author>
-    <reference value="Practitioner/example0"/>
-    <display value="Dr. Helen Mayo"/>
+    <reference value="RelatedPerson/example0"/>
+    <display value="Benedicte du Marche"/>
   </author>
 
-  <title value="Composition with related person as attester party"/>
-
-  <confidentiality value="N"/>
+  <title value="Stella's Final Wishes"/>
 
   <!--       Attester Related Party      -->
   <attester id="attester001">
@@ -108,11 +48,7 @@
         <p>
           <b>Additional Narrative</b>
         </p>
-        <p><b>Goals</b>: Patient wants to remain as pain free as possible.</p>
-        <p><b>Preferences</b>: Patient wants a social life and does not want aggressive treatment
-          that would prevent her from being social. Patient does not want to be resuscitated.</p>
-        <p><b>Priorities</b>: Remaining pain free as much as possible is a priority over not being
-          resuscitated.</p>
+        <p><b>Goals, Preferences and Priorities</b>: The washing of the body should be carried out by someone of the same sex.</p>        
       </div>
     </text>
 

--- a/examples/composition-example0.xml
+++ b/examples/composition-example0.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Composition xmlns="http://hl7.org/fhir">
 
-  <id value="WithAttesterRelatedParty"/>
+  <id value="example0"/>
 
   <status value="final"/>
 

--- a/pages/_includes/au-composition-intro.md
+++ b/pages/_includes/au-composition-intro.md
@@ -8,5 +8,5 @@ This Composition profile provided for use in an Australian context.
 
 [Composition with some sections having a different section author to the composition author](Composition-composition-different-authors.html)
 
-[Composition with related person as attester party](composition-WithAttesterRelatedParty.html)
+[Composition with related person as attester party](Composition-WithAttesterRelatedParty.html)
 

--- a/pages/_includes/au-composition-intro.md
+++ b/pages/_includes/au-composition-intro.md
@@ -8,5 +8,5 @@ This Composition profile provided for use in an Australian context.
 
 [Composition with some sections having a different section author to the composition author](Composition-composition-different-authors.html)
 
-[Patient's preference upon death](Composition-WithAttesterRelatedParty.html)
+[Patient's preference upon death](Composition-example0.html)
 

--- a/pages/_includes/au-composition-intro.md
+++ b/pages/_includes/au-composition-intro.md
@@ -8,5 +8,5 @@ This Composition profile provided for use in an Australian context.
 
 [Composition with some sections having a different section author to the composition author](Composition-composition-different-authors.html)
 
-[Composition with related person as attester party](Composition-WithAttesterRelatedParty.html)
+[Patient's preference upon death](Composition-WithAttesterRelatedParty.html)
 

--- a/resources/ig.xml
+++ b/resources/ig.xml
@@ -530,7 +530,7 @@
       <name value="Composition with attester party"/>
       <description value="Shows a typical composition with a related party as attester"/>
       <sourceReference>
-        <reference value="Composition/WithAttesterRelatedParty"/>
+        <reference value="Composition/example0"/>
       </sourceReference>
     </resource>
 	<resource>


### PR DESCRIPTION
Hi Brett,

Can you please accept the pull request which consists of the example being updated after a number of internal reviews.
This is an example where the Related Person is the Attester Party.

There are a number of changes made.

- example's id is changed.
- example file renamed as the id was changed. 
- Description about the example in the intro file is updated. 
- ig.xml file is updated as the example file was renamed. 
- the manual entry for the narrative has been removed from the example and now defaults to the generated narrative.
- author and attester are now the same person.
- dates have been updated to represent the chronological order.
- some elements which were immaterial to the example presented has been removed. 
- the section has been added and the narrative of the section matches the loinc id.


Thanks and Regards,
Vikas