### PR TITLE
au-organisation profile - simplified narratives

### DIFF
--- a/resources/au-organisation.xml
+++ b/resources/au-organisation.xml
@@ -20,7 +20,7 @@
       <value value="http://hl7.org.au/fhir" />
     </telecom>
   </contact>
-  <description value="Australian realm Organisation." />
+  <description value="Australian realm Organisation profile." />
   <purpose value="Tracking patient is the center of the healthcare process." />
   <fhirVersion value="3.0.1" />
   <kind value="resource" />

--- a/resources/au-organisation.xml
+++ b/resources/au-organisation.xml
@@ -20,7 +20,7 @@
       <value value="http://hl7.org.au/fhir" />
     </telecom>
   </contact>
-  <description value="Australian realm Organisation profile often healthcare or related service provision." />
+  <description value="Australian realm Organisation." />
   <purpose value="Tracking patient is the center of the healthcare process." />
   <fhirVersion value="3.0.1" />
   <kind value="resource" />
@@ -32,7 +32,7 @@
     <element id="Organization">
       <path value="Organization" />
       <short value="Australian Organisation" />
-      <definition value="Australian realm Organisation profile often healthcare or related service provision." />
+      <definition value="Australian realm Organisation." />
     </element>
     <element id="Organization.identifier">
       <path value="Organization.identifier" />


### PR DESCRIPTION
The [current definition of the root element Organization](http://build.fhir.org/ig/hl7au/au-fhir-base/StructureDefinition-au-organisation-definitions.html#Organization) currently reads:
> Australian realm Organisation profile often healthcare or related service provision.

Which doesn't seem quite right, particularly the last half. The Agency is working towards a revised Participant Data Specification, as derived from the HL7 AU profiles, that uses this content. We are therefore looking to have this content improved and are proposing a simplification to just:
> Australian realm Organisation

This PR makes this change for the following 2 elements in the profile:
- StructureDefinition.description (to be "_Australian realm Organisation profile_")
- root element Organization.definition (to be "_Australian realm Organisation_")

thank you