### PR TITLE
au-practitionerrole - minor revision to identifier definition

### DIFF
--- a/resources/au-practitionerrole.xml
+++ b/resources/au-practitionerrole.xml
@@ -49,7 +49,7 @@
         <rules value="open" />
       </slicing>
       <short value="Practitioner role identifiers" />
-      <definition value="business identifiers for practitioner in a role" />
+      <definition value="Business identifiers for practitioner in a role." />
     </element>
     <element id="PractitionerRole.identifier:providerNumber">
       <path value="PractitionerRole.identifier" />


### PR DESCRIPTION
The [current definition of the PractitionerRole.identifier element](http://build.fhir.org/ig/hl7au/au-fhir-base/StructureDefinition-au-practitionerrole-definitions.html#PractitionerRole.identifier) reads:
> business identifiers for practitioner in a role

Proposing minor edits to add first letter capitalisation and a period at the end.
> Business identifiers for practitioner in a role.