### PR TITLE
Stribild 4 medications example

### DIFF
--- a/examples/medication-FixedDoseCombinationMedicineStribild.xml
+++ b/examples/medication-FixedDoseCombinationMedicineStribild.xml
@@ -7,15 +7,7 @@
             <p>
                 <b>Manually Generated Narrative</b>
             </p>
-            <p>This is the structure for the <a
-                    href="https://www.safetyandquality.gov.au/wp-content/uploads/2016/03/National-guidelines-for-onscreen-display-of-clinical-medicines-information.pdf#page=34"
-                    >Product with four or more active ingredients</a> example given in the National
-                guidelines for on-screen display of clinical medicines information document.</p>
-            <p>The fixed dose combination medicine Stribild contains:<ul>
-                    <li>tenofovir disoproxil fumarate 300 mg</li>
-                    <li>emtricitabine 200 mg</li>
-                    <li>elvitegravir 150 mg</li>
-                    <li>cobicistat 150 mg</li></ul>
+            <p>Strbild - tablet
             </p>
         </div>
     </text>

--- a/examples/medication-FixedDoseCombinationMedicineStribild.xml
+++ b/examples/medication-FixedDoseCombinationMedicineStribild.xml
@@ -4,10 +4,8 @@
     <text>
         <status value="extensions"/>
         <div xmlns="http://www.w3.org/1999/xhtml">
-            <p>
-                <b>Manually Generated Narrative</b>
-            </p>
-            <p>Strbild - tablet
+
+            <p><emphasis>Stribild</emphasis> - tablet
             </p>
         </div>
     </text>

--- a/examples/medication-FixedDoseCombinationMedicineStribild.xml
+++ b/examples/medication-FixedDoseCombinationMedicineStribild.xml
@@ -5,7 +5,7 @@
         <status value="extensions"/>
         <div xmlns="http://www.w3.org/1999/xhtml">
 
-            <p><b>Stribild</b> - tablet
+            <p><i>Stribild</i> - tablet
             </p>
         </div>
     </text>

--- a/examples/medication-FixedDoseCombinationMedicineStribild.xml
+++ b/examples/medication-FixedDoseCombinationMedicineStribild.xml
@@ -5,7 +5,7 @@
         <status value="extensions"/>
         <div xmlns="http://www.w3.org/1999/xhtml">
 
-            <p><emphasis>Stribild</emphasis> - tablet
+            <p><b>Stribild</b> - tablet
             </p>
         </div>
     </text>

--- a/examples/medication-FixedDoseCombinationMedicineStribild.xml
+++ b/examples/medication-FixedDoseCombinationMedicineStribild.xml
@@ -1,0 +1,151 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Medication xmlns="http://hl7.org/fhir">
+    <id value="FixedDoseCombinationMedicineStribild"/>
+    <text>
+        <status value="extensions"/>
+        <div xmlns="http://www.w3.org/1999/xhtml">
+            <p>
+                <b>Manually Generated Narrative</b>
+            </p>
+            <p>This is the structure for the <a
+                    href="https://www.safetyandquality.gov.au/wp-content/uploads/2016/03/National-guidelines-for-onscreen-display-of-clinical-medicines-information.pdf#page=34"
+                    >Product with four or more active ingredients</a> example given in the National
+                guidelines for on-screen display of clinical medicines information document.</p>
+            <p>The fixed dose combination medicine Stribild contains:<ul>
+                    <li>tenofovir disoproxil fumarate 300 mg</li>
+                    <li>emtricitabine 200 mg</li>
+                    <li>elvitegravir 150 mg</li>
+                    <li>cobicistat 150 mg</li></ul>
+            </p>
+        </div>
+    </text>
+    <code>
+        <coding>
+            <extension url="http://hl7.org.au/fhir/StructureDefinition/medication-type">
+                <valueCoding>
+                    <system value="http://hl7.org.au/fhir/CodeSystem/medication-type"/>
+                    <code value="BPD"/>
+                    <display value="Branded product with no strengths or form"/>
+                </valueCoding>
+            </extension>
+            <system value="http://snomed.info/sct"/>
+            <code value="154481000036105"/>
+            <display value="Stribild"/>
+        </coding>
+    </code>
+    <form>
+        <coding>
+            <system value="http://snomed.info/sct"/>
+            <code value="385055001"/>
+            <display value="Tablet"/>
+        </coding>
+    </form>
+    <ingredient>
+        <itemCodeableConcept>
+            <coding>
+                <extension url="http://hl7.org.au/fhir/StructureDefinition/medication-type">
+                    <valueCoding>
+                        <system value="http://hl7.org.au/fhir/CodeSystem/medication-type"/>
+                        <code value="UPD"/>
+                        <display value="Unbranded product with no strengths or form"/>
+                    </valueCoding>
+                </extension>
+                <system value="http://snomed.info/sct"/>
+                <code value="2624011000036108"/>
+                <display value="tenofovir disoproxil fumarate"/>
+            </coding>
+        </itemCodeableConcept>
+        <isActive value="true"/>
+        <amount>
+            <numerator>
+                <value value="300"/>
+                <unit value="mg"/>
+            </numerator>
+            <denominator>
+                <value value="1"/>
+                <unit value="unit"/>
+            </denominator>
+        </amount>
+    </ingredient>
+    <ingredient>
+        <itemCodeableConcept>
+            <coding>
+                <extension url="http://hl7.org.au/fhir/StructureDefinition/medication-type">
+                    <valueCoding>
+                        <system value="http://hl7.org.au/fhir/CodeSystem/medication-type"/>
+                        <code value="UPD"/>
+                        <display value="Unbranded product with no strengths or form"/>
+                    </valueCoding>
+                </extension>
+                <system value="http://snomed.info/sct"/>
+                <code value="2070011000036109"/>
+                <display value="emtricitabine"/>
+            </coding>
+        </itemCodeableConcept>
+        <isActive value="true"/>
+        <amount>
+            <numerator>
+                <value value="200"/>
+                <unit value="mg"/>
+            </numerator>
+            <denominator>
+                <value value="1"/>
+                <unit value="unit"/>
+            </denominator>
+        </amount>
+    </ingredient>
+    <ingredient>
+        <itemCodeableConcept>
+            <coding>
+                <extension url="http://hl7.org.au/fhir/StructureDefinition/medication-type">
+                    <valueCoding>
+                        <system value="http://hl7.org.au/fhir/CodeSystem/medication-type"/>
+                        <code value="UPD"/>
+                        <display value="Unbranded product with no strengths or form"/>
+                    </valueCoding>
+                </extension>
+                <system value="http://snomed.info/sct"/>
+                <code value="154421000036109"/>
+                <display value="elvitegravir"/>
+            </coding>
+        </itemCodeableConcept>
+        <isActive value="true"/>
+        <amount>
+            <numerator>
+                <value value="150"/>
+                <unit value="mg"/>
+            </numerator>
+            <denominator>
+                <value value="1"/>
+                <unit value="unit"/>
+            </denominator>
+        </amount>
+    </ingredient>
+    <ingredient>
+        <itemCodeableConcept>
+            <coding>
+                <extension url="http://hl7.org.au/fhir/StructureDefinition/medication-type">
+                    <valueCoding>
+                        <system value="http://hl7.org.au/fhir/CodeSystem/medication-type"/>
+                        <code value="UPD"/>
+                        <display value="Unbranded product with no strengths or form"/>
+                    </valueCoding>
+                </extension>
+                <system value="http://snomed.info/sct"/>
+                <code value="154431000036106"/>
+                <display value="cobicistat"/>
+            </coding>
+        </itemCodeableConcept>
+        <isActive value="true"/>
+        <amount>
+            <numerator>
+                <value value="150"/>
+                <unit value="mg"/>
+            </numerator>
+            <denominator>
+                <value value="1"/>
+                <unit value="unit"/>
+            </denominator>
+        </amount>
+    </ingredient>
+</Medication>

--- a/pages/_includes/au-medication-intro.md
+++ b/pages/_includes/au-medication-intro.md
@@ -22,4 +22,4 @@ The following elements available in STU3 [Medication](http://hl7.org/fhir/STU3/m
 * [Clarithromycin 500mg Tablet Unbranded Product](medication-UnbrandedProduct0.html)
 * [Esomeprazole 20mg Tablet Unbranded Product](medication-UnbrandedProduct1.html)
 * [Amoxicillin 500mg Capsule Unbranded Product](medication-UnbrandedProduct2.html)
-* [Stribild - fixed dose combination medicine](Medication-FixedDoseCombinationMedicineStribild.html)
+* [Stribild Fixed Dose Combination Medication](Medication-FixedDoseCombinationMedicineStribild.html)

--- a/pages/_includes/au-medication-intro.md
+++ b/pages/_includes/au-medication-intro.md
@@ -22,3 +22,4 @@ The following elements available in STU3 [Medication](http://hl7.org/fhir/STU3/m
 * [Clarithromycin 500mg Tablet Unbranded Product](medication-UnbrandedProduct0.html)
 * [Esomeprazole 20mg Tablet Unbranded Product](medication-UnbrandedProduct1.html)
 * [Amoxicillin 500mg Capsule Unbranded Product](medication-UnbrandedProduct2.html)
+* [Stribild - fixed dose combination medicine](Medication-FixedDoseCombinationMedicineStribild.html)

--- a/resources/ig.xml
+++ b/resources/ig.xml
@@ -583,6 +583,14 @@
     </resource>
     <resource>
       <example value="true"/>
+      <name value="Medication with four active ingredients (Stribild)"/>
+      <description value="Stribild - a medication with four active ingredients"/>
+      <sourceReference>
+        <reference value="Medication/FixedDoseCombinationMedicineStribild"/>
+      </sourceReference>
+    </resource>
+    <resource>
+      <example value="true"/>
       <name value="composition-multiple-information-recipients-and-author-role"/>
       <description value="Shows a typical example of a composition author role and multiple information recipients of different resource type"/>
       <sourceReference>


### PR DESCRIPTION
A medication example with four active ingredients taken from the National guidelines for on-screen display of clinical medicines information - refer to section 6, page 32..
[National-guidelines-for-onscreen-display-of-clinical-medicines-information.pdf](https://github.com/hl7au/au-fhir-base/files/2191374/National-guidelines-for-onscreen-display-of-clinical-medicines-information.pdf)
