### PR TITLE
ig.json typo fix

### DIFF
--- a/ig.json
+++ b/ig.json
@@ -156,159 +156,159 @@
             },
         "ValueSet/snomed-practitioner-role": {
             "base": "Valueset-snomed-practitioner-role.html",
-            "defns": "Valueset-snomed-practitioner-role-definition.html"
+            "defns": "Valueset-snomed-practitioner-role-definitions.html"
             },
         "StructureDefinition/au-patient": {
             "base": "StructureDefinition-au-patient.html",
-            "defns": "StructureDefinition-au-patient-definition.html"
+            "defns": "StructureDefinition-au-patient-definitions.html"
             },
         "CodeSystem/au-hl7v2-0203": {
             "base": "CodeSystem-au-hl7v2-0203.html",
-            "defns": "CodeSystem-au-hl7v2-0203-definition.html"
+            "defns": "CodeSystem-au-hl7v2-0203-definitions.html"
             },
         "ValueSet/au-hl7v2-0203": {
             "base": "ValueSet-au-hl7v2-0203.html",
-            "defns": "ValueSet-au-hl7v2-0203-definition.html"
+            "defns": "ValueSet-au-hl7v2-0203-definitions.html"
             },
         "StructureDefinition/au-practitioner": {
             "base": "StructureDefinition-au-practitioner.html",
-            "defns": "StructureDefinition-au-practitioner-definition.html" 
+            "defns": "StructureDefinition-au-practitioner-definitions.html" 
             },
         "StructureDefinition/au-organisation": {
             "base": "StructureDefinition-au-organisation.html",
-            "defns": "StructureDefinition-au-organisation-definition.html" 
+            "defns": "StructureDefinition-au-organisation-definitions.html" 
             },
         "StructureDefinition/au-medication": {
             "base": "StructureDefinition-au-medication.html",
-            "defns": "StructureDefinition-au-medication-definition.html"
+            "defns": "StructureDefinition-au-medication-definitions.html"
             },
         "StructureDefinition/au-healthcareservice": {
             "base": "StructureDefinition-au-healthcareservice.html",
-            "defns": "StructureDefinition-au-healthcareservice-definition.html"
+            "defns": "StructureDefinition-au-healthcareservice-definitions.html"
             },
         "StructureDefinition/au-prescription": {
             "base": "StructureDefinition-au-prescription.html",
-            "defns": "StructureDefinition-au-prescription-definition.html"
+            "defns": "StructureDefinition-au-prescription-definitions.html"
             },
         "StructureDefinition/au-immunisation": {
             "base": "StructureDefinition-au-immunisation.html",
-            "defns": "StructureDefinition-au-immunisation-definition.html"
+            "defns": "StructureDefinition-au-immunisation-definitions.html"
             },
         "StructureDefinition/au-dispenserecord": {
             "base": "StructureDefinition-au-dispenserecord.html",
-            "defns": "StructureDefinition-au-dispenserecord-definition.html"
+            "defns": "StructureDefinition-au-dispenserecord-definitions.html"
             },
         "StructureDefinition/au-medicationstatement": {
             "base": "StructureDefinition-au-medicationstatement.html",
-             "defns": "StructureDefinition-au-medicationstatement-definition.html"
+             "defns": "StructureDefinition-au-medicationstatement-definitions.html"
             },
         "StructureDefinition/au-practitionerrole": {
             "base": "StructureDefinition-au-practitionerrole.html",
-             "defns": "StructureDefinition-au-practitionerrole-definition.html"
+             "defns": "StructureDefinition-au-practitionerrole-definitions.html"
             },
         "StructureDefinition/au-pbs-pharma-manufacturer": {
             "base": "StructureDefinition-au-pbs-pharma-manufacturer.html",
-             "defns": "StructureDefinition-au-pbs-pharma-manufacturer-definition.html"
+             "defns": "StructureDefinition-au-pbs-pharma-manufacturer-definitions.html"
             },
         "StructureDefinition/au-relatedperson": {
             "base": "StructureDefinition-au-relatedperson.html",
-            "defns": "StructureDefinition-au-relatedperson-definition.html"
+            "defns": "StructureDefinition-au-relatedperson-definitions.html"
             },
         "StructureDefinition/composition-author-role": {
             "base": "StructureDefinition-composition-author-role.html",
-            "defns": "StructureDefinition-composition-author-role-definition.html"
+            "defns": "StructureDefinition-composition-author-role-definitions.html"
             },
         "CodeSystem/medication-type": {
             "base": "CodeSystem-medication-type.html",
-             "defns": "CodeSystem-medication-type-definition.html"
+             "defns": "CodeSystem-medication-type-definitions.html"
             },
         "ValueSet/medication-type": {
             "base": "ValueSet-medication-type.html",
-            "defns": "ValueSet-medication-type-definition.html"
+            "defns": "ValueSet-medication-type-definitions.html"
             },
         "ValueSet/date-accuracy-indicator": {
             "base": "ValueSet-date-accuracy-indicator.html",
-            "defns": "ValueSet-date-accuracy-indicator-definition.html"
+            "defns": "ValueSet-date-accuracy-indicator-definitions.html"
             },
         "CodeSystem/date-accuracy-indicator": {
             "base": "CodeSystem-date-accuracy-indicator.html",
-            "defns": "CodeSystem-date-accuracy-indicator-definition.html"
+            "defns": "CodeSystem-date-accuracy-indicator-definitions.html"
             },
         "ValueSet/grounds-for-concurrent-supply": {
             "base": "ValueSet-grounds-for-concurrent-supply.html",
-            "defns": "ValueSet-grounds-for-concurrent-supply-definition.html"
+            "defns": "ValueSet-grounds-for-concurrent-supply-definitions.html"
             },
         "StructureDefinition/au-device": {
             "base": "StructureDefinition-au-device.html",
-            "defns": "StructureDefinition-au-device-definition.html"
+            "defns": "StructureDefinition-au-device-definitions.html"
             },
         "ValueSet/mims": {
             "base": "ValueSet-mims.html",
-            "defns": "ValueSet-mims-definition.html"
+            "defns": "ValueSet-mims-definitions.html"
             },
         "CodeSystem/mims": {
             "base": "CodeSystem-mims.html",
-            "defns": "CodeSystem-mims-definition.html"
+            "defns": "CodeSystem-mims-definitions.html"
             },
         "ValueSet/amt-codes": {
             "base": "ValueSet-amt-codes.html",
-            "defns": "ValueSet-amt-codes-definition.html"
+            "defns": "ValueSet-amt-codes-definitions.html"
             },
         "ValueSet/amt-ctpp-codes": {
             "base": "ValueSet-amt-ctpp-codes.html",
-            "defns": "ValueSet-amt-ctpp-codes-definition.html"
+            "defns": "ValueSet-amt-ctpp-codes-definitions.html"
             },
         "ValueSet/amt-tpp-codes": {
             "base": "ValueSet-amt-tpp-codes.html",
-            "defns": "ValueSet-amt-tpp-codes-definition.html"
+            "defns": "ValueSet-amt-tpp-codes-definitions.html"
             },
         "ValueSet/amt-tp-codes": {
             "base": "ValueSet-amt-tp-codes.html",
-            "defns": "ValueSet-amt-tp-codes-definition.html"
+            "defns": "ValueSet-amt-tp-codes-definitions.html"
             },
         "ValueSet/amt-mp-codes": {
             "base": "ValueSet-amt-mp-codes.html",
-            "defns": "ValueSet-amt-mp-codes-definition.html"
+            "defns": "ValueSet-amt-mp-codes-definitions.html"
             },
         "ValueSet/amt-mpp-codes": {
             "base": "ValueSet-amt-mpp-codes.html",
-            "defns": "ValueSet-amt-mpp-codes-definition.html"
+            "defns": "ValueSet-amt-mpp-codes-definitions.html"
             },
         "ValueSet/amt-mpuu-codes": {
             "base": "ValueSet-amt-mpuu-codes.html",
-            "defns": "ValueSet-amt-mpuu-codes-definition.html"
+            "defns": "ValueSet-amt-mpuu-codes-definitions.html"
             },
         "ValueSet/amt-tpuu-codes": {
             "base": "ValueSet-amt-tpuu-codes.html",
-            "defns": "ValueSet-amt-tpuu-codes-definition.html"
+            "defns": "ValueSet-amt-tpuu-codes-definitions.html"
             },
         "ValueSet/gtin": {
             "base": "ValueSet-gtin.html",
-            "defns": "ValueSet-gtin-definition.html"
+            "defns": "ValueSet-gtin-definitions.html"
             },
         "CodeSystem/gtin": {
             "base": "CodeSystem-gtin.html",
-            "defns": "CodeSystem-gtin-definition.html"
+            "defns": "CodeSystem-gtin-definitions.html"
             },
         "CodeSystem/pbs-item": {
             "base": "CodeSystem-pbs-item.html",
-            "defns": "CodeSystem-pbs-item-definition.html"
+            "defns": "CodeSystem-pbs-item-definitions.html"
             },
         "ValueSet/pbs-item": {
             "base": "ValueSet-pbs-item.html",
-            "defns": "ValueSet-pbs-item-definition.html"
+            "defns": "ValueSet-pbs-item-definitions.html"
             },
         "ValueSet/snomed-healthcareservice-services": {
             "base": "ValueSet-snomed-healthcareservice-services.html",
-            "defns": "ValueSet-snomed-healthcareservice-services-definition.html"
+            "defns": "ValueSet-snomed-healthcareservice-services-definitions.html"
             },
         "StructureDefinition/medication-brand-name": {
             "base": "StructureDefinition-medication-brand-name.html",
-             "defns": "StructureDefinition-medication-brand-name-definition.html"
+             "defns": "StructureDefinition-medication-brand-name-definitions.html"
             },
        "StructureDefinition/medication-generic-name": {
             "base": "StructureDefinition-medication-generic-name.html",
-             "defns": "StructureDefinition-medication-generic-name-definition.html"
+             "defns": "StructureDefinition-medication-generic-name-definitions.html"
             }
     }
 }


### PR DESCRIPTION
Hi Brett, with one of the [new commits made to master](https://github.com/hl7au/au-fhir-base/commit/30c87b322f548f4af978a4458a3c7c0b9758a444#diff-fa7d071b576c819977fd9c91648449a4), to introduce element hyperlinks to their detailed descriptions via changes to the ig.json, there are a number of typos. Some of the links are "...definition.html" not "...definition**s**.html".

Consequently, their profile detailed description tabs are giving 404 error.

This commit fixes the typo and the links were tested via a new IG build and the detailed description tabs are now working as expected.