### PR TITLE
Added new body site profile

### DIFF
--- a/ig.json
+++ b/ig.json
@@ -309,6 +309,10 @@
        "StructureDefinition/medication-generic-name": {
             "base": "StructureDefinition-medication-generic-name.html",
              "defns": "StructureDefinition-medication-generic-name-definitions.html"
+            },
+       "StructureDefinition/au-bodysite": {
+            "base": "StructureDefinition-au-bodysite.html",
+            "defns": "StructureDefinition-au-bodysite-definitions.html"
             }
     }
 }

--- a/pages/_includes/au-bodysite-intro.md
+++ b/pages/_includes/au-bodysite-intro.md
@@ -1,0 +1,1 @@
+This BodySite profile is provided for use in an Australian context.

--- a/pages/_includes/au-bodysite-search.md
+++ b/pages/_includes/au-bodysite-search.md
@@ -1,0 +1,1 @@
+none defined

--- a/pages/_includes/au-bodysite-summary.md
+++ b/pages/_includes/au-bodysite-summary.md
@@ -1,0 +1,6 @@
+AU BodySite profile contains:
+
+1. An invariant such that the body site shall at least have a code or a description or an image
+1. Optional code with required binding to Body Site
+1. At most one qualifier.coding with required binding to Bodysite Location Qualifier
+1. Mandatory patient with a reference to HL7 AU Base patient

--- a/pages/_includes/profiles.md
+++ b/pages/_includes/profiles.md
@@ -25,6 +25,8 @@ These Profiles have been defined for this implementation guide.
 
 ## Orders and Observations Profiles
 * [AU Base Observation Age](StructureDefinition-au-observation-age.html) - record of age at a point in time
+* [AU Body Site](StructureDefinition-au-bodysite.html) - body site with local coding
+
 
 ## Composition Profiles
 * [AU Base Composition](StructureDefinition-au-composition.html) - composition pattern aligned with local CDA requirements

--- a/resources/au-bodysite.xml
+++ b/resources/au-bodysite.xml
@@ -1,0 +1,66 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="au-bodysite"/>
+  <url value="http://hl7.org.au/fhir/StructureDefinition/au-bodysite"/>
+  <version value="0.1" />
+  <name value="AUBaseBodySite"/>
+  <title value="AU Base Body Site"/>
+  <status value="draft"/>
+  <date value="2018-07-23T09:04:25.483+10:00"/>
+  <publisher value="Health Level Seven Australia"/>
+  <contact>
+    <telecom>
+      <system value="url"/>
+      <value value="http://hl7.org.au"/>
+      <use value="work"/>
+    </telecom>
+  </contact>
+  <description value="Australian realm Base BodySite profile."/>
+  <fhirVersion value="3.0.1"/>
+  <kind value="resource"/>
+  <abstract value="false"/>
+  <type value="BodySite"/>
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/BodySite"/>
+  <derivation value="constraint"/>
+  <differential>
+    <element id="BodySite">
+      <path value="BodySite"/>
+      <short value="Australian context BodySite information"/>
+      <constraint>
+        <key value="inv-bodsit-0"/>
+        <severity value="error"/>
+        <human value="The body site shall at least have a code or a description or an image"/>
+        <expression value="code.exists() or description.exists() or image.exists()"/>
+      </constraint>
+    </element>
+    <element id="BodySite.code">
+      <path value="BodySite.code"/>
+    </element>
+    <element id="BodySite.code.coding">
+      <path value="BodySite.code.coding"/>
+      <short value="Coded anatomical location"/>
+      <binding>
+        <strength value="required"/>
+        <valueSetUri value="https://healthterminologies.gov.au/fhir/ValueSet/body-site-1"/>
+      </binding>
+    </element>
+    <element id="BodySite.qualifier">
+      <path value="BodySite.qualifier"/>
+    </element>
+    <element id="BodySite.qualifier.coding">
+      <path value="BodySite.qualifier.coding"/>
+      <max value="1"/>
+      <binding>
+        <strength value="required"/>
+        <valueSetUri value="http://hl7.org/fhir/ValueSet/bodysite-relative-location"/>
+      </binding>
+    </element>
+    <element id="BodySite.patient">
+      <path value="BodySite.patient"/>
+      <type>
+        <code value="Reference"/>
+        <targetProfile value="http://hl7.org.au/fhir/StructureDefinition/au-patient"/>
+      </type>
+    </element>
+  </differential>
+</StructureDefinition>

--- a/resources/ig.xml
+++ b/resources/ig.xml
@@ -687,6 +687,12 @@
         <reference value="Observation/observation-age-example-6monthsto5years"/>
       </sourceReference>
     </resource>
+    <resource>
+      <example value="false"/>
+      <sourceReference>
+        <reference value="StructureDefinition/au-bodysite"/>
+      </sourceReference>
+    </resource>
   </package>
   <page>
     <source value="index.html"/>


### PR DESCRIPTION
Hi Brett, this PR is to add a new profile on [BodySite](http://hl7.org/fhir/bodysite.html).

It contains 
- a new StructureDefinition file (au-bodysite)
- the usual supporting markdown files (noting that the summary of changes will likely change anyway via the XSLT generation recently discussed)
- updates to ig.json and ig.xml

Note that there are no accompanying examples at this point - we figure that these will come in the future to support specific use case scenarios.

Also, the single commit was rebased onto the tip of your recent master updates and the conflicts in ig.json and ig.xml were resolved). The IG builds successfully and there are no associated errors/warnings related to this content.