### PR TITLE
 Au Composition Profile - Invariant and Guidance

### DIFF
--- a/pages/_includes/au-composition-intro.md
+++ b/pages/_includes/au-composition-intro.md
@@ -10,3 +10,13 @@ This Composition profile provided for use in an Australian context.
 
 [Patient's preference upon death](Composition-example0.html)
 
+**Extensions**
+
+Extensions used in this profile:
+
+* Composition: [Composition Author Role](StructureDefinition-composition-author-role.html)
+* Composition: [Information Recipient](StructureDefinition-information-recipient.html)
+* Composition: [Related Person Attester Party](StructureDefinition-attester-related-party.html)
+* Composition: [Section Author](StructureDefinition-section-author.html)
+
+When capturing a composition practitioner role as the sole author of the composition, a practitioner linked to that practitioner role is required to be supplied as a composition author. Where there is more than one author this is not necessary or recommended.

--- a/resources/au-composition.xml
+++ b/resources/au-composition.xml
@@ -62,6 +62,12 @@
     </element>
     <element id="Composition.attester">
       <path value="Composition.attester" />
+	  <constraint>
+        <key value="inv-com-0" />
+        <severity value="error" />
+        <human value="Related party or party shall exist but not both" />
+        <expression value="attester.extension('http://hl7.org.au/fhir/StructureDefinition/attester-related-party').exists() xor attester.party.exists()" />
+    </constraint>
     </element>
     <element id="Composition.attester.extension">
       <path value="Composition.attester.extension" />


### PR DESCRIPTION
Hi Brett,
This pull request deals with the invariant you have asked for attester related party:
1. Invariant/Constraint included to cater for 'either Composition.attester.attester-related-party or Composition.attester.party shall exist but not both'.
2. Guidance included for the extensions used in the profile.
Thank you
Satya