### PR TITLE
Added link to Author Role Extension example in introduction.

### DIFF
--- a/pages/_includes/composition-author-role-intro.md
+++ b/pages/_includes/composition-author-role-intro.md
@@ -2,3 +2,6 @@ Extension: Authoring Practitioner Role
 
 This extension applies to the Composition resource and provides a practitioner role that authored this composition. This is not to be confused with who typed in the information.
 
+**Examples**
+
+[Composition with multiple information recipients and one author role](Composition-multiple-information-recipients-and-author-role.html)

--- a/pages/_includes/information-recipient-intro.md
+++ b/pages/_includes/information-recipient-intro.md
@@ -4,4 +4,4 @@ This extension applies to the Composition resource and allows recording of inten
 
 **Examples**
 
-[Composition with multiple information recipients and one author role](composition-multiple-information-recipients-and-author-role.html)
+[Composition with multiple information recipients and one author role](Composition-multiple-information-recipients-and-author-role.html)


### PR DESCRIPTION
Corrected a broken link in Information recipient Extension that uses the same example.