### PR TITLE
Healthcare service ext link update

### DIFF
--- a/ig.json
+++ b/ig.json
@@ -28,6 +28,10 @@
 		"template-base": "ex.html",
 		"template-format": "ex-format.html" 
 	},
+	"HealthcareService": { 
+		"template-base": "ex.html",
+		"template-format": "ex-format.html" 
+	},
 	"Practitioner": { 
 		"template-base": "ex.html",
 		"template-format": "ex-format.html" 

--- a/pages/_includes/healthcareservice-eligibility-detail-intro.md
+++ b/pages/_includes/healthcareservice-eligibility-detail-intro.md
@@ -2,4 +2,6 @@ Extension: Healthcare Service Eligibility Details
 
 This extension applies to the HealthcareService resource and allows enhanced eligibiliy status value for a healthcare service to be recorded.
 
+**Examples**
 
+[HealthcareService with HPI-O and SNOMED-CT coded specialty](HealthcareService-example0.html)


### PR DESCRIPTION
Hi Brett,
A change to the text used in the link for the example in Healthcare Service extension - to make the text more aligned with the style that is being used.