### PR TITLE
Close the gap ext guidance

### DIFF
--- a/pages/_includes/close-the-gap-registration-intro.md
+++ b/pages/_includes/close-the-gap-registration-intro.md
@@ -1,9 +1,9 @@
 Extension: Close the Gap Registration
 
-This extension applies to the Patient resource and provides  an indicator of whether the patient is eligible for a Closing the Gap (CTG) co-payment. 
+This extension applies to the Patient resource and provides  an indicator of whether the patient is eligible for a Close the Gap (CTG) co-payment. 
 
-Set to 'true' if eligible for closing the gap co-payment.
+Set to 'true' if eligible for CTG co-payment.
 
 **Examples**
 
-[Patient with no birth date, and eligible for close the gap registration](Patient-example2.html)
+[Patient with no birth date, and eligible for CTG registration](Patient-example2.html)

--- a/pages/_includes/close-the-gap-registration-intro.md
+++ b/pages/_includes/close-the-gap-registration-intro.md
@@ -1,6 +1,8 @@
 Extension: Close the Gap Registration
 
-This extension applies to the Patient resource and provides  an indicator of whether the patient is eligible for a Closing the Gap (CTG) co-payment.
+This extension applies to the Patient resource and provides  an indicator of whether the patient is eligible for a Closing the Gap (CTG) co-payment. 
+
+Set to 'true' if eligible for closing the gap co-payment.
 
 **Examples**
 


### PR DESCRIPTION
Hi Brett,
A change to the text used in the link for the example in Close the Gap extension - to make the text more aligned with the style that is being used.