### PR TITLE
Aligned the IHI Record Status extension hyperlink text to be the same…

### DIFF
--- a/pages/_includes/ihi-record-status-intro.md
+++ b/pages/_includes/ihi-record-status-intro.md
@@ -4,7 +4,8 @@ This extension applies to the [Identifier datatype](http://hl7.org/fhir/datatype
 
 This IHI record status extension describes whether verification of the individual identifier has occurred and is based on the evidence available for a person’s identity.
 
-#### Examples
-1. [Patient with Individual Healthcare Identifier Record Status (IHI Record Status) of "Verified".](Patient-example0.html)
-1. [Patient with Individual Healthcare Identifier Record Status (IHI Record Status) of "Unverified".](Patient-example1.html)
+**Examples**
 
+[Patient with IHI, Medicare Number, and Health Care Card](Patient-example0.html)
+
+[Patient with IHI and DVA Number](Patient-example1.html)


### PR DESCRIPTION
Hi Brett,
A change to the text used in the link for the example in IHI Record Status extension - to make the text more aligned with the style that is being used.