### PR TITLE
Added example links to the extension Medication-type 

### DIFF
--- a/pages/_includes/au-medication-intro.md
+++ b/pages/_includes/au-medication-intro.md
@@ -15,17 +15,27 @@ The following elements available in STU3 [Medication](http://hl7.org/fhir/STU3/m
 
 **Examples**
 
-* [Fluconazole Dose Based Medication](Medication-MedicationDoseBased.html)
-* [Paracetamol Generic Pack](medication-GenericPack0.html)
-* [Nexium Hp7 Brand Pack](medication-BrandedPack0.html)
-* [Nexium Hp7 Combination Package with Product Parts](medication-CombinationPackage0.html)
-* [Clarithromycin 500mg Tablet Unbranded Product](medication-UnbrandedProduct0.html)
-* [Esomeprazole 20mg Tablet Unbranded Product](medication-UnbrandedProduct1.html)
-* [Amoxicillin 500mg Capsule Unbranded Product](medication-UnbrandedProduct2.html)
-* [Norvasc 10 mg Tablet Brand Product with Batch Details](medication-BrandProductwithBatchDetails0.html)
+[Fluconazole Dose Based Medication](Medication-MedicationDoseBased.html)
+
+[Paracetamol Generic Pack](medication-GenericPack0.html)
+
+[Nexium Hp7 Brand Pack](medication-BrandedPack0.html)
+
+[Nexium Hp7 Combination Package with Product Parts](medication-CombinationPackage0.html)
+
+[Clarithromycin 500mg Tablet Unbranded Product](medication-UnbrandedProduct0.html)
+
+[Esomeprazole 20mg Tablet Unbranded Product](medication-UnbrandedProduct1.html)
+
+[Amoxicillin 500mg Capsule Unbranded Product](medication-UnbrandedProduct2.html)
+
+[Norvasc 10 mg Tablet Brand Product with Batch Details](medication-BrandProductwithBatchDetails0.html)
+
 
 The following examples have been taken from the [National guidelines for on-screen display of clinical medicines information – January 2016](https://www.safetyandquality.gov.au/publications/national-guidelines-for-on-screen-display-of-clinical-medicines-information/) published by the Australian Commission on Safety and Quality in Health Care. Care has been taken with the clinical content in the structured data, and construction of narrative to be consistent with the guidelines:
 
-* [Single active ingredient product: pack-based](medication-BrandedPackSingleActiveIngredient0.html)
-* [Two active ingredients product](medication-TwoActiveIngredientsProduct0.html)
-* [Product with four or more active ingredients](medication-FourOrMoreActiveIngredientsProduct0.html)
+[Single active ingredient product: pack-based](medication-BrandedPackSingleActiveIngredient0.html)
+
+[Two active ingredients product](medication-TwoActiveIngredientsProduct0.html)
+
+[Product with four or more active ingredients](medication-FourOrMoreActiveIngredientsProduct0.html)

--- a/pages/_includes/medication-type-intro.md
+++ b/pages/_includes/medication-type-intro.md
@@ -2,3 +2,30 @@ Extension: Medication Type
 
 This extension applies to the Coding datatype and provides a value to indicate a classification of the type of medication the parent coding. This is useful
 when there are multiple codings from the same CodingSystem at different levels/classifications.
+
+**Examples**
+
+[Fluconazole Dose Based Medication](Medication-MedicationDoseBased.html)
+
+[Paracetamol Generic Pack](medication-GenericPack0.html)
+
+[Nexium Hp7 Brand Pack](medication-BrandedPack0.html)
+
+[Nexium Hp7 Combination Package with Product Parts](medication-CombinationPackage0.html)
+
+[Clarithromycin 500mg Tablet Unbranded Product](medication-UnbrandedProduct0.html)
+
+[Esomeprazole 20mg Tablet Unbranded Product](medication-UnbrandedProduct1.html)
+
+[Amoxicillin 500mg Capsule Unbranded Product](medication-UnbrandedProduct2.html)
+
+[Norvasc 10 mg Tablet Brand Product with Batch Details](medication-BrandProductwithBatchDetails0.html)
+
+
+The following examples have been taken from the [National guidelines for on-screen display of clinical medicines information – January 2016](https://www.safetyandquality.gov.au/publications/national-guidelines-for-on-screen-display-of-clinical-medicines-information/) published by the Australian Commission on Safety and Quality in Health Care. Care has been taken with the clinical content in the structured data, and construction of narrative to be consistent with the guidelines:
+
+[Single active ingredient product: pack-based](medication-BrandedPackSingleActiveIngredient0.html)
+
+[Two active ingredients product](medication-TwoActiveIngredientsProduct0.html)
+
+[Product with four or more active ingredients](medication-FourOrMoreActiveIngredientsProduct0.html)


### PR DESCRIPTION
Hi Brett,
The extension "Medication Type" now has links to examples that use this profile ie same examples as available from the Medications profile.  The appearance of the examples on the Medications profile was changed to the updated style of a space between each example and the removal of the dot points for each example.