### PR TITLE
au-medicationstatement :: Slices for reasonNotTaken and reasonCode and AU Base Dosage reference

### DIFF
--- a/resources/au-medicationstatement.xml
+++ b/resources/au-medicationstatement.xml
@@ -52,9 +52,9 @@
         </discriminator>
         <rules value="open" />
       </slicing>
-	  <min value="1" />
-	  <max value="1" />
       <short value="Medication Detail" />
+    <min value="1" />
+	  <max value="1" />      
       <type>
         <code value="CodeableConcept" />
       </type>
@@ -441,15 +441,15 @@
       <slicing>
         <discriminator>
           <type value="value" />
-          <path value="coding.system" />
+          <path value="system" />
         </discriminator>
         <rules value="open" />
-      </slicing>
+      </slicing>      
     </element>
     <element id="MedicationStatement.reasonNotTaken.coding:snomedReasonNotTaken">
       <path value="MedicationStatement.reasonNotTaken.coding" />
       <sliceName value="snomedReasonNotTaken" />
-      <short value="Medication Reason Not Taken (SNOMED CT)" />
+      <short value="Reason Not Taken (SNOMED CT)" />
       <max value="1" />
       <binding>
         <strength value="required" />
@@ -466,15 +466,15 @@
       <slicing>
         <discriminator>
           <type value="value" />
-          <path value="coding.system" />
+          <path value="system" />
         </discriminator>
         <rules value="open" />
       </slicing>
     </element>
     <element id="MedicationStatement.reasonCode.coding:snomedReasonTaken">
       <path value="MedicationStatement.reasonCode.coding" />
-      <sliceName value="snomedReasonTaken" />
-      <short value="Medication Reason Taken (SNOMED CT)" />
+      <sliceName value="snomedReasonCode" />
+      <short value="Reason For Medication (SNOMED CT)" />
       <max value="1" />
       <binding>
         <strength value="required" />

--- a/resources/au-medicationstatement.xml
+++ b/resources/au-medicationstatement.xml
@@ -433,5 +433,60 @@
         <targetProfile value="http://hl7.org/fhir/StructureDefinition/Group" />
       </type>
     </element>
+    <element id="MedicationStatement.reasonNotTaken">
+      <path value="MedicationStatement.reasonNotTaken" />      
+    </element>
+    <element id="MedicationStatement.reasonNotTaken.coding">
+      <path value="MedicationStatement.reasonNotTaken.coding" />
+      <slicing>
+        <discriminator>
+          <type value="value" />
+          <path value="coding.system" />
+        </discriminator>
+        <rules value="open" />
+      </slicing>
+    </element>
+    <element id="MedicationStatement.reasonNotTaken.coding:snomedReasonNotTaken">
+      <path value="MedicationStatement.reasonNotTaken.coding" />
+      <sliceName value="snomedReasonNotTaken" />
+      <short value="Medication Reason Not Taken (SNOMED CT)" />
+      <max value="1" />
+      <binding>
+        <strength value="required" />
+        <valueSetReference>
+          <reference value="https://healthterminologies.gov.au/fhir/ValueSet/medication-reason-not-taken-1" />
+        </valueSetReference>
+      </binding>
+    </element>
+    <element id="MedicationStatement.reasonCode">
+      <path value="MedicationStatement.reasonCode" />      
+    </element>
+    <element id="MedicationStatement.reasonCode.coding">
+      <path value="MedicationStatement.reasonCode.coding" />
+      <slicing>
+        <discriminator>
+          <type value="value" />
+          <path value="coding.system" />
+        </discriminator>
+        <rules value="open" />
+      </slicing>
+    </element>
+    <element id="MedicationStatement.reasonCode.coding:snomedReasonTaken">
+      <path value="MedicationStatement.reasonCode.coding" />
+      <sliceName value="snomedReasonTaken" />
+      <short value="Medication Reason Taken (SNOMED CT)" />
+      <max value="1" />
+      <binding>
+        <strength value="required" />
+        <valueSetUri value="https://healthterminologies.gov.au/fhir/ValueSet/medication-reason-taken-1" />
+      </binding>
+    </element>
+    <element id="MedicationStatement.dosage">
+      <path value="MedicationStatement.dosage" />
+      <type>
+        <code value="Dosage" />
+        <profile value="http://hl7.org.au/fhir/StructureDefinition/au-dosage" />
+      </type>
+    </element>    
   </differential>
 </StructureDefinition>


### PR DESCRIPTION
Hello Brett, 

Please accept the following changes to au-medicationstatement profile -

**reasonNotTaken**

1. coding slice, unordered, open, on value:system
2. 0..1 slice coding (SNOMED CT) with required binding to https://healthterminologies.gov.au/fhir/ValueSet/medication-reason-not-taken-1
3. slice name is snomedReasonNotTaken
4. slice description is Reason Not Taken (SNOMED CT)

**reasonCode**
1. coding slice, unordered, open, on value:system
2. 0..1 slice coding (SNOMED CT) with required binding to https://healthterminologies.gov.au/fhir/ValueSet/medication-reason-taken-1
3. slice name is snomedReasonCode
4. slice description is Reason For Medication (SNOMED CT)

**dosage** typed to AU Base Dosage

Resolved FHIR schema error with the location if <short> element at "Medication Detail" slice.

Kind Regards, 
Uday