### PR TITLE
Added common Australian languages valueset to patient communication & practitioner communication

### DIFF
--- a/resources/au-patient.xml
+++ b/resources/au-patient.xml
@@ -822,6 +822,29 @@
         <profile value="http://hl7.org.au/fhir/StructureDefinition/date-accuracy-indicator" />
       </type>
     </element>
+    <element id="Patient.communication">
+      <path value="Patient.communication"/>
+    </element>
+    <element id="Patient.communication.language">
+      <path value="Patient.communication.language" />
+      <binding>
+        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet">
+          <valueReference>
+            <reference value="http://hl7.org/fhir/ValueSet/all-languages" />
+          </valueReference>
+        </extension>
+        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
+          <valueString value="Language" />
+        </extension>
+        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding">
+          <valueBoolean value="true" />
+        </extension>
+        <strength value="extensible" />
+        <valueSetReference>
+          <reference value="https://healthterminologies.gov.au/fhir/ValueSet/common-languages-australia-1" />
+        </valueSetReference>
+      </binding>
+    </element>
     <element id="Patient.generalPractitioner">
       <path value="Patient.generalPractitioner" />
       <short value="AU Base Practitioner | AU Base Organisation" />

--- a/resources/au-patient.xml
+++ b/resources/au-patient.xml
@@ -828,17 +828,6 @@
     <element id="Patient.communication.language">
       <path value="Patient.communication.language" />
       <binding>
-        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet">
-          <valueReference>
-            <reference value="http://hl7.org/fhir/ValueSet/all-languages" />
-          </valueReference>
-        </extension>
-        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
-          <valueString value="Language" />
-        </extension>
-        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding">
-          <valueBoolean value="true" />
-        </extension>
         <strength value="extensible" />
         <valueSetReference>
           <reference value="https://healthterminologies.gov.au/fhir/ValueSet/common-languages-australia-1" />

--- a/resources/au-practitioner.xml
+++ b/resources/au-practitioner.xml
@@ -313,5 +313,25 @@
       <min value="1" />
       <fixedString value="AHPRA" />
     </element>
+    <element id="Practitioner.communication">
+      <path value="Practitioner.communication" />
+      <binding>
+        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet">
+          <valueReference>
+            <reference value="http://hl7.org/fhir/ValueSet/all-languages" />
+          </valueReference>
+        </extension>
+        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
+          <valueString value="Language" />
+        </extension>
+        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding">
+          <valueBoolean value="true" />
+        </extension>
+        <strength value="extensible" />
+        <valueSetReference>
+          <reference value="https://healthterminologies.gov.au/fhir/ValueSet/common-languages-australia-1" />
+        </valueSetReference>
+      </binding>
+    </element>
   </differential>
 </StructureDefinition>

--- a/resources/au-practitioner.xml
+++ b/resources/au-practitioner.xml
@@ -316,17 +316,6 @@
     <element id="Practitioner.communication">
       <path value="Practitioner.communication" />
       <binding>
-        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet">
-          <valueReference>
-            <reference value="http://hl7.org/fhir/ValueSet/all-languages" />
-          </valueReference>
-        </extension>
-        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
-          <valueString value="Language" />
-        </extension>
-        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding">
-          <valueBoolean value="true" />
-        </extension>
         <strength value="extensible" />
         <valueSetReference>
           <reference value="https://healthterminologies.gov.au/fhir/ValueSet/common-languages-australia-1" />


### PR DESCRIPTION
As agreed in the HL7 AU PAWG 29-8-2018 (refer [minutes](https://confluence.hl7australia.com/display/PA/2018-08-29+Minutes)), the following elements are to have a new terminology binding to a NCTS valueset:
- `Patient.communication.language`
- `Practitioner.communication`

The new binding extends the current STU3 binding to [Common Languages (bcp.47)](http://hl7.org/fhir/valueset-languages.html) to include a number of Indigenous Australian languages; and is https://healthterminologies.gov.au/fhir/ValueSet/common-languages-australia-1