### PR TITLE
au-practitioner :: Radiologist example :: Changed the text value of AHPRA qualification to "Diagnostic radiology"

### DIFF
--- a/examples/practitioner-example1.xml
+++ b/examples/practitioner-example1.xml
@@ -40,7 +40,7 @@
 				<code value="253917"/> 
 				<display value="Diagnostic and Interventional Radiologist"/> 
 			</coding>		
-			<text value="Diagnostic and Interventional Radiologist"/>
+			<text value="Diagnostic radiology"/>
 		</code> 		
 		<issuer> 
 			<display value="AHPRA"/> 


### PR DESCRIPTION
Hi Brett, 

Please accept the pull request to change the text value of AHPRA qualification in au-practitioner

<text value="Diagnostic and Interventional Radiologist"/>
<text value="Diagnostic radiology"/>

Kind Regards,
Uday