### PR TITLE
au-practitionerrole - reverted location cardinality to default

### DIFF
--- a/pages/_includes/au-practitionerrole-summary.md
+++ b/pages/_includes/au-practitionerrole-summary.md
@@ -9,4 +9,3 @@ This profile contains the following variations from [PractitionerRole](http://hl
 1. at most one <span style='color:green'> organization </span> Organisation managing this role (Reference as: au-organisation)
 1. zero or more <span style='color:green'> specialty </span> Practitioner specialties sliced
    * zero or more <span style='color:green'> specialty </span> SNOMED Practitioner Specialty
-1. at most one <span style='color:green'> location </span> Location of Provider

--- a/resources/au-practitionerrole.xml
+++ b/resources/au-practitionerrole.xml
@@ -35,7 +35,6 @@
     <element id="PractitionerRole">
       <path value="PractitionerRole" />
       <short value="A practitioner in a healthcare role in an Australian healthcare context" />
-      <definition value="A practitioner, at a location, performing a role." />
     </element>
     <element id="PractitionerRole.identifier">
       <path value="PractitionerRole.identifier" />
@@ -346,9 +345,6 @@
     </element>
     <element id="PractitionerRole.location">
       <path value="PractitionerRole.location" />
-      <short value="Location of Provider" />
-      <definition value="Single location of provision of services for this role.  This is aligned with the use of an associated location specific Medicare Provider Number." />
-      <max value="1" />
       <type>
         <code value="Reference" />
         <targetProfile value="http://hl7.org.au/fhir/StructureDefinition/au-location" />


### PR DESCRIPTION
PractitionerRole.location cardinality constraint of 0..1 was removed to revert to the default 0..*.
This was the agreement at the HL7 AU working group meetings held 13/9/2018.

Also updated various narratives to align with the multiplicity.
No new errors/warnings on QA report.

(Note that this element in this commit still references the AU Base Location profile rather than the STU3 location. My intent here is to create a targeted change specifically for cardinality & the type change will be the subject of the next PR).