### PR TITLE
au-practitionerrole - reverted type references

### DIFF
--- a/pages/_includes/au-practitionerrole-summary.md
+++ b/pages/_includes/au-practitionerrole-summary.md
@@ -5,7 +5,5 @@ This profile contains the following variations from [PractitionerRole](http://hl
    * at most one <span style='color:green'> identifier </span> Provider at Organisation Identifier
    * at most one <span style='color:green'> identifier </span> Care Agency Employee Identifier
    * zero or more <span style='color:green'> identifier </span> Employee Number
-1. at most one <span style='color:green'> practitioner </span> Practitioner in this role (Reference as: au-practitioner)
-1. at most one <span style='color:green'> organization </span> Organisation managing this role (Reference as: au-organisation)
 1. zero or more <span style='color:green'> specialty </span> Practitioner specialties sliced
    * zero or more <span style='color:green'> specialty </span> SNOMED Practitioner Specialty

--- a/resources/au-practitionerrole.xml
+++ b/resources/au-practitionerrole.xml
@@ -300,22 +300,6 @@
       <short value="Employing organisation name" />
       <min value="1" />
     </element>
-    <element id="PractitionerRole.practitioner">
-      <path value="PractitionerRole.practitioner" />
-      <short value="Practitioner in this role" />
-      <type>
-        <code value="Reference" />
-        <targetProfile value="http://hl7.org.au/fhir/StructureDefinition/au-practitioner" />
-      </type>
-    </element>
-    <element id="PractitionerRole.organization">
-      <path value="PractitionerRole.organization" />
-      <short value="Organisation managing this role" />
-      <type>
-        <code value="Reference" />
-        <targetProfile value="http://hl7.org.au/fhir/StructureDefinition/au-organisation" />
-      </type>
-    </element>
     <element id="PractitionerRole.specialty">
       <path value="PractitionerRole.specialty" />
       <slicing>
@@ -342,20 +326,6 @@
           <reference value="http://hl7.org.au/fhir/ValueSet/snomed-practitioner-role" />
         </valueSetReference>
       </binding>
-    </element>
-    <element id="PractitionerRole.location">
-      <path value="PractitionerRole.location" />
-      <type>
-        <code value="Reference" />
-        <targetProfile value="http://hl7.org.au/fhir/StructureDefinition/au-location" />
-      </type>
-    </element>
-    <element id="PractitionerRole.healthcareService">
-      <path value="PractitionerRole.healthcareService" />
-      <type>
-        <code value="Reference" />
-        <targetProfile value="http://hl7.org.au/fhir/StructureDefinition/au-healthcareservice" />
-      </type>
     </element>
   </differential>
 </StructureDefinition>


### PR DESCRIPTION
The constraint of typing the following elements in the PractitionerRole profile to AU Base profiles has been removed:
- PractitionerRole.practitioner
- PractitionerRole.organization
- PractitionerRole.location
- PractitionerRole.healthcareService

The result of which is that they all reference the STU3 counterparts instead. This was the agreement at the HL7 AU working group meetings held 13/9/2018.

No new errors/warnings on QA report.