### PR TITLE
au-practitioner - reverted type references

### DIFF
--- a/resources/au-practitioner.xml
+++ b/resources/au-practitioner.xml
@@ -211,13 +211,6 @@
         <rules value="open" />
       </slicing>
     </element>
-    <element id="Practitioner.qualification.issuer">
-      <path value="Practitioner.qualification.issuer" />
-      <type>
-        <code value="Reference" />
-        <targetProfile value="http://hl7.org.au/fhir/StructureDefinition/au-organisation" />
-      </type>
-    </element>
     <element id="Practitioner.qualification:ahpraRegistration">
       <path value="Practitioner.qualification" />
       <sliceName value="ahpraRegistration" />
@@ -317,10 +310,6 @@
     <element id="Practitioner.qualification:ahpraRegistration.issuer">
       <path value="Practitioner.qualification.issuer" />
       <min value="1" />
-      <type>
-        <code value="Reference" />
-        <targetProfile value="http://hl7.org.au/fhir/StructureDefinition/au-organisation" />
-      </type>
     </element>
     <element id="Practitioner.qualification:ahpraRegistration.issuer.display">
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable">


### PR DESCRIPTION
The constraint of typing the following elements in the Practitioner profile to AU Base profiles has been removed:
- Practitioner.qualification.issuer
- Practitioner.qualification:ahpraRegistration.issuer

The result of which is that they all reference the STU3 counterparts instead. This was the agreement at the HL7 AU working group meetings held 13/9/2018.

No new errors/warnings on QA report.