### PR TITLE
au-patient - reverted type references

### DIFF
--- a/pages/_includes/au-patient-summary.md
+++ b/pages/_includes/au-patient-summary.md
@@ -24,5 +24,3 @@ This profile contains the following variations from [Patient](http://hl7.org/fhi
    * <span style='color:green'> deceased[x] </span> Deceased Date Time
       * Deceased Date Accuracy Indicator extension
 1. zero or more <span style='color:green'> communication </span> 
-1. zero or more <span style='color:green'> generalPractitioner </span> Usual GP practice or practitioner (Reference as: au-practitioner \| au-organisation)
-1. at most one <span style='color:green'> managingOrganization </span> Patient managing organisation (Reference as: au-organisation)

--- a/resources/au-patient.xml
+++ b/resources/au-patient.xml
@@ -825,13 +825,6 @@
         <profile value="http://hl7.org.au/fhir/StructureDefinition/date-accuracy-indicator" />
       </type>
     </element>
-    <element id="Patient.contact.organization">
-      <path value="Patient.contact.organization" />
-      <type>
-        <code value="Reference" />
-        <targetProfile value="http://hl7.org.au/fhir/StructureDefinition/au-organisation" />
-      </type>
-    </element>
     <element id="Patient.communication">
       <path value="Patient.communication" />
     </element>
@@ -843,37 +836,6 @@
           <reference value="https://healthterminologies.gov.au/fhir/ValueSet/common-languages-australia-1" />
         </valueSetReference>
       </binding>
-    </element>
-    <element id="Patient.generalPractitioner">
-      <path value="Patient.generalPractitioner" />
-      <short value="Usual GP practice or practitioner" />
-      <type>
-        <code value="Reference" />
-        <targetProfile value="http://hl7.org.au/fhir/StructureDefinition/au-practitioner" />
-      </type>
-      <type>
-        <code value="Reference" />
-        <targetProfile value="http://hl7.org.au/fhir/StructureDefinition/au-organisation" />
-      </type>
-    </element>
-    <element id="Patient.managingOrganization">
-      <path value="Patient.managingOrganization" />
-      <short value="Patient managing organisation" />
-      <type>
-        <code value="Reference" />
-        <targetProfile value="http://hl7.org.au/fhir/StructureDefinition/au-organisation" />
-      </type>
-    </element>
-    <element id="Patient.link.other">
-      <path value="Patient.link.other" />
-      <type>
-        <code value="Reference" />
-        <targetProfile value="http://hl7.org.au/fhir/StructureDefinition/au-patient" />
-      </type>
-      <type>
-        <code value="Reference" />
-        <targetProfile value="http://hl7.org.au/fhir/StructureDefinition/au-relatedperson" />
-      </type>
     </element>
   </differential>
 </StructureDefinition>


### PR DESCRIPTION
The constraint of typing the following elements in the Patient profile to AU Base profiles has been removed:
- Patient.contact.organization
- Patient.generalPractitioner (as Practitioner and Organization)
- Patient.managingOrganization
- Patient.link.other (as Patient and RelatedPerson)

The result of which is that they all reference the STU3 counterparts instead. This was the agreement at the HL7 AU working group meetings held 13/9/2018.

No new errors/warnings on QA report.