### PR TITLE
au-organisation - reverted type references

### DIFF
--- a/resources/au-organisation.xml
+++ b/resources/au-organisation.xml
@@ -389,12 +389,5 @@
       <path value="Organization.identifier.value" />
       <min value="1" />
     </element>
-    <element id="Organization.partOf">
-      <path value="Organization.partOf" />
-      <type>
-        <code value="Reference" />
-        <targetProfile value="http://hl7.org.au/fhir/StructureDefinition/au-organisation" />
-      </type>
-    </element>
   </differential>
 </StructureDefinition>


### PR DESCRIPTION
The constraint of typing the following element in the Organization profile to a AU Base profile has been removed:
- Organization.partOf

The result of which is that it references its STU3 counterpart instead. This was the agreement at the HL7 AU working group meetings held 13/9/2018.

No new errors/warnings on QA report.