### PR TITLE
au-device - reverted type references

### DIFF
--- a/pages/_includes/au-device-summary.md
+++ b/pages/_includes/au-device-summary.md
@@ -2,5 +2,3 @@ This profile contains the following variations from [Device](http://hl7.org/fhir
 
 1. zero or more <span style='color:green'> identifier </span>  sliced
    * at most one <span style='color:green'> identifier </span> PAI-D
-1. at most one <span style='color:green'> patient </span> Associated patient (Reference as: au-patient)
-1. at most one <span style='color:green'> owner </span> Device owning organisation (Reference as: au-organisation)

--- a/resources/au-device.xml
+++ b/resources/au-device.xml
@@ -134,28 +134,5 @@
          />
       </constraint>
     </element>
-    <element id="Device.patient">
-      <path value="Device.patient" />
-	  <short value="Associated patient" />
-      <type>
-        <code value="Reference" />
-        <targetProfile value="http://hl7.org.au/fhir/StructureDefinition/au-patient" />
-      </type>
-    </element>
-    <element id="Device.owner">
-      <path value="Device.owner" />
-	   <short value="Device owning organisation" />
-      <type>
-        <code value="Reference" />
-        <targetProfile value="http://hl7.org.au/fhir/StructureDefinition/au-organisation" />
-      </type>
-    </element>
-    <element id="Device.location">
-      <path value="Device.location" />
-      <type>
-        <code value="Reference" />
-        <targetProfile value="http://hl7.org.au/fhir/StructureDefinition/au-location" />
-      </type>
-    </element>
   </differential>
 </StructureDefinition>


### PR DESCRIPTION
The constraint of typing the following elements in the Device profile to AU Base profiles has been removed:
- Device.patient
- Device.owner
- Device.location

The result of which is that they all reference the STU3 counterparts instead. This was the agreement at the HL7 AU working group meetings held 13/9/2018.

No new errors/warnings on QA report.