### PR TITLE
au-relatedperson - reverted type references

### DIFF
--- a/pages/_includes/au-relatedperson-summary.md
+++ b/pages/_includes/au-relatedperson-summary.md
@@ -11,5 +11,4 @@ This profile contains the following variations from [RelatedPerson](http://hl7.o
    * at most one <span style='color:green'> identifier </span> Commonwealth Seniors Health Card Identifier
    * zero or more <span style='color:green'> identifier </span> Medical Record Number
    * zero or more <span style='color:green'> identifier </span> Private Health Insurance Member Number
-1. exactly one <span style='color:green'> patient </span> Patient record this person relates to (Reference as: au-patient)
 1. at most one <span style='color:green'> relationship </span> 

--- a/resources/au-relatedperson.xml
+++ b/resources/au-relatedperson.xml
@@ -667,14 +667,6 @@
       <path value="RelatedPerson.identifier.assigner.display" />
       <min value="1" />
     </element>
-    <element id="RelatedPerson.patient">
-      <path value="RelatedPerson.patient" />
-      <short value="Patient record this person relates to" />
-      <type>
-        <code value="Reference" />
-        <targetProfile value="http://hl7.org.au/fhir/StructureDefinition/au-patient" />
-      </type>
-    </element>
     <element id="RelatedPerson.relationship">
       <path value="RelatedPerson.relationship" />
       <binding>


### PR DESCRIPTION
The constraint of typing the following element in the RelatedPerson profile to a AU Base profile has been removed:
- RelatedPerson.patient

The result of which is that it references its STU3 counterpart instead. This was the agreement at the HL7 AU working group meetings held 13/9/2018.

No new errors/warnings on QA report.