### PR TITLE
au-location - reverted type references

### DIFF
--- a/resources/au-location.xml
+++ b/resources/au-location.xml
@@ -79,19 +79,5 @@
       <path value="Location.identifier.value" />
       <min value="1" />
     </element>
-    <element id="Location.managingOrganization">
-      <path value="Location.managingOrganization" />
-      <type>
-        <code value="Reference" />
-        <targetProfile value="http://hl7.org.au/fhir/StructureDefinition/au-organisation" />
-      </type>
-    </element>
-    <element id="Location.partOf">
-      <path value="Location.partOf" />
-      <type>
-        <code value="Reference" />
-        <targetProfile value="http://hl7.org.au/fhir/StructureDefinition/au-location" />
-      </type>
-    </element>
   </differential>
 </StructureDefinition>


### PR DESCRIPTION
The constraint of typing the following elements in the Location profile to AU Base profiles has been removed:
- Location.managingOrganization
- Location.partOf

The result of which is that they all reference the STU3 counterparts instead. This was the agreement at the HL7 AU working group meetings held 13/9/2018.

No new errors/warnings on QA report.