### PR TITLE
au-allergyintolerance - reverted type references

### DIFF
--- a/pages/_includes/au-allergyintolerance-summary.md
+++ b/pages/_includes/au-allergyintolerance-summary.md
@@ -2,9 +2,6 @@ This profile contains the following variations from [AllergyIntolerance](http://
 
 1. at most one <span style='color:green'> code </span> 
    * at most one <span style='color:green'> coding </span> Allergy or intolerance to substance (SNOMED CT)
-1. exactly one <span style='color:green'> patient </span> Patient with allergy/intolerance (Reference as: au-patient)
-1. at most one <span style='color:green'> recorder </span> Condition recorded by (Reference as: au-patient \| au-practitioner \| au-relatedperson)
-1. at most one <span style='color:green'> asserter </span> Condition asserted by (Reference as: au-patient \| au-practitioner \| au-relatedperson)
 1. zero or more <span style='color:green'> reaction </span> 
    * at most one <span style='color:green'> coding </span> Substance or Agent (SNOMED CT)
    * zero or more <span style='color:green'> coding </span> Clinical Finding (SNOMED CT)

--- a/resources/au-allergyintolerance.xml
+++ b/resources/au-allergyintolerance.xml
@@ -54,46 +54,6 @@
         <valueSetUri value="https://healthterminologies.gov.au/fhir/ValueSet/indicator-hypersensitivity-intolerance-to-substance-1"/>
       </binding>
     </element>
-    <element id="AllergyIntolerance.patient">
-      <path value="AllergyIntolerance.patient"/>
-	  <short value="Patient with allergy/intolerance"/>
-      <type>
-        <code value="Reference"/>
-        <targetProfile value="http://hl7.org.au/fhir/StructureDefinition/au-patient"/>
-      </type>
-    </element>
-    <element id="AllergyIntolerance.recorder">
-      <path value="AllergyIntolerance.recorder"/>
-	  <short value="Condition recorded by"/>
-      <type>
-        <code value="Reference"/>
-        <targetProfile value="http://hl7.org.au/fhir/StructureDefinition/au-patient"/>
-      </type>
-      <type>
-        <code value="Reference"/>
-        <targetProfile value="http://hl7.org.au/fhir/StructureDefinition/au-practitioner"/>
-      </type>
-      <type>
-        <code value="Reference"/>
-        <targetProfile value="http://hl7.org.au/fhir/StructureDefinition/au-relatedperson"/>
-      </type>
-    </element>
-    <element id="AllergyIntolerance.asserter">
-      <path value="AllergyIntolerance.asserter"/>
-	  <short value="Condition asserted by"/>
-      <type>
-        <code value="Reference"/>
-        <targetProfile value="http://hl7.org.au/fhir/StructureDefinition/au-patient"/>
-      </type>
-      <type>
-        <code value="Reference"/>
-        <targetProfile value="http://hl7.org.au/fhir/StructureDefinition/au-practitioner"/>
-      </type>
-      <type>
-        <code value="Reference"/>
-        <targetProfile value="http://hl7.org.au/fhir/StructureDefinition/au-relatedperson"/>
-      </type>
-    </element>
     <element id="AllergyIntolerance.reaction">
       <path value="AllergyIntolerance.reaction"/>
     </element>


### PR DESCRIPTION
The constraint of typing the following elements in the AllergyIntolerance profile to AU Base profiles has been removed:

- AllergyIntolerance.patient
- AllergyIntolerance.recorder (as patient, practitioner or relatedperson)
- AllergyIntolerance.asserter (as patient, practitioner or relatedperson)

The result of which is that they all reference the STU3 counterparts instead. This was the agreement at the HL7 AU working group meetings held 13/9/2018.

No new errors/warnings on QA report.