### PR TITLE
au-condition - reverted type references

### DIFF
--- a/pages/_includes/au-condition-summary.md
+++ b/pages/_includes/au-condition-summary.md
@@ -2,8 +2,6 @@ This profile contains the following variations from [Condition](http://hl7.org/f
 
 1. at most one <span style='color:green'> code </span> 
    * at most one <span style='color:green'> coding </span> Clinical Condition (SNOMED CT)
-1. zero or more <span style='color:green'> bodySite </span> 
-1. exactly one <span style='color:green'> subject </span> Subject of this condition (Reference as: Group \| au-patient)
-1. at most one <span style='color:green'> asserter </span> Condition asserted by (Reference as: au-patient \| au-relatedperson \| au-practitioner)
+1. zero or more <span style='color:green'> bodySite </span>
 1. zero or more <span style='color:green'> evidence </span> 
    * at most one <span style='color:green'> coding </span> Clinical Finding (SNOMED CT)

--- a/resources/au-condition.xml
+++ b/resources/au-condition.xml
@@ -62,34 +62,6 @@
         <valueSetUri value="https://healthterminologies.gov.au/fhir/ValueSet/body-site-1" />
       </binding>
     </element>
-    <element id="Condition.subject">
-      <path value="Condition.subject" />
-	  <short value="Subject of this condition" />
-      <type>
-        <code value="Reference" />
-        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Group" />
-      </type>
-      <type>
-        <code value="Reference" />
-        <targetProfile value="http://hl7.org.au/fhir/StructureDefinition/au-patient" />
-      </type>
-    </element>
-    <element id="Condition.asserter">
-      <path value="Condition.asserter" />
-	   <short value="Condition asserted by" />
-      <type>
-        <code value="Reference" />
-        <targetProfile value="http://hl7.org.au/fhir/StructureDefinition/au-patient" />
-      </type>
-      <type>
-        <code value="Reference" />
-        <targetProfile value="http://hl7.org.au/fhir/StructureDefinition/au-relatedperson" />
-      </type>
-      <type>
-        <code value="Reference" />
-        <targetProfile value="http://hl7.org.au/fhir/StructureDefinition/au-practitioner" />
-      </type>
-    </element>
     <element id="Condition.evidence">
       <path value="Condition.evidence" />
     </element>


### PR DESCRIPTION
The constraint of typing the following elements in the Condition profile to AU Base profiles has been removed:
- Condition.subject (as patient)
- Condition.asserter (as patient, practitioner or relatedperson)

The result of which is that they all reference the STU3 counterparts instead. This was the agreement at the HL7 AU working group meetings held 13/9/2018.

No new errors/warnings on QA report.