### PR TITLE
au-bodysite - reverted type references

### DIFF
--- a/pages/_includes/au-bodysite-summary.md
+++ b/pages/_includes/au-bodysite-summary.md
@@ -1,5 +1,4 @@
 This profile contains the following variations from [BodySite](http://hl7.org/fhir/STU3/BodySite):
 
 1. at most one <span style='color:green'> code </span> 
-1. zero or more <span style='color:green'> qualifier </span> 
-1. exactly one <span style='color:green'> patient </span>  (Reference as: au-patient)
+1. zero or more <span style='color:green'> qualifier </span>

--- a/resources/au-bodysite.xml
+++ b/resources/au-bodysite.xml
@@ -55,12 +55,5 @@
         <valueSetUri value="http://hl7.org/fhir/ValueSet/bodysite-relative-location"/>
       </binding>
     </element>
-    <element id="BodySite.patient">
-      <path value="BodySite.patient"/>
-      <type>
-        <code value="Reference"/>
-        <targetProfile value="http://hl7.org.au/fhir/StructureDefinition/au-patient"/>
-      </type>
-    </element>
   </differential>
 </StructureDefinition>


### PR DESCRIPTION
The constraint of typing the following elements in the Bodysite profile to AU Base profiles has been removed:
- BodySite.patient

The result of which is that they all reference the STU3 counterparts instead. This was the agreement at the HL7 AU working group meetings held 13/9/2018.

No new errors/warnings on QA report.