### PR TITLE
Meds - remove au references

### DIFF
--- a/resources/au-dispenserecord.xml
+++ b/resources/au-dispenserecord.xml
@@ -1,578 +1,566 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
-  <id value="au-dispenserecord" />
+  <id value="au-dispenserecord"/>
   <meta>
-    <lastUpdated value="2018-03-03T06:38:51.483+11:00" />
+    <lastUpdated value="2018-03-03T06:38:51.483+11:00"/>
   </meta>
-  <url value="http://hl7.org.au/fhir/StructureDefinition/au-dispenserecord" />
-  <version value="0.1" />
-  <name value="AUBaseDispenseRecord" />
-  <title value="AU Base Dispense Record" />
-  <status value="draft" />
-  <date value="2017-05-11T09:51:36.6519188+10:00" />
-  <publisher value="Health Level Seven Australia (Medications WG)" />
+  <url value="http://hl7.org.au/fhir/StructureDefinition/au-dispenserecord"/>
+  <version value="0.1"/>
+  <name value="AUBaseDispenseRecord"/>
+  <title value="AU Base Dispense Record"/>
+  <status value="draft"/>
+  <date value="2017-05-11T09:51:36.6519188+10:00"/>
+  <publisher value="Health Level Seven Australia (Medications WG)"/>
   <contact>
     <telecom>
-      <system value="url" />
-      <value value="http://hl7.org.au/fhir" />
-      <use value="work" />
+      <system value="url"/>
+      <value value="http://hl7.org.au/fhir"/>
+      <use value="work"/>
     </telecom>
   </contact>
-  <description value="Australian realm dispense record profile." />
-  <fhirVersion value="3.0.1" />
-  <kind value="resource" />
-  <abstract value="false" />
-  <type value="MedicationDispense" />
-  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/MedicationDispense" />
-  <derivation value="constraint" />
+  <description value="Australian realm dispense record profile."/>
+  <fhirVersion value="3.0.1"/>
+  <kind value="resource"/>
+  <abstract value="false"/>
+  <type value="MedicationDispense"/>
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/MedicationDispense"/>
+  <derivation value="constraint"/>
   <differential>
     <element id="MedicationDispense">
-      <path value="MedicationDispense" />
-      <short value="Australian dispense record" />
-      <definition value="Dispensing of a medication to patient in an Australian healthcare contex" />
+      <path value="MedicationDispense"/>
+      <short value="Australian dispense record"/>
+      <definition value="Dispensing of a medication to patient in an Australian healthcare contex"/>
     </element>
     <element id="MedicationDispense.extension">
-      <path value="MedicationDispense.extension" />
+      <path value="MedicationDispense.extension"/>
       <slicing>
         <discriminator>
-          <type value="value" />
-          <path value="url" />
+          <type value="value"/>
+          <path value="url"/>
         </discriminator>
-        <rules value="open" />
+        <rules value="open"/>
       </slicing>
     </element>
     <element id="MedicationDispense.extension:groundsForConcurrentSupply">
-      <path value="MedicationDispense.extension" />
-      <sliceName value="groundsForConcurrentSupply" />
-      <short value="Grounds for concurrent supply of medication" />
-      <max value="1" />
+      <path value="MedicationDispense.extension"/>
+      <sliceName value="groundsForConcurrentSupply"/>
+      <short value="Grounds for concurrent supply of medication"/>
+      <max value="1"/>
       <type>
-        <code value="Extension" />
-        <profile value="http://hl7.org.au/fhir/StructureDefinition/grounds-for-concurrent-supply" />
+        <code value="Extension"/>
+        <profile value="http://hl7.org.au/fhir/StructureDefinition/grounds-for-concurrent-supply"/>
       </type>
     </element>
     <element id="MedicationDispense.extension:dispenseNumber">
-      <path value="MedicationDispense.extension" />
-      <sliceName value="dispenseNumber" />
-      <short value="Number of this dispense" />
+      <path value="MedicationDispense.extension"/>
+      <sliceName value="dispenseNumber"/>
+      <short value="Number of this dispense"/>
       <type>
-        <code value="Extension" />
-        <profile value="http://hl7.org.au/fhir/StructureDefinition/dispense-number" />
+        <code value="Extension"/>
+        <profile value="http://hl7.org.au/fhir/StructureDefinition/dispense-number"/>
       </type>
     </element>
     <element id="MedicationDispense.extension:brandName">
-      <path value="MedicationDispense.extension" />
-      <sliceName value="brandName" />
-      <short value="Medication Brand Name" />
-      <definition value="Optional Extension Element - found in all resources." />
-      <min value="0" />
-      <max value="1" />
+      <path value="MedicationDispense.extension"/>
+      <sliceName value="brandName"/>
+      <short value="Medication Brand Name"/>
+      <definition value="Optional Extension Element - found in all resources."/>
+      <min value="0"/>
+      <max value="1"/>
       <type>
-        <code value="Extension" />
-        <profile value="http://hl7.org.au/fhir/StructureDefinition/medication-brand-name" />
+        <code value="Extension"/>
+        <profile value="http://hl7.org.au/fhir/StructureDefinition/medication-brand-name"/>
       </type>
     </element>
     <element id="MedicationDispense.extension:genericName">
-      <path value="MedicationDispense.extension" />
-      <sliceName value="genericName" />
-      <short value="Medication Generic Drug Name" />
-      <definition value="Optional Extension Element - found in all resources." />
-      <min value="0" />
-      <max value="1" />
+      <path value="MedicationDispense.extension"/>
+      <sliceName value="genericName"/>
+      <short value="Medication Generic Drug Name"/>
+      <definition value="Optional Extension Element - found in all resources."/>
+      <min value="0"/>
+      <max value="1"/>
       <type>
-        <code value="Extension" />
-        <profile value="http://hl7.org.au/fhir/StructureDefinition/medication-generic-name" />
+        <code value="Extension"/>
+        <profile value="http://hl7.org.au/fhir/StructureDefinition/medication-generic-name"/>
       </type>
     </element>
     <element id="MedicationDispense.identifier">
-      <path value="MedicationDispense.identifier" />
+      <path value="MedicationDispense.identifier"/>
       <slicing>
         <discriminator>
-          <type value="value" />
-          <path value="system" />
+          <type value="value"/>
+          <path value="system"/>
         </discriminator>
         <discriminator>
-          <type value="value" />
-          <path value="type" />
+          <type value="value"/>
+          <path value="type"/>
         </discriminator>
-        <rules value="open" />
+        <rules value="open"/>
       </slicing>
     </element>
     <element id="MedicationDispense.identifier:localDispenseIdentifier">
-      <path value="MedicationDispense.identifier" />
-      <sliceName value="localDispenseIdentifier" />
-      <short value="Local Dispense Identifier" />
+      <path value="MedicationDispense.identifier"/>
+      <sliceName value="localDispenseIdentifier"/>
+      <short value="Local Dispense Identifier"/>
     </element>
     <element id="MedicationDispense.identifier:localDispenseIdentifier.type">
-      <path value="MedicationDispense.identifier.type" />
-      <min value="1" />
+      <path value="MedicationDispense.identifier.type"/>
+      <min value="1"/>
       <binding>
         <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
-          <valueString value="IdentifierType" />
+          <valueString value="IdentifierType"/>
         </extension>
         <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding">
-          <valueBoolean value="true" />
+          <valueBoolean value="true"/>
         </extension>
-        <strength value="required" />
-        <description value="Local identifier type" />
+        <strength value="required"/>
+        <description value="Local identifier type"/>
         <valueSetReference>
-          <reference value="http://hl7.org.au/fhir/ValueSet/au-hl7v2-0203" />
+          <reference value="http://hl7.org.au/fhir/ValueSet/au-hl7v2-0203"/>
         </valueSetReference>
       </binding>
     </element>
     <element id="MedicationDispense.identifier:localDispenseIdentifier.type.coding">
-      <path value="MedicationDispense.identifier.type.coding" />
-      <min value="1" />
-      <max value="1" />
+      <path value="MedicationDispense.identifier.type.coding"/>
+      <min value="1"/>
+      <max value="1"/>
     </element>
     <element id="MedicationDispense.identifier:localDispenseIdentifier.type.coding.system">
-      <path value="MedicationDispense.identifier.type.coding.system" />
-      <min value="1" />
-      <fixedUri value="http://hl7.org.au/fhir/v2/0203" />
+      <path value="MedicationDispense.identifier.type.coding.system"/>
+      <min value="1"/>
+      <fixedUri value="http://hl7.org.au/fhir/v2/0203"/>
     </element>
     <element id="MedicationDispense.identifier:localDispenseIdentifier.type.coding.code">
-      <path value="MedicationDispense.identifier.type.coding.code" />
-      <min value="1" />
-      <fixedCode value="LDI" />
+      <path value="MedicationDispense.identifier.type.coding.code"/>
+      <min value="1"/>
+      <fixedCode value="LDI"/>
     </element>
     <element id="MedicationDispense.identifier:localDispenseIdentifier.type.text">
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable">
-        <valueBoolean value="true" />
+        <valueBoolean value="true"/>
       </extension>
-      <path value="MedicationDispense.identifier.type.text" />
-      <min value="1" />
-      <fixedString value="Local Dispense Identifier" />
+      <path value="MedicationDispense.identifier.type.text"/>
+      <min value="1"/>
+      <fixedString value="Local Dispense Identifier"/>
     </element>
     <element id="MedicationDispense.identifier:localDispenseIdentifier.system">
-      <path value="MedicationDispense.identifier.system" />
-      <min value="1" />
+      <path value="MedicationDispense.identifier.system"/>
+      <min value="1"/>
     </element>
     <element id="MedicationDispense.identifier:localDispenseIdentifier.value">
-      <path value="MedicationDispense.identifier.value" />
-      <min value="1" />
+      <path value="MedicationDispense.identifier.value"/>
+      <min value="1"/>
     </element>
     <element id="MedicationDispense.identifier:localDispenseIdentifier.assigner">
-      <path value="MedicationDispense.identifier.assigner" />
-      <min value="1" />
+      <path value="MedicationDispense.identifier.assigner"/>
+      <min value="1"/>
     </element>
     <element id="MedicationDispense.identifier:localDispenseIdentifier.assigner.display">
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable">
-        <valueBoolean value="true" />
+        <valueBoolean value="true"/>
       </extension>
-      <path value="MedicationDispense.identifier.assigner.display" />
-      <min value="1" />
+      <path value="MedicationDispense.identifier.assigner.display"/>
+      <min value="1"/>
     </element>
     <element id="MedicationDispense.medication[x]">
-      <path value="MedicationDispense.medication[x]" />
+      <path value="MedicationDispense.medication[x]"/>
       <slicing>
         <discriminator>
-          <type value="type" />
-          <path value="$this" />
+          <type value="type"/>
+          <path value="$this"/>
         </discriminator>
-        <rules value="open" />
+        <rules value="open"/>
       </slicing>
       <min value="1"/>
       <max value="1"/>
       <type>
-        <code value="CodeableConcept" />
+        <code value="CodeableConcept"/>
       </type>
       <type>
-        <code value="Reference" />
-        <targetProfile value="http://hl7.org.au/fhir/StructureDefinition/au-medication" />
+        <code value="Reference"/>
+        <targetProfile value="http://hl7.org.au/fhir/StructureDefinition/au-medication"/>
       </type>
     </element>
     <element id="MedicationDispense.medication[x]:medicationCoded">
-      <path value="MedicationDispense.medication[x]" />
-      <sliceName value="medicationCoded" />
-      <short value="Coded medication" />
+      <path value="MedicationDispense.medication[x]"/>
+      <sliceName value="medicationCoded"/>
+      <short value="Coded medication"/>
       <type>
-        <code value="CodeableConcept" />
+        <code value="CodeableConcept"/>
       </type>
     </element>
     <element id="MedicationDispense.medication[x]:medicationCoded.coding">
-      <path value="MedicationDispense.medication[x].coding" />
+      <path value="MedicationDispense.medication[x].coding"/>
       <slicing>
         <discriminator>
-          <type value="value" />
-          <path value="system" />
+          <type value="value"/>
+          <path value="system"/>
         </discriminator>
         <discriminator>
-          <type value="value" />
-          <path value="code" />
+          <type value="value"/>
+          <path value="code"/>
         </discriminator>
-        <rules value="open" />
+        <rules value="open"/>
       </slicing>
     </element>
     <element id="MedicationDispense.medication[x]:medicationCoded.coding:pbs">
-      <path value="MedicationDispense.medication[x].coding" />
-      <sliceName value="pbs" />
-      <short value="Medication PBS coding (ignore item context)" />
-      <definition value="PBS code from http://pbs.gov.au/code/item. Use of PBS as a code to refer to a type of medication, this excludes implication of context based on the PBS code. Where context is to be implied or stated PBS code needs to be associated with recording a prescription (MedicationRequest) or dispense record(MedicationDispense)" />
+      <path value="MedicationDispense.medication[x].coding"/>
+      <sliceName value="pbs"/>
+      <short value="Medication PBS coding (ignore item context)"/>
+      <definition
+        value="PBS code from http://pbs.gov.au/code/item. Use of PBS as a code to refer to a type of medication, this excludes implication of context based on the PBS code. Where context is to be implied or stated PBS code needs to be associated with recording a prescription (MedicationRequest) or dispense record(MedicationDispense)"/>
       <binding>
-        <strength value="required" />
+        <strength value="required"/>
         <valueSetReference>
-          <reference value="http://hl7.org.au/fhir/ValueSet/pbs-item" />
+          <reference value="http://hl7.org.au/fhir/ValueSet/pbs-item"/>
         </valueSetReference>
       </binding>
     </element>
     <element id="MedicationDispense.medication[x]:medicationCoded.coding:gtin">
-      <path value="MedicationDispense.medication[x].coding" />
-      <sliceName value="gtin" />
-      <short value="Medication Package GTIN" />
-      <definition value="GTIN value from http://www.gs1.org/gtin." />
+      <path value="MedicationDispense.medication[x].coding"/>
+      <sliceName value="gtin"/>
+      <short value="Medication Package GTIN"/>
+      <definition value="GTIN value from http://www.gs1.org/gtin."/>
       <binding>
-        <strength value="required" />
+        <strength value="required"/>
         <valueSetReference>
-          <reference value="http://hl7.org.au/fhir/ValueSet/gtin" />
+          <reference value="http://hl7.org.au/fhir/ValueSet/gtin"/>
         </valueSetReference>
       </binding>
     </element>
     <element id="MedicationDispense.medication[x]:medicationCoded.coding:amtTPP">
-      <path value="MedicationDispense.medication[x].coding" />
-      <sliceName value="amtTPP" />
-      <short value="AMT Trade Product Pack" />
-      <max value="1" />
+      <path value="MedicationDispense.medication[x].coding"/>
+      <sliceName value="amtTPP"/>
+      <short value="AMT Trade Product Pack"/>
+      <max value="1"/>
       <binding>
-        <strength value="required" />
+        <strength value="required"/>
         <valueSetReference>
-          <reference value="http://hl7.org.au/fhir/ValueSet/amt-tpp-codes" />
+          <reference value="http://hl7.org.au/fhir/ValueSet/amt-tpp-codes"/>
         </valueSetReference>
       </binding>
     </element>
     <element id="MedicationDispense.medication[x]:medicationCoded.coding:amtTPP.extension">
-      <path value="MedicationDispense.medication[x].coding.extension" />
+      <path value="MedicationDispense.medication[x].coding.extension"/>
       <slicing>
         <discriminator>
-          <type value="value" />
-          <path value="url" />
+          <type value="value"/>
+          <path value="url"/>
         </discriminator>
-        <rules value="open" />
+        <rules value="open"/>
       </slicing>
     </element>
-    <element id="MedicationDispense.medication[x]:medicationCoded.coding:amtTPP.extension:medicationType">
-      <path value="MedicationDispense.medication[x].coding.extension" />
-      <sliceName value="medicationType" />
-      <short value="Type of medication coding" />
-      <definition value="General category of coding to allow usage of codes to be distinguished from the same CodeSystem" />
-      <max value="1" />
+    <element
+      id="MedicationDispense.medication[x]:medicationCoded.coding:amtTPP.extension:medicationType">
+      <path value="MedicationDispense.medication[x].coding.extension"/>
+      <sliceName value="medicationType"/>
+      <short value="Type of medication coding"/>
+      <definition
+        value="General category of coding to allow usage of codes to be distinguished from the same CodeSystem"/>
+      <max value="1"/>
       <type>
-        <code value="Extension" />
-        <profile value="http://hl7.org.au/fhir/StructureDefinition/medication-type" />
+        <code value="Extension"/>
+        <profile value="http://hl7.org.au/fhir/StructureDefinition/medication-type"/>
       </type>
     </element>
-    <element id="MedicationDispense.medication[x]:medicationCoded.coding:amtTPP.extension:medicationType.valueCoding:valueCoding">
-      <path value="MedicationDispense.medication[x].coding.extension.valueCoding" />
-      <sliceName value="valueCoding" />
+    <element
+      id="MedicationDispense.medication[x]:medicationCoded.coding:amtTPP.extension:medicationType.valueCoding:valueCoding">
+      <path value="MedicationDispense.medication[x].coding.extension.valueCoding"/>
+      <sliceName value="valueCoding"/>
       <fixedCoding>
-        <system value="http://hl7.org.au/fhir/CodeSystem/medication-type" />
-        <code value="BPG" />
-        <display value="Branded package with no container" />
+        <system value="http://hl7.org.au/fhir/CodeSystem/medication-type"/>
+        <code value="BPG"/>
+        <display value="Branded package with no container"/>
       </fixedCoding>
     </element>
     <element id="MedicationDispense.medication[x]:medicationCoded.coding:amtMPP">
-      <path value="MedicationDispense.medication[x].coding" />
-      <sliceName value="amtMPP" />
-      <short value="AMT Medicinal Product Pack" />
-      <max value="1" />
+      <path value="MedicationDispense.medication[x].coding"/>
+      <sliceName value="amtMPP"/>
+      <short value="AMT Medicinal Product Pack"/>
+      <max value="1"/>
       <binding>
-        <strength value="required" />
+        <strength value="required"/>
         <valueSetReference>
-          <reference value="http://hl7.org.au/fhir/ValueSet/amt-mpp-codes" />
+          <reference value="http://hl7.org.au/fhir/ValueSet/amt-mpp-codes"/>
         </valueSetReference>
       </binding>
     </element>
     <element id="MedicationDispense.medication[x]:medicationCoded.coding:amtMPP.extension">
-      <path value="MedicationDispense.medication[x].coding.extension" />
+      <path value="MedicationDispense.medication[x].coding.extension"/>
       <slicing>
         <discriminator>
-          <type value="value" />
-          <path value="url" />
+          <type value="value"/>
+          <path value="url"/>
         </discriminator>
-        <rules value="open" />
+        <rules value="open"/>
       </slicing>
     </element>
-    <element id="MedicationDispense.medication[x]:medicationCoded.coding:amtMPP.extension:medicationType">
-      <path value="MedicationDispense.medication[x].coding.extension" />
-      <sliceName value="medicationType" />
-      <short value="Type of medication coding" />
-      <definition value="General category of coding to allow usage of codes to be distinguished from the same CodeSystem" />
-      <max value="1" />
+    <element
+      id="MedicationDispense.medication[x]:medicationCoded.coding:amtMPP.extension:medicationType">
+      <path value="MedicationDispense.medication[x].coding.extension"/>
+      <sliceName value="medicationType"/>
+      <short value="Type of medication coding"/>
+      <definition
+        value="General category of coding to allow usage of codes to be distinguished from the same CodeSystem"/>
+      <max value="1"/>
       <type>
-        <code value="Extension" />
-        <profile value="http://hl7.org.au/fhir/StructureDefinition/medication-type" />
+        <code value="Extension"/>
+        <profile value="http://hl7.org.au/fhir/StructureDefinition/medication-type"/>
       </type>
     </element>
-    <element id="MedicationDispense.medication[x]:medicationCoded.coding:amtMPP.extension:medicationType.valueCoding:valueCoding">
-      <path value="MedicationDispense.medication[x].coding.extension.valueCoding" />
-      <sliceName value="valueCoding" />
+    <element
+      id="MedicationDispense.medication[x]:medicationCoded.coding:amtMPP.extension:medicationType.valueCoding:valueCoding">
+      <path value="MedicationDispense.medication[x].coding.extension.valueCoding"/>
+      <sliceName value="valueCoding"/>
       <fixedCoding>
-        <system value="http://hl7.org.au/fhir/CodeSystem/medication-type" />
-        <code value="UPG" />
-        <display value="Unbranded package with no container" />
+        <system value="http://hl7.org.au/fhir/CodeSystem/medication-type"/>
+        <code value="UPG"/>
+        <display value="Unbranded package with no container"/>
       </fixedCoding>
     </element>
     <element id="MedicationDispense.medication[x]:medicationCoded.coding:amtCTPP">
-      <path value="MedicationDispense.medication[x].coding" />
-      <sliceName value="amtCTPP" />
-      <short value="AMT Containered Trade Product Pack" />
-      <max value="1" />
+      <path value="MedicationDispense.medication[x].coding"/>
+      <sliceName value="amtCTPP"/>
+      <short value="AMT Containered Trade Product Pack"/>
+      <max value="1"/>
       <binding>
-        <strength value="required" />
+        <strength value="required"/>
         <valueSetReference>
-          <reference value="http://hl7.org.au/fhir/ValueSet/amt-ctpp-codes" />
+          <reference value="http://hl7.org.au/fhir/ValueSet/amt-ctpp-codes"/>
         </valueSetReference>
       </binding>
     </element>
     <element id="MedicationDispense.medication[x]:medicationCoded.coding:amtCTPP.extension">
-      <path value="MedicationDispense.medication[x].coding.extension" />
+      <path value="MedicationDispense.medication[x].coding.extension"/>
       <slicing>
         <discriminator>
-          <type value="value" />
-          <path value="url" />
+          <type value="value"/>
+          <path value="url"/>
         </discriminator>
-        <rules value="open" />
+        <rules value="open"/>
       </slicing>
     </element>
-    <element id="MedicationDispense.medication[x]:medicationCoded.coding:amtCTPP.extension:medicationType">
-      <path value="MedicationDispense.medication[x].coding.extension" />
-      <sliceName value="medicationType" />
-      <short value="Type of medication coding" />
-      <definition value="General type of coding to allow usage of codes to be distinguished from the same CodeSystem" />
-      <max value="1" />
+    <element
+      id="MedicationDispense.medication[x]:medicationCoded.coding:amtCTPP.extension:medicationType">
+      <path value="MedicationDispense.medication[x].coding.extension"/>
+      <sliceName value="medicationType"/>
+      <short value="Type of medication coding"/>
+      <definition
+        value="General type of coding to allow usage of codes to be distinguished from the same CodeSystem"/>
+      <max value="1"/>
       <type>
-        <code value="Extension" />
-        <profile value="http://hl7.org.au/fhir/StructureDefinition/medication-type" />
+        <code value="Extension"/>
+        <profile value="http://hl7.org.au/fhir/StructureDefinition/medication-type"/>
       </type>
     </element>
-    <element id="MedicationDispense.medication[x]:medicationCoded.coding:amtCTPP.extension:medicationType.valueCoding:valueCoding">
-      <path value="MedicationDispense.medication[x].coding.extension.valueCoding" />
-      <sliceName value="valueCoding" />
+    <element
+      id="MedicationDispense.medication[x]:medicationCoded.coding:amtCTPP.extension:medicationType.valueCoding:valueCoding">
+      <path value="MedicationDispense.medication[x].coding.extension.valueCoding"/>
+      <sliceName value="valueCoding"/>
       <fixedCoding>
-        <system value="http://hl7.org.au/fhir/CodeSystem/medication-type" />
-        <code value="BPGC" />
-        <display value="Branded package with container" />
+        <system value="http://hl7.org.au/fhir/CodeSystem/medication-type"/>
+        <code value="BPGC"/>
+        <display value="Branded package with container"/>
       </fixedCoding>
     </element>
     <element id="MedicationDispense.medication[x]:medicationCoded.coding:amtTPUU">
-      <path value="MedicationDispense.medication[x].coding" />
-      <sliceName value="amtTPUU" />
-      <short value="AMT Trade Product Unit of Use" />
-      <max value="1" />
+      <path value="MedicationDispense.medication[x].coding"/>
+      <sliceName value="amtTPUU"/>
+      <short value="AMT Trade Product Unit of Use"/>
+      <max value="1"/>
       <binding>
-        <strength value="required" />
+        <strength value="required"/>
         <valueSetReference>
-          <reference value="http://hl7.org.au/fhir/ValueSet/amt-tpuu-codes" />
+          <reference value="http://hl7.org.au/fhir/ValueSet/amt-tpuu-codes"/>
         </valueSetReference>
       </binding>
     </element>
     <element id="MedicationDispense.medication[x]:medicationCoded.coding:amtTPUU.extension">
-      <path value="MedicationDispense.medication[x].coding.extension" />
+      <path value="MedicationDispense.medication[x].coding.extension"/>
       <slicing>
         <discriminator>
-          <type value="value" />
-          <path value="url" />
+          <type value="value"/>
+          <path value="url"/>
         </discriminator>
-        <rules value="open" />
+        <rules value="open"/>
       </slicing>
     </element>
-    <element id="MedicationDispense.medication[x]:medicationCoded.coding:amtTPUU.extension:medicationType">
-      <path value="MedicationDispense.medication[x].coding.extension" />
-      <sliceName value="medicationType" />
-      <short value="Type of medication coding" />
-      <max value="1" />
+    <element
+      id="MedicationDispense.medication[x]:medicationCoded.coding:amtTPUU.extension:medicationType">
+      <path value="MedicationDispense.medication[x].coding.extension"/>
+      <sliceName value="medicationType"/>
+      <short value="Type of medication coding"/>
+      <max value="1"/>
       <type>
-        <code value="Extension" />
-        <profile value="http://hl7.org.au/fhir/StructureDefinition/medication-type" />
+        <code value="Extension"/>
+        <profile value="http://hl7.org.au/fhir/StructureDefinition/medication-type"/>
       </type>
     </element>
-    <element id="MedicationDispense.medication[x]:medicationCoded.coding:amtTPUU.extension:medicationType.valueCoding:valueCoding">
-      <path value="MedicationDispense.medication[x].coding.extension.valueCoding" />
-      <sliceName value="valueCoding" />
+    <element
+      id="MedicationDispense.medication[x]:medicationCoded.coding:amtTPUU.extension:medicationType.valueCoding:valueCoding">
+      <path value="MedicationDispense.medication[x].coding.extension.valueCoding"/>
+      <sliceName value="valueCoding"/>
       <fixedCoding>
-        <system value="http://hl7.org.au/fhir/CodeSystem/medication-type" />
-        <code value="BPDSF" />
-        <display value="Branded product with strengths and form" />
+        <system value="http://hl7.org.au/fhir/CodeSystem/medication-type"/>
+        <code value="BPDSF"/>
+        <display value="Branded product with strengths and form"/>
       </fixedCoding>
     </element>
     <element id="MedicationDispense.medication[x]:medicationCoded.coding:amtMPUU">
-      <path value="MedicationDispense.medication[x].coding" />
-      <sliceName value="amtMPUU" />
-      <short value="AMT Medicinal Product Unit of Use" />
-      <max value="1" />
+      <path value="MedicationDispense.medication[x].coding"/>
+      <sliceName value="amtMPUU"/>
+      <short value="AMT Medicinal Product Unit of Use"/>
+      <max value="1"/>
       <binding>
-        <strength value="required" />
+        <strength value="required"/>
         <valueSetReference>
-          <reference value="http://hl7.org.au/fhir/ValueSet/amt-mpuu-codes" />
+          <reference value="http://hl7.org.au/fhir/ValueSet/amt-mpuu-codes"/>
         </valueSetReference>
       </binding>
     </element>
     <element id="MedicationDispense.medication[x]:medicationCoded.coding:amtMPUU.extension">
-      <path value="MedicationDispense.medication[x].coding.extension" />
+      <path value="MedicationDispense.medication[x].coding.extension"/>
       <slicing>
         <discriminator>
-          <type value="value" />
-          <path value="url" />
+          <type value="value"/>
+          <path value="url"/>
         </discriminator>
-        <rules value="open" />
+        <rules value="open"/>
       </slicing>
     </element>
-    <element id="MedicationDispense.medication[x]:medicationCoded.coding:amtMPUU.extension:medicationType">
-      <path value="MedicationDispense.medication[x].coding.extension" />
-      <sliceName value="medicationType" />
-      <short value="Type of medication coding" />
-      <max value="1" />
+    <element
+      id="MedicationDispense.medication[x]:medicationCoded.coding:amtMPUU.extension:medicationType">
+      <path value="MedicationDispense.medication[x].coding.extension"/>
+      <sliceName value="medicationType"/>
+      <short value="Type of medication coding"/>
+      <max value="1"/>
       <type>
-        <code value="Extension" />
-        <profile value="http://hl7.org.au/fhir/StructureDefinition/medication-type" />
+        <code value="Extension"/>
+        <profile value="http://hl7.org.au/fhir/StructureDefinition/medication-type"/>
       </type>
     </element>
-    <element id="MedicationDispense.medication[x]:medicationCoded.coding:amtMPUU.extension:medicationType.valueCoding:valueCoding">
-      <path value="MedicationDispense.medication[x].coding.extension.valueCoding" />
-      <sliceName value="valueCoding" />
+    <element
+      id="MedicationDispense.medication[x]:medicationCoded.coding:amtMPUU.extension:medicationType.valueCoding:valueCoding">
+      <path value="MedicationDispense.medication[x].coding.extension.valueCoding"/>
+      <sliceName value="valueCoding"/>
       <fixedCoding>
-        <system value="http://hl7.org.au/fhir/CodeSystem/medication-type" />
-        <code value="UPDSF" />
-        <display value="Unbranded product with strengths and form" />
+        <system value="http://hl7.org.au/fhir/CodeSystem/medication-type"/>
+        <code value="UPDSF"/>
+        <display value="Unbranded product with strengths and form"/>
       </fixedCoding>
     </element>
     <element id="MedicationDispense.medication[x]:medicationCoded.coding:amtTP">
-      <path value="MedicationDispense.medication[x].coding" />
-      <sliceName value="amtTP" />
-      <short value="AMT Trade Product" />
-      <max value="1" />
+      <path value="MedicationDispense.medication[x].coding"/>
+      <sliceName value="amtTP"/>
+      <short value="AMT Trade Product"/>
+      <max value="1"/>
       <binding>
-        <strength value="required" />
+        <strength value="required"/>
         <valueSetReference>
-          <reference value="http://hl7.org.au/fhir/ValueSet/amt-tp-codes" />
+          <reference value="http://hl7.org.au/fhir/ValueSet/amt-tp-codes"/>
         </valueSetReference>
       </binding>
     </element>
     <element id="MedicationDispense.medication[x]:medicationCoded.coding:amtTP.extension">
-      <path value="MedicationDispense.medication[x].coding.extension" />
+      <path value="MedicationDispense.medication[x].coding.extension"/>
       <slicing>
         <discriminator>
-          <type value="value" />
-          <path value="url" />
+          <type value="value"/>
+          <path value="url"/>
         </discriminator>
-        <rules value="open" />
+        <rules value="open"/>
       </slicing>
     </element>
-    <element id="MedicationDispense.medication[x]:medicationCoded.coding:amtTP.extension:medicationType">
-      <path value="MedicationDispense.medication[x].coding.extension" />
-      <sliceName value="medicationType" />
-      <short value="Type of medication coding" />
-      <max value="1" />
+    <element
+      id="MedicationDispense.medication[x]:medicationCoded.coding:amtTP.extension:medicationType">
+      <path value="MedicationDispense.medication[x].coding.extension"/>
+      <sliceName value="medicationType"/>
+      <short value="Type of medication coding"/>
+      <max value="1"/>
       <type>
-        <code value="Extension" />
-        <profile value="http://hl7.org.au/fhir/StructureDefinition/medication-type" />
+        <code value="Extension"/>
+        <profile value="http://hl7.org.au/fhir/StructureDefinition/medication-type"/>
       </type>
     </element>
-    <element id="MedicationDispense.medication[x]:medicationCoded.coding:amtTP.extension:medicationType.valueCoding:valueCoding">
-      <path value="MedicationDispense.medication[x].coding.extension.valueCoding" />
-      <sliceName value="valueCoding" />
+    <element
+      id="MedicationDispense.medication[x]:medicationCoded.coding:amtTP.extension:medicationType.valueCoding:valueCoding">
+      <path value="MedicationDispense.medication[x].coding.extension.valueCoding"/>
+      <sliceName value="valueCoding"/>
       <fixedCoding>
-        <system value="http://hl7.org.au/fhir/CodeSystem/medication-type" />
-        <code value="BPD" />
-        <display value="Branded product with no strengths or form" />
+        <system value="http://hl7.org.au/fhir/CodeSystem/medication-type"/>
+        <code value="BPD"/>
+        <display value="Branded product with no strengths or form"/>
       </fixedCoding>
     </element>
     <element id="MedicationDispense.medication[x]:medicationCoded.coding:amtMP">
-      <path value="MedicationDispense.medication[x].coding" />
-      <sliceName value="amtMP" />
-      <short value="AMT Medicinal Product" />
-      <max value="1" />
+      <path value="MedicationDispense.medication[x].coding"/>
+      <sliceName value="amtMP"/>
+      <short value="AMT Medicinal Product"/>
+      <max value="1"/>
       <binding>
-        <strength value="required" />
+        <strength value="required"/>
         <valueSetReference>
-          <reference value="http://hl7.org.au/fhir/ValueSet/amt-mp-codes" />
+          <reference value="http://hl7.org.au/fhir/ValueSet/amt-mp-codes"/>
         </valueSetReference>
       </binding>
     </element>
     <element id="MedicationDispense.medication[x]:medicationCoded.coding:amtMP.extension">
-      <path value="MedicationDispense.medication[x].coding.extension" />
+      <path value="MedicationDispense.medication[x].coding.extension"/>
       <slicing>
         <discriminator>
-          <type value="value" />
-          <path value="url" />
+          <type value="value"/>
+          <path value="url"/>
         </discriminator>
-        <rules value="open" />
+        <rules value="open"/>
       </slicing>
     </element>
-    <element id="MedicationDispense.medication[x]:medicationCoded.coding:amtMP.extension:medicationType">
-      <path value="MedicationDispense.medication[x].coding.extension" />
-      <sliceName value="medicationType" />
-      <short value="Type of medication coding" />
-      <max value="1" />
+    <element
+      id="MedicationDispense.medication[x]:medicationCoded.coding:amtMP.extension:medicationType">
+      <path value="MedicationDispense.medication[x].coding.extension"/>
+      <sliceName value="medicationType"/>
+      <short value="Type of medication coding"/>
+      <max value="1"/>
       <type>
-        <code value="Extension" />
-        <profile value="http://hl7.org.au/fhir/StructureDefinition/medication-type" />
+        <code value="Extension"/>
+        <profile value="http://hl7.org.au/fhir/StructureDefinition/medication-type"/>
       </type>
     </element>
-    <element id="MedicationDispense.medication[x]:medicationCoded.coding:amtMP.extension:medicationType.valueCoding:valueCoding">
-      <path value="MedicationDispense.medication[x].coding.extension.valueCoding" />
-      <sliceName value="valueCoding" />
+    <element
+      id="MedicationDispense.medication[x]:medicationCoded.coding:amtMP.extension:medicationType.valueCoding:valueCoding">
+      <path value="MedicationDispense.medication[x].coding.extension.valueCoding"/>
+      <sliceName value="valueCoding"/>
       <fixedCoding>
-        <system value="http://hl7.org.au/fhir/CodeSystem/medication-type" />
-        <code value="UPD" />
-        <display value="Unbranded product with no strengths or form" />
+        <system value="http://hl7.org.au/fhir/CodeSystem/medication-type"/>
+        <code value="UPD"/>
+        <display value="Unbranded product with no strengths or form"/>
       </fixedCoding>
     </element>
     <element id="MedicationDispense.medication[x]:medicationCoded.coding:mimsPackage">
-      <path value="MedicationDispense.medication[x].coding" />
-      <sliceName value="mimsPackage" />
-      <short value="MIMS Package" />
-      <max value="1" />
+      <path value="MedicationDispense.medication[x].coding"/>
+      <sliceName value="mimsPackage"/>
+      <short value="MIMS Package"/>
+      <max value="1"/>
       <binding>
-        <strength value="required" />
+        <strength value="required"/>
         <valueSetReference>
-          <reference value="http://hl7.org.au/fhir/ValueSet/mims" />
+          <reference value="http://hl7.org.au/fhir/ValueSet/mims"/>
         </valueSetReference>
       </binding>
     </element>
     <element id="MedicationDispense.medication[x]:medicationReference">
-      <path value="MedicationDispense.medication[x]" />
-      <sliceName value="medicationReference" />
-      <short value="Dispensed medication" />
+      <path value="MedicationDispense.medication[x]"/>
+      <sliceName value="medicationReference"/>
+      <short value="Dispensed medication"/>
       <type>
-        <code value="Reference" />
-        <targetProfile value="http://hl7.org.au/fhir/StructureDefinition/au-medication" />
-      </type>
-    </element>
-    <element id="MedicationDispense.subject">
-      <path value="MedicationDispense.subject" />
-      <short value="Subject of dispened medication" />
-      <type>
-        <code value="Reference" />
-        <targetProfile value="http://hl7.org.au/fhir/StructureDefinition/au-patient" />
-      </type>
-      <type>
-        <code value="Reference" />
-        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Group" />
+        <code value="Reference"/>
+        <targetProfile value="http://hl7.org.au/fhir/StructureDefinition/au-medication"/>
       </type>
     </element>
     <element id="MedicationDispense.authorizingPrescription">
-      <path value="MedicationDispense.authorizingPrescription" />
+      <path value="MedicationDispense.authorizingPrescription"/>
       <type>
-        <code value="Reference" />
-        <targetProfile value="http://hl7.org.au/fhir/StructureDefinition/au-prescription" />
-      </type>
-    </element>
-    <element id="MedicationDispense.receiver">
-      <path value="MedicationDispense.receiver" />
-      <type>
-        <code value="Reference" />
-        <targetProfile value="http://hl7.org.au/fhir/StructureDefinition/au-patient" />
-      </type>
-      <type>
-        <code value="Reference" />
-        <targetProfile value="http://hl7.org.au/fhir/StructureDefinition/au-practitioner" />
-      </type>
-    </element>
-    <element id="MedicationDispense.dosageInstruction">
-      <path value="MedicationDispense.dosageInstruction" />
-      <type>
-        <code value="Dosage" />
-        <profile value="http://hl7.org.au/fhir/StructureDefinition/au-dosage" />
+        <code value="Reference"/>
+        <targetProfile value="http://hl7.org.au/fhir/StructureDefinition/au-prescription"/>
       </type>
     </element>
   </differential>

--- a/resources/au-immunisation.xml
+++ b/resources/au-immunisation.xml
@@ -160,7 +160,7 @@
       <short value="Administering practitioner" />
       <type>
         <code value="Reference" />
-        <targetProfile value="http://hl7.org.au/fhir/StructureDefinition/au-practitioner" />
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Practitioner" />
       </type>
     </element>
     <element id="Immunization.practitioner:approvedBy">
@@ -196,7 +196,7 @@
       <short value="Approving practitioner" />
       <type>
         <code value="Reference" />
-        <targetProfile value="http://hl7.org.au/fhir/StructureDefinition/au-practitioner" />
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Practitioner" />
       </type>
     </element>
     <element id="Immunization.explanation">

--- a/resources/au-prescription.xml
+++ b/resources/au-prescription.xml
@@ -661,23 +661,6 @@
         <valueSetUri value="http://hl7.org/fhir/ValueSet/condition-code" />
       </binding>
     </element>
-    <element id="MedicationRequest.dosageInstruction">
-      <path value="MedicationRequest.dosageInstruction" />
-      <type>
-        <code value="Dosage" />
-        <profile value="http://hl7.org.au/fhir/StructureDefinition/au-dosage" />
-      </type>
-    </element>
-    <element id="MedicationRequest.dosageInstruction.additionalInstruction">
-      <path value="MedicationRequest.dosageInstruction.additionalInstruction" />
-      <slicing>
-        <discriminator>
-          <type value="value" />
-          <path value="coding.system" />
-        </discriminator>
-        <rules value="open" />
-      </slicing>
-    </element>
     <element id="MedicationRequest.dispenseRequest">
       <path value="MedicationRequest.dispenseRequest" />
       <short value="Requested dispensing" />


### PR DESCRIPTION
Hi Brett, 
This PR continues on from the recent removal of AU profile references, this time with the following medication-related profiles:
- au-dispenserecord
- au-immunisation
- au-prescription

For further information, see the individual commit messages.