### PR TITLE
Updated Encounter examples ids

### DIFF
--- a/examples/encounter-example0.xml
+++ b/examples/encounter-example0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Encounter xmlns="http://hl7.org/fhir">
-  <id value="example0"/>
+  <id value="encounter-example0"/>
   <extension url=" http://hl7.org.au/fhir/StructureDefinition/encounter-description">
     <valueString
       value="Admitted for elective bronchoscopy for assessment of left lingular and bibasal pneumonia. No focal endobronchial pathology identified. No evidence of malignancy and no pathogens isolated on bronchial brushings and washings."

--- a/examples/encounter-example0.xml
+++ b/examples/encounter-example0.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Encounter xmlns="http://hl7.org/fhir">
   <id value="encounter-example0"/>
-  <extension url=" http://hl7.org.au/fhir/StructureDefinition/encounter-description">
+  <extension url="http://hl7.org.au/fhir/StructureDefinition/encounter-description">
     <valueString
       value="Admitted for elective bronchoscopy for assessment of left lingular and bibasal pneumonia. No focal endobronchial pathology identified. No evidence of malignancy and no pathogens isolated on bronchial brushings and washings."
     />

--- a/examples/encounter-example1.xml
+++ b/examples/encounter-example1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Encounter xmlns="http://hl7.org/fhir">
   <id value="encounter-example1"/>
-  <extension url=" http://hl7.org.au/fhir/StructureDefinition/encounter-description">
+  <extension url="http://hl7.org.au/fhir/StructureDefinition/encounter-description">
     <valueString value="3/52 ago involved in a rear end motor vehicle accident, mid-velocity impact; complaining of neck pain, dizziness, nausea and difficulties concentrating. Disturbed sleep. No spinal cord signs."/>
   </extension>
   <status value="in-progress"/>

--- a/examples/encounter-example1.xml
+++ b/examples/encounter-example1.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Encounter xmlns="http://hl7.org/fhir">
-  <id value="example1"/>
+  <id value="encounter-example1"/>
   <extension url=" http://hl7.org.au/fhir/StructureDefinition/encounter-description">
     <valueString value="3/52 ago involved in a rear end motor vehicle accident, mid-velocity impact; complaining of neck pain, dizziness, nausea and difficulties concentrating. Disturbed sleep. No spinal cord signs."/>
   </extension>

--- a/pages/_includes/encounter-description-intro.md
+++ b/pages/_includes/encounter-description-intro.md
@@ -6,6 +6,6 @@ The description may include a summary of the issues or problems, management stra
 
 **Examples**
 
-[Admitted for elective bronchoscopy](Encounter-example0.html)
+[Admitted for elective bronchoscopy](Encounter-encounter-example0.html)
 
-[Involved in a rear end motor vehicle accident](Encounter-example1.html)
+[Involved in a rear end motor vehicle accident](Encounter-encounter-example1.html)

--- a/resources/ig.xml
+++ b/resources/ig.xml
@@ -1150,7 +1150,7 @@
       <name value="Encounter with description"/>
       <description value="Encounter with encounter description"/>
       <sourceReference>
-        <reference value="Encounter/example0"/>
+        <reference value="Encounter/encounter-example0"/>
       </sourceReference>
     </resource>
     <resource>
@@ -1158,7 +1158,7 @@
       <name value="Encounter with narative description"/>
       <description value="Encounter with narrative description"/>
       <sourceReference>
-        <reference value="Encounter/example1"/>
+        <reference value="Encounter/encounter-example1"/>
       </sourceReference>
     </resource>
     <resource>


### PR DESCRIPTION
Hi Brett,

A small PR to add "encounter" into the `id` value of the existing encounter examples.

Also corrected an issue with their extension URLs (leading whitespace).

cheers
Rob