### PR TITLE
Author role extension

### DIFF
--- a/ig.json
+++ b/ig.json
@@ -236,6 +236,10 @@
             "base": "StructureDefinition-composition-author-role.html",
             "defns": "StructureDefinition-composition-author-role-definitions.html"
         },
+        "StructureDefinition/author-role": {
+            "base": "StructureDefinition-author-role.html",
+            "defns": "StructureDefinition-author-role-definitions.html"
+        },
         "StructureDefinition/recorder-related-person": {
             "base": "StructureDefinition-recorder-related-person.html",
             "defns": "StructureDefinition-recorder-related-person-definitions.html"

--- a/pages/_includes/author-role-intro.md
+++ b/pages/_includes/author-role-intro.md
@@ -1,0 +1,7 @@
+**Extension: Authoring Practitioner Role** *[[FMM Level 1](guidance.html)]*
+
+This extension pre-adopts (from R4) an author that is a practitioner role for use in DocumentReference, and CarePlan. 
+
+**Examples**
+
+TBD

--- a/pages/_includes/author-role-intro.md
+++ b/pages/_includes/author-role-intro.md
@@ -1,7 +1,4 @@
-**Extension: Authoring Practitioner Role** *[[FMM Level 1](guidance.html)]*
+**Extension: Authoring Practitioner Role** *[[FMM Level 0](guidance.html)]*
 
-This extension pre-adopts (from R4) an author that is a practitioner role for use in DocumentReference, and CarePlan. 
+This extension pre-adopts (from R4) an author that is a practitioner role for use in DocumentReference and CarePlan. 
 
-**Examples**
-
-TBD

--- a/pages/_includes/author-role-search.md
+++ b/pages/_includes/author-role-search.md
@@ -1,0 +1,1 @@
+none defined

--- a/pages/_includes/author-role-summary.md
+++ b/pages/_includes/author-role-summary.md
@@ -1,0 +1,4 @@
+This profile contains the following variations from [Extension](http://hl7.org/fhir/STU3/Extension):
+
+1. exactly one <span style='color:green'> url </span> 
+   * exactly one <span style='color:green'> valueReference </span>  (Reference as: PractitionerRole)

--- a/pages/_includes/extensions.md
+++ b/pages/_includes/extensions.md
@@ -28,6 +28,7 @@ Related to administration records such as patient, practitioner, practitioner ro
 * [Strength Text](StructureDefinition-medication-strength-text.html) - text representation of medication strength
 * [Change Description](StructureDefinition-change-description.html) - description of the change including reason for change
 * [List Source Role](StructureDefinition-list-source-role.html) - list practitioner role (R4 preadopt) 
+* [Author Role](StructureDefinition-author-role.html) - author practitioner role (R4 preadopt)
 
 ## Clinical
 * [Recorder as a RelatedPerson](StructureDefinition-recorder-related-person.html) - recorder as a related person (R4 preadopt)
@@ -55,3 +56,4 @@ Related to administration records such as patient, practitioner, practitioner ro
 * [List Source Role](StructureDefinition-list-source-role.html) - PractitonerRole support as per R4
 * [Recorder as a RelatedPerson](StructureDefinition-recorder-related-person.html) - recorder as a related person support as per R4
 * [Condition Recorder](StructureDefinition-recorder.html) - support as per R4
+* [Author Role](StructureDefinition-author-role.html) - author practitioner role as per R4 

--- a/pages/_includes/extensions.md
+++ b/pages/_includes/extensions.md
@@ -12,6 +12,7 @@ Related to administration records such as patient, practitioner, practitioner ro
 * [IHI Record Status](StructureDefinition-ihi-record-status.html) - identifier record status
 * [No Fixed Address](StructureDefinition-no-fixed-address.html) - address flag
 * [Encounter Description](StructureDefinition-encounter-description.html) - description of an encounter
+* [Authoring Practitioner Role](StructureDefinition-author-role.html) - PractitonerRole support as per R4
 
 ## Medication
 * [Medication Type](StructureDefinition-medication-type.html) - drug code classification
@@ -28,7 +29,6 @@ Related to administration records such as patient, practitioner, practitioner ro
 * [Strength Text](StructureDefinition-medication-strength-text.html) - text representation of medication strength
 * [Change Description](StructureDefinition-change-description.html) - description of the change including reason for change
 * [List Source Role](StructureDefinition-list-source-role.html) - list practitioner role (R4 preadopt) 
-* [Author Role](StructureDefinition-author-role.html) - author practitioner role (R4 preadopt)
 
 ## Clinical
 * [Recorder as a RelatedPerson](StructureDefinition-recorder-related-person.html) - recorder as a related person (R4 preadopt)
@@ -56,4 +56,4 @@ Related to administration records such as patient, practitioner, practitioner ro
 * [List Source Role](StructureDefinition-list-source-role.html) - PractitonerRole support as per R4
 * [Recorder as a RelatedPerson](StructureDefinition-recorder-related-person.html) - recorder as a related person support as per R4
 * [Condition Recorder](StructureDefinition-recorder.html) - support as per R4
-* [Author Role](StructureDefinition-author-role.html) - author practitioner role as per R4 
+* [Authoring Practitioner Role](StructureDefinition-author-role.html) - PractitonerRole support as per R4

--- a/resources/ig.xml
+++ b/resources/ig.xml
@@ -181,6 +181,12 @@
     <resource>
       <example value="false"/>
       <sourceReference>
+        <reference value="StructureDefinition/author-role"/>
+      </sourceReference>
+    </resource>
+    <resource>
+      <example value="false"/>
+      <sourceReference>
         <reference value="StructureDefinition/healthcareservice-eligibility-detail"/>
       </sourceReference>
     </resource>

--- a/resources/structuredefinition-author-role.xml
+++ b/resources/structuredefinition-author-role.xml
@@ -30,7 +30,6 @@
       <path value="Extension"/>
       <short value="Practitioner role that authored the resource"/>         
       <definition value="Identifies the practitioner role responsible for the information in the resource (aka author), not necessarily who typed it in."/>
-      <max value="1"/>   
     </element>
     <element id="Extension.url">
       <path value="Extension.url"/>

--- a/resources/structuredefinition-author-role.xml
+++ b/resources/structuredefinition-author-role.xml
@@ -1,0 +1,49 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="author-role"/>
+  <url value="http://hl7.org.au/fhir/StructureDefinition/author-role"/>
+  <version value="1.0.0"/>
+  <name value="AuthorRole"/>
+  <title value="Authoring Practitioner Role"/>
+  <status value="draft"/>
+  <date value="2019-01-22" />
+  <publisher value="Health Level Seven Australia (Patient Administration WG)" />
+  <contact>
+    <telecom>
+      <system value="url"/>
+      <value value="http://hl7.org.au"/>
+      <use value="work" />
+    </telecom>
+  </contact>
+  <description
+    value="Reference to practitioner role that authored the resource."/>
+  <fhirVersion value="3.0.1"/>
+  <kind value="complex-type"/>
+  <abstract value="false"/>
+  <contextType value="resource"/>
+  <context value="Resource"/>
+  <type value="Extension"/>
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Extension"/>
+  <derivation value="constraint"/>
+  <differential>
+    <element id="Extension">
+      <path value="Extension"/>
+      <short value="Practitioner role that authored the resource"/>         
+      <definition value="Identifies the practitioner role responsible for the information in the resource (aka author), not necessarily who typed it in."/>
+      <max value="1"/>   
+    </element>
+    <element id="Extension.url">
+      <path value="Extension.url"/>
+      <fixedUri value="http://hl7.org.au/fhir/StructureDefinition/author-role"/>
+    </element>
+    <element id="Extension.value[x]:valueReference">
+      <path value="Extension.valueReference"/>
+      <sliceName value="valueReference"/>
+      <min value="1"/>
+      <type>
+        <code value="Reference"/>
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/PractitionerRole"/>
+      </type>
+    </element>
+  </differential>
+</StructureDefinition>


### PR DESCRIPTION
Created new author role extension which is an R4 pre-adoption extension that is needed to allow PractitionerRole to be referenced as an author for DocumentReference and CarePlan…