### PR TITLE
au-allergyintolerance bugfix - reordered extension elements

### DIFF
--- a/resources/au-allergyintolerance.xml
+++ b/resources/au-allergyintolerance.xml
@@ -33,6 +33,28 @@
         <expression value="(extension('http://hl7.org.au/fhir/StructureDefinition/recorder-related-person').exists() and recorder.exists()).not()"/>
       </constraint>
     </element>
+    <element id="AllergyIntolerance.extension">
+      <path value="AllergyIntolerance.extension"/>
+      <slicing>
+        <discriminator>
+          <type value="value"/>
+          <path value="url"/>
+        </discriminator>
+        <rules value="open"/>
+      </slicing>
+    </element>
+    <element id="AllergyIntolerance.extension:recorderRelatedPerson">
+      <path value="AllergyIntolerance.extension"/>
+      <sliceName value="recorderRelatedPerson"/>
+      <short value="Related person that recorded the sensitivity"/>
+      <definition value="Reference to related person that recorded the record and takes responsibility for its content."/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="Extension"/>
+        <profile value="http://hl7.org.au/fhir/StructureDefinition/recorder-related-person"/>
+      </type>
+    </element>
     <element id="AllergyIntolerance.code">
       <path value="AllergyIntolerance.code"/>
     </element>
@@ -56,28 +78,6 @@
         <strength value="required"/>
         <valueSetUri value="https://healthterminologies.gov.au/fhir/ValueSet/indicator-hypersensitivity-intolerance-to-substance-1"/>
       </binding>
-    </element>
-    <element id="AllergyIntolerance.extension">
-      <path value="AllergyIntolerance.extension"/>
-      <slicing>
-        <discriminator>
-          <type value="value"/>
-          <path value="url"/>
-        </discriminator>
-        <rules value="open"/>
-      </slicing>
-    </element>
-    <element id="AllergyIntolerance.extension:recorderRelatedPerson">
-      <path value="AllergyIntolerance.extension"/>
-      <sliceName value="recorderRelatedPerson"/>
-      <short value="Related person that recorded the sensitivity"/>
-      <definition value="Reference to related person that recorded the record and takes responsibility for its content."/>
-      <min value="0"/>
-      <max value="1"/>
-      <type>
-        <code value="Extension"/>
-        <profile value="http://hl7.org.au/fhir/StructureDefinition/recorder-related-person"/>
-      </type>
     </element>
     <element id="AllergyIntolerance.reaction">
       <path value="AllergyIntolerance.reaction"/>


### PR DESCRIPTION
Moved extension elements to be directly following the root element rather than interspersed between other elements.
Fixes #247 