### PR TITLE
au-medication bugfix - added missing parent elements

### DIFF
--- a/resources/au-medication.xml
+++ b/resources/au-medication.xml
@@ -444,6 +444,9 @@
       <short value="Physical product manufacturer organisation" />
       <definition value="Manufacturer of the actual physical medicine product" />
     </element>
+    <element id="Medication.form">
+      <path value="Medication.form"/>
+    </element>
     <element id="Medication.form.coding">
       <path value="Medication.form.coding" />
       <slicing>
@@ -516,6 +519,9 @@
     <element id="Medication.ingredient.amount">
       <path value="Medication.ingredient.amount" />
       <short value="Strength of ingredient" />
+    </element>
+    <element id="Medication.package">
+      <path value="Medication.package"/>
     </element>
     <element id="Medication.package.content">
       <path value="Medication.package.content" />


### PR DESCRIPTION
Added parent elements for Medication.form and Medication.package so that constraints on their respective children appear in the generated differential table.
Fixes #246 