### PR TITLE
Updated version of common-languages-australia valueset to v2

### DIFF
--- a/resources/au-patient.xml
+++ b/resources/au-patient.xml
@@ -745,7 +745,7 @@
       <binding>
         <strength value="extensible" />
         <valueSetReference>
-          <reference value="https://healthterminologies.gov.au/fhir/ValueSet/common-languages-australia-1" />
+          <reference value="https://healthterminologies.gov.au/fhir/ValueSet/common-languages-australia-2" />
         </valueSetReference>
       </binding>
     </element>

--- a/resources/au-practitioner.xml
+++ b/resources/au-practitioner.xml
@@ -397,7 +397,7 @@
       <binding>
         <strength value="extensible" />
         <valueSetReference>
-          <reference value="https://healthterminologies.gov.au/fhir/ValueSet/common-languages-australia-1" />
+          <reference value="https://healthterminologies.gov.au/fhir/ValueSet/common-languages-australia-2" />
         </valueSetReference>
       </binding>
     </element>

--- a/resources/structuredefinition-healthcareservice-communication.xml
+++ b/resources/structuredefinition-healthcareservice-communication.xml
@@ -41,7 +41,7 @@
         <strength value="extensible" />
         <description value="Common languages" />
         <valueSetReference>
-          <reference value="https://healthterminologies.gov.au/fhir/ValueSet/common-languages-australia-1" />
+          <reference value="https://healthterminologies.gov.au/fhir/ValueSet/common-languages-australia-2" />
         </valueSetReference>
       </binding>
     </element>


### PR DESCRIPTION
Hi Brett, this PR updates the version number of the common-lanuages-australia binding to v2.

URL updated in the 3 profiles where this binding is present:
- [au-patient profile](http://build.fhir.org/ig/hl7au/au-fhir-base/StructureDefinition-au-patient.html)
- [au-practitioner profile](http://build.fhir.org/ig/hl7au/au-fhir-base/StructureDefinition-au-practitioner.html)
- [Healthcare Service Communication extension](http://build.fhir.org/ig/hl7au/au-fhir-base/StructureDefinition-healthcareservice-communication.html)

URLs changed to 
https://healthterminologies.gov.au/fhir/ValueSet/common-languages-australia-2

The v2 valueset has been implemented by NCTS, and from that perspective the PR is ready to be merged in. However, a [zulip thread](https://chat.fhir.org/#narrow/stream/179173-australia/topic/new.20AU.20languages.20ValueSet) has been raised re the v2 valueset as a few duplicate codes were found. This has been raised with NCTS and the fix will be in the Apr release.
