### PR TITLE
AU Base Medicine List - added allowance for Assertion of No Relevant Finding

### DIFF
--- a/pages/_includes/au-medlist-intro.md
+++ b/pages/_includes/au-medlist-intro.md
@@ -2,6 +2,8 @@
 
 This profile defines a list structure including core localisation concepts for use as a medicines list in an Australian context. This profile is intended to offer a common structure and expectations to record, exchange, and fetch a list of medications associated with a patient in an Australian healthcare context. 
 
+Assertion of no relevant finding can be used to positively state that there is no history of immunisations for a patient or that the patient is known not to have current medications.
+
 Forthcoming work around this profile is expected to result in guidance and additional structures that define types of medication lists, e.g. current medications or medication changes or prescription history. 
 
 #### Extensions
@@ -9,4 +11,6 @@ Extensions used in this profile:
 * List: List Source Role [<sup>[1]</sup>](http://hl7.org.au/fhir/StructureDefinition/list-source-role)
 * List.entry: Change Description [<sup>[1]</sup>](http://hl7.org.au/fhir/StructureDefinition/change-description)
 
+
+**Examples**
 

--- a/resources/au-medlist.xml
+++ b/resources/au-medlist.xml
@@ -50,6 +50,7 @@
       <path value="List.extension" />
       <sliceName value="sourceRole" />
       <short value="Practitioner role that defined the list contents (aka Author)" />
+      <max value="1"/>
       <type>
         <code value="Extension" />
         <profile value="http://hl7.org.au/fhir/StructureDefinition/list-source-role" />

--- a/resources/au-medlist.xml
+++ b/resources/au-medlist.xml
@@ -115,6 +115,10 @@
         <code value="Reference" />
         <targetProfile value="http://hl7.org/fhir/StructureDefinition/Immunization" />
       </type>
+      <type>
+        <code value="Reference" />
+        <targetProfile value="http://hl7.org.au/fhir/StructureDefinition/au-norelevantfinding" />
+      </type>
     </element>
   </differential>
 </StructureDefinition>


### PR DESCRIPTION
Hi Brett, this PR is for the AU Base Medicine List profile to allow Assertion of No Relevant Finding. Some guidance text has also been added for when the assertion of no relevant finding would be used. 

Note this is the set of changes authored by Dushi which she has spoken with you about.