### PR TITLE
DescriptionUpdate all HL7 AU profile StructureDefinition.description update

### DIFF
--- a/pages/_includes/list-source-role-intro.md
+++ b/pages/_includes/list-source-role-intro.md
@@ -1,4 +1,4 @@
 **Extension: List Source Role**  *[[FMM Level 0](guidance.html)]*
 
-This extension applies to the List resource and provides provides a practitioner role that authored this list. This is the practitioner role responsible for deciding the contents of the list. 
+This extension applies to the List resource and provides a practitioner role that authored this list. This is the practitioner role responsible for deciding the contents of the list. 
 

--- a/resources/au-address.xml
+++ b/resources/au-address.xml
@@ -15,7 +15,8 @@
       <use value="work" />
     </telecom>
   </contact>
-  <description value="Australian realm Australian Address profile." />
+  <description value="This profile is provided for use in an Australian context where some constraint on content is desirable to guarantee the quality of an Australian address whilst still supporting
+    other uses such as unstructured addresses." />
   <fhirVersion value="3.0.1" />
   <kind value="complex-type" />
   <abstract value="false" />

--- a/resources/au-allergyintolerance.xml
+++ b/resources/au-allergyintolerance.xml
@@ -15,7 +15,7 @@
       <use value="work"/>
     </telecom>
   </contact>
-  <description value="Base profile for Australian context Allergy Intolerance"/>
+  <description value="This profile defines an allergy intolerance structure including core localisation concepts for use in an Australian context."/>
   <fhirVersion value="3.0.1"/>
   <kind value="resource"/>
   <abstract value="false"/>

--- a/resources/au-bodyheight.xml
+++ b/resources/au-bodyheight.xml
@@ -14,7 +14,7 @@
       <use value="work" />
     </telecom>
   </contact>
-  <description value="Australian realm Body Height profile derived from STU3 Vital Signs Body Height profile." />
+  <description value="This profile defines a body height information structure for use in an Australian context that tightens the BodyHeightCode slice, aligning to the proposed [R4 Observation Body Height](http://build.fhir.org/bodyheight.html) profile." />
   <copyright value="This resource contains content from LOINC™ (http://loinc.org). The LOINC Table, LOINC Table Core, LOINC Panels and Forms File, LOINC Answer File, LOINC Part File, LOINC Group File, LOINC Document Ontology File, LOINC Hierarchies, LOINC Linguistic Variants File, LOINC/RSNA Radiology Playbook, and LOINC/IEEE Medical Device Code Mapping Table are copyright © 1995-2017, Regenstrief Institute, Inc. and the Logical Observation Identifiers Names and Codes (LOINC) Committee and is available at no cost under the license at http://loinc.org/license." />
   <fhirVersion value="3.0.1" />
   <kind value="resource" />

--- a/resources/au-bodysite.xml
+++ b/resources/au-bodysite.xml
@@ -15,7 +15,7 @@
       <use value="work"/>
     </telecom>
   </contact>
-  <description value="Australian realm Base BodySite profile."/>
+  <description value="This BodySite profile is provided for use in an Australian context."/>
   <fhirVersion value="3.0.1"/>
   <kind value="resource"/>
   <abstract value="false"/>

--- a/resources/au-bodyweight.xml
+++ b/resources/au-bodyweight.xml
@@ -14,7 +14,7 @@
       <use value="work" />
     </telecom>
   </contact>
-  <description value="Australian realm Body Weight profile derived from STU3 Vital Signs Body Weight profile." />
+  <description value="This profile defines a body weight information structure for use in an Australian context that tightens the BodyWeightCode slice, aligning to the proposed [R4 Observation Body Weight](http://build.fhir.org/bodyweight.html) profile." />
   <copyright value="This resource contains content from LOINC™ (http://loinc.org). The LOINC Table, LOINC Table Core, LOINC Panels and Forms File, LOINC Answer File, LOINC Part File, LOINC Group File, LOINC Document Ontology File, LOINC Hierarchies, LOINC Linguistic Variants File, LOINC/RSNA Radiology Playbook, and LOINC/IEEE Medical Device Code Mapping Table are copyright © 1995-2017, Regenstrief Institute, Inc. and the Logical Observation Identifiers Names and Codes (LOINC) Committee and is available at no cost under the license at http://loinc.org/license." />
   <fhirVersion value="3.0.1" />
   <kind value="resource" />

--- a/resources/au-composition.xml
+++ b/resources/au-composition.xml
@@ -14,7 +14,7 @@
       <use value="work" />
     </telecom>
   </contact>
-  <description value="Australian realm Base Composition profile." />
+  <description value="This profile defines a composition structure that includes core localisation concepts for use in an Australian context." />
   <fhirVersion value="3.0.1" />
   <kind value="resource" />
   <abstract value="false" />

--- a/resources/au-condition.xml
+++ b/resources/au-condition.xml
@@ -15,7 +15,7 @@
       <use value="work" />
     </telecom>
   </contact>
-  <description value="Australian realm Base Condition profile." />
+  <description value="This profile defines a condition structure including core localisation concepts for use in an Australian context." />
   <fhirVersion value="3.0.1" />
   <kind value="resource" />
   <abstract value="false" />

--- a/resources/au-device.xml
+++ b/resources/au-device.xml
@@ -15,7 +15,7 @@
       <use value="work" />
     </telecom>
   </contact>
-  <description value="Australian realm Device profile" />
+  <description value="This profile defines a device administration details structure that includes core localisation concepts for use in an Australian context." />
   <fhirVersion value="3.0.1" />
   <kind value="resource" />
   <abstract value="false" />

--- a/resources/au-dispenserecord.xml
+++ b/resources/au-dispenserecord.xml
@@ -15,7 +15,7 @@
       <use value="work" />
     </telecom>
   </contact>
-  <description value="Australian realm dispense record profile." />
+  <description value="This profile defines a medication dispense structure including core localisation concepts for use as a dispense record in an Australian context." />
   <fhirVersion value="3.0.1" />
   <kind value="resource" />
   <abstract value="false" />

--- a/resources/au-dosage.xml
+++ b/resources/au-dosage.xml
@@ -14,7 +14,7 @@
       <use value="work" />
     </telecom>
   </contact>
-  <description value="Australian realm Base Dosage profile." />
+  <description value="This profile defines a dosage structure including core localisation concepts for use in an Australian context." />
   <fhirVersion value="3.0.1" />
   <kind value="complex-type" />
   <abstract value="false" />

--- a/resources/au-headcircum.xml
+++ b/resources/au-headcircum.xml
@@ -14,7 +14,7 @@
       <use value="work" />
     </telecom>
   </contact>
-  <description value="Australian realm Head Circumference profile derived from Vital Signs Head Circumference profile." />
+  <description value="This profile defines a head circumference information structure for use in an Australian context that tightens the HeadCircumCode slice, aligning to the proposed [R4 Observation Head Circumference](http://build.fhir.org/headcircum.html) profile." />
   <copyright value="This resource contains content from LOINC™ (http://loinc.org). The LOINC Table, LOINC Table Core, LOINC Panels and Forms File, LOINC Answer File, LOINC Part File, LOINC Group File, LOINC Document Ontology File, LOINC Hierarchies, LOINC Linguistic Variants File, LOINC/RSNA Radiology Playbook, and LOINC/IEEE Medical Device Code Mapping Table are copyright © 1995-2017, Regenstrief Institute, Inc. and the Logical Observation Identifiers Names and Codes (LOINC) Committee and is available at no cost under the license at http://loinc.org/license." />
   <fhirVersion value="3.0.1" />
   <kind value="resource" />

--- a/resources/au-healthcareservice.xml
+++ b/resources/au-healthcareservice.xml
@@ -15,7 +15,7 @@
       <use value="work" />
     </telecom>
   </contact>
-  <description value="Base profile for Australian context Healthcare Service" />
+  <description value="This profile defines a healthcare service administration details structure that includes core localisation concepts for use in an Australian context." />
   <fhirVersion value="3.0.1" />
   <kind value="resource" />
   <abstract value="false" />

--- a/resources/au-immunisation.xml
+++ b/resources/au-immunisation.xml
@@ -15,7 +15,7 @@
       <use value="work" />
     </telecom>
   </contact>
-  <description value="Immunisation record for Australian context" />
+  <description value="This profile defines an immunisation structure including core localisation concepts for use in an Australian context." />
   <fhirVersion value="3.0.1" />
   <kind value="resource" />
   <abstract value="false" />

--- a/resources/au-immunisationrecommendation.xml
+++ b/resources/au-immunisationrecommendation.xml
@@ -15,7 +15,7 @@
       <use value="work" />
     </telecom>
   </contact>
-  <description value="Base profile for Australian context immunisation recommendation." />
+  <description value="This profile defines an immunisation recommendation structure including core localisation concepts for use in an Australian context." />
   <fhirVersion value="3.0.1" />
   <kind value="resource" />
   <abstract value="false" />

--- a/resources/au-location.xml
+++ b/resources/au-location.xml
@@ -15,7 +15,7 @@
       <use value="work" />
     </telecom>
   </contact>
-  <description value="Base profile for Australian context Location" />
+  <description value="This profile defines a location administration details structure that includes core localisation concepts for use in an Australian context." />
   <fhirVersion value="3.0.0" />
   <kind value="resource" />
   <abstract value="false" />

--- a/resources/au-medication.xml
+++ b/resources/au-medication.xml
@@ -18,7 +18,7 @@
       <use value="work" />
     </telecom>
   </contact>
-  <description value="Medication record for Australian context" />
+  <description value="This profile defines a medication structure including core localisation concepts for use in an Australian context." />
   <fhirVersion value="3.0.1" />
   <kind value="resource" />
   <abstract value="false" />

--- a/resources/au-medicationadministration.xml
+++ b/resources/au-medicationadministration.xml
@@ -14,7 +14,7 @@
       <use value="work" />
     </telecom>
   </contact>
-  <description value="Medication administration record for Australian context" />
+  <description value="This profile defines a medication administration structure including core localisation concepts for use in an Australian context. " />
   <fhirVersion value="3.0.1" />
   <kind value="resource" />
   <abstract value="false" />

--- a/resources/au-medicationstatement.xml
+++ b/resources/au-medicationstatement.xml
@@ -15,7 +15,7 @@
       <use value="work" />
     </telecom>
   </contact>
-  <description value="Medication statement for Australian context" />
+  <description value="This profile defines a medication statement structure including core localisation concepts for use in an Australian context." />
   <fhirVersion value="3.0.1" />
   <kind value="resource" />
   <abstract value="false" />

--- a/resources/au-medlist.xml
+++ b/resources/au-medlist.xml
@@ -15,7 +15,7 @@
       <use value="work" />
     </telecom>
   </contact>
-  <description value="List of medications for Australian context" />
+  <description value="This profile defines a list structure including core localisation concepts for use as a medicines list in an Australian context. This profile is intended to offer a common structure and expectations to record, exchange, and fetch a list of medications associated with a patient in an Australian healthcare context." />
   <fhirVersion value="3.0.1" />
   <kind value="resource" />
   <abstract value="false" />

--- a/resources/au-norelevantfinding.xml
+++ b/resources/au-norelevantfinding.xml
@@ -14,7 +14,7 @@
       <use value="work" />
     </telecom>
   </contact>
-  <description value="Australian realm Observation profile for assertion of no relevant finding." />
+  <description value="This profile provides an observation information structure for asserting a clinical judgement that there are no items of specific interest, e.g. allergies, no medications, for a patient." />
   <fhirVersion value="3.0.1" />
   <kind value="resource" />
   <abstract value="false" />

--- a/resources/au-observation-age.xml
+++ b/resources/au-observation-age.xml
@@ -14,7 +14,7 @@
       <use value="work" />
     </telecom>
   </contact>
-  <description value="The chronological age or age range of a patient." />
+  <description value="This profile defines the chronological age or age range of a patient." />
   <copyright
     value="This resource includes SNOMED Clinical Terms™ (SNOMED CT®) which is used by permission of the International Health Terminology Standards Development Organisation (IHTSDO). All rights reserved. SNOMED CT®, was originally created by The College of American Pathologists. &quot;SNOMED&quot; and &quot;SNOMED CT&quot; are registered trademarks of the IHTSDO. The rights to use and implement or implementation of SNOMED CT content are limited to the extent it is necessary to allow for the end use of this material.  No further rights are granted in respect of the International Release and no further use of any SNOMED CT content by any other party is permitted. All copies of this resource must include this copyright statement and all information contained in this statement."/>
   <fhirVersion value="3.0.1" />

--- a/resources/au-organisation.xml
+++ b/resources/au-organisation.xml
@@ -15,7 +15,7 @@
       <use value="work" />
     </telecom>
   </contact>
-  <description value="Australian realm Organisation profile" />
+  <description value="This profile defines an organisation administration details structure that includes core localisation concepts for use in an Australian context." />
   <fhirVersion value="3.0.1" />
   <kind value="resource" />
   <abstract value="false" />

--- a/resources/au-patient.xml
+++ b/resources/au-patient.xml
@@ -15,7 +15,7 @@
       <use value="work" />
     </telecom>
   </contact>
-  <description value="Australian realm Patient profile" />
+  <description value="This profile defines a patient administration details structure that includes core localisation concepts for use in an Australian context." />
   <fhirVersion value="3.0.1" />
   <kind value="resource" />
   <abstract value="false" />

--- a/resources/au-pbs-sponsor.xml
+++ b/resources/au-pbs-sponsor.xml
@@ -15,7 +15,7 @@
       <use value="work" />
     </telecom>
   </contact>
-  <description value="Details of PBS sponsor organisation that is responsible for the supply of products listed." />
+  <description value="This extension applies to the Medication resource and is defining organisation administration details structure including core localisation concepts for use as a PBS sponsor in an Australian context. A PBS sponsor is an organisation with a PBS-assigned code responsible for the supply of medication." />
   <fhirVersion value="3.0.1" />
   <kind value="resource" />
   <abstract value="false" />

--- a/resources/au-practitioner.xml
+++ b/resources/au-practitioner.xml
@@ -15,7 +15,7 @@
       <use value="work" />
     </telecom>
   </contact>
-  <description value="Base profile for Australian context Practitioner" />
+  <description value="This profile defines a practitioner administration details structure that includes core localisation concepts for use in an Australian context." />
   <fhirVersion value="3.0.1" />
   <kind value="resource" />
   <abstract value="false" />

--- a/resources/au-practitionerrole.xml
+++ b/resources/au-practitionerrole.xml
@@ -15,7 +15,7 @@
       <use value="work" />
     </telecom>
   </contact>
-  <description value="Base profile for Australian context Practitioner Role (Individual Provider)" />
+  <description value="This profile defines a practitioner role administration details structure that includes core localisation concepts for use in an Australian context." />
   <fhirVersion value="3.0.1" />
   <kind value="resource" />
   <abstract value="false" />

--- a/resources/au-prescription.xml
+++ b/resources/au-prescription.xml
@@ -15,7 +15,7 @@
       <use value="work" />
     </telecom>
   </contact>
-  <description value="Prescription record for Australian context" />
+  <description value="This profile defines a medication request structure including core localisation concepts for use as a prescription in an Australian context." />
   <fhirVersion value="3.0.0" />
   <kind value="resource" />
   <abstract value="false" />

--- a/resources/au-relatedperson.xml
+++ b/resources/au-relatedperson.xml
@@ -18,7 +18,7 @@
       <use value="work" />
     </telecom>
   </contact>
-  <description value="Australian realm RelatedPerson resource" />
+  <description value="This profile defines a related person administration details structure that includes core localisation concepts for use in an Australian context." />
   <fhirVersion value="3.0.1" />
   <kind value="resource" />
   <abstract value="false" />

--- a/resources/au-specimen.xml
+++ b/resources/au-specimen.xml
@@ -22,7 +22,7 @@
       <use value="work"/>
     </telecom>
   </contact>
-  <description value="Australian realm Base Specimen profile."/>
+  <description value="This profile defines a specimen details structure that includes core localisation concepts for use in an Australian context."/>
   <fhirVersion value="3.0.1"/>
   <kind value="resource"/>
   <abstract value="false"/>

--- a/resources/structuredefinition-attester-related-party.xml
+++ b/resources/structuredefinition-attester-related-party.xml
@@ -15,7 +15,7 @@
       <use value="work" />
     </telecom>
   </contact>
-  <description value="A related person that attested this composition." />
+  <description value="This extension applies to the Composition resource and provides an extension for an attester who is a related person." />
   <fhirVersion value="3.0.1" />
   <kind value="complex-type" />
   <abstract value="false" />

--- a/resources/structuredefinition-au-assigningauthority.xml
+++ b/resources/structuredefinition-au-assigningauthority.xml
@@ -15,7 +15,7 @@
       <use value="work" />
     </telecom>
   </contact>
-  <description value="Values for routing HLV2 messages, useful for PRD-7 provider identifier." />
+  <description value="This extension defines a HL7v2 assigning authority value for HL7v2 identification for routing." />
   <fhirVersion value="3.0.1" />
   <kind value="complex-type" />
   <abstract value="false" />

--- a/resources/structuredefinition-au-receivingfacility.xml
+++ b/resources/structuredefinition-au-receivingfacility.xml
@@ -15,7 +15,7 @@
       <use value="work" />
     </telecom>
   </contact>
-  <description value="Values for routing HLV2 message payloads associated with an endpoint. Suitable for MSH-6." />
+  <description value="This extension defines a HL7v2 receiving facility value for HL7v2 routing purposes associated with an endpoint." />
   <fhirVersion value="3.0.0" />
   <kind value="complex-type" />
   <abstract value="false" />

--- a/resources/structuredefinition-author-role.xml
+++ b/resources/structuredefinition-author-role.xml
@@ -16,7 +16,7 @@
     </telecom>
   </contact>
   <description
-    value="Reference to practitioner role that authored the resource."/>
+    value="This extension pre-adopts (from R4) an author that is a practitioner role for use in DocumentReference and CarePlan."/>
   <fhirVersion value="3.0.1"/>
   <kind value="complex-type"/>
   <abstract value="false"/>

--- a/resources/structuredefinition-change-description.xml
+++ b/resources/structuredefinition-change-description.xml
@@ -15,7 +15,7 @@
       <use value="work" />
     </telecom>
   </contact>
-  <description value="Description of the change including reason for change." />
+  <description value="This extension applies to the List resource and provides a narrative description of the change to an item in a list entry. The narrative description may include the reason for the change to an item." />
   <fhirVersion value="3.0.1" />
   <kind value="complex-type" />
   <abstract value="false" />

--- a/resources/structuredefinition-closing-the-gap-registration.xml
+++ b/resources/structuredefinition-closing-the-gap-registration.xml
@@ -15,7 +15,7 @@
       <use value="work"/>
     </telecom>
   </contact>
-  <description value="Indicator flag for Closing the Gap registration eligibility for an Australian patient." />
+  <description value="This extension applies to the Patient resource and provides  an indicator of whether the patient is eligible for a Closing the Gap (CTG) co-payment." />
   <fhirVersion value="3.0.1" />
   <kind value="complex-type" />
   <abstract value="false" />

--- a/resources/structuredefinition-composition-author-role.xml
+++ b/resources/structuredefinition-composition-author-role.xml
@@ -16,7 +16,7 @@
     </telecom>
   </contact>
   <description
-    value="A practitioner role that authored this composition. This is not to be confused with who typed in the information."/>
+    value="This extension applies to the Composition resource and provides a practitioner role that authored this composition. This is not to be confused with who typed in the information."/>
   <fhirVersion value="3.0.1"/>
   <kind value="complex-type"/>
   <abstract value="false"/>

--- a/resources/structuredefinition-date-accuracy-indicator.xml
+++ b/resources/structuredefinition-date-accuracy-indicator.xml
@@ -15,7 +15,7 @@
       <use value="work"/>
     </telecom>
   </contact>
-  <description value="Coded date accuracy indicator for estimated and unknown date content." />
+  <description value="This extension applies to the Date or DateTime datatypes and indicates the asserted accuracy of the associated date via a coding." />
   <fhirVersion value="3.0.1" />
   <kind value="primitive-type" />
   <abstract value="false" />

--- a/resources/structuredefinition-dispense-number.xml
+++ b/resources/structuredefinition-dispense-number.xml
@@ -15,7 +15,7 @@
       <use value="work" />
     </telecom>
   </contact>
-  <description value="A numeric value that represents the dispense number or sequence number that has been reached for a therapeutic good prescribed with repeats. This count includes the first dispense. It has the value 1 when there are no repeats." />
+  <description value="This extension applies to the MedicationDispense resource and the value indicates the dispense number or sequence number that has been reached for a therapeutic good prescribed with repeats. It has the value 1 when there are no repeats. The value increments by one each time a dispense act is successfully completed." />
   <fhirVersion value="3.0.1" />
   <kind value="complex-type" />
   <abstract value="false" />

--- a/resources/structuredefinition-encounter-description.xml
+++ b/resources/structuredefinition-encounter-description.xml
@@ -15,7 +15,7 @@
       <use value="work"/>
     </telecom>
   </contact>
-  <description value="Narrative description of an encounter."/>
+  <description value="This extension applies to the Encounter resource and provides narrative about the healthcare event or encounter."/>
   <fhirVersion value="3.0.1"/>
   <kind value="complex-type"/>
   <abstract value="false"/>

--- a/resources/structuredefinition-encryption-certificate-pem-x509.xml
+++ b/resources/structuredefinition-encryption-certificate-pem-x509.xml
@@ -15,7 +15,7 @@
       <use value="work" />
     </telecom>
   </contact>
-  <description value="Mechanism to hold value of an X509 certificate in PEM format for encrypting." />
+  <description value="This extension is defined to support encrypting certficate content for use with an endpoint." />
   <fhirVersion value="3.0.1" />
   <kind value="complex-type" />
   <abstract value="false" />

--- a/resources/structuredefinition-grounds-for-concurrent-supply.xml
+++ b/resources/structuredefinition-grounds-for-concurrent-supply.xml
@@ -15,7 +15,8 @@
       <use value="work"/>
     </telecom>
   </contact>
-  <description value="Indicates the reason a pharmacist may or has supplied multiple repeats of a medication prescription at one time." />
+  <description value="This extension applies to MedicationRequest or MedicationDispense resources and the value indicates the reason a pharmacist
+    may or has supplied multiple repeats of a medication prescription at one time." />
   <fhirVersion value="3.0.1" />
   <kind value="complex-type" />
   <abstract value="false" />

--- a/resources/structuredefinition-healthcareservice-communication.xml
+++ b/resources/structuredefinition-healthcareservice-communication.xml
@@ -20,7 +20,7 @@
     <element id="Extension">
       <path value="Extension" />
       <short value="Healthcare service communication" />
-      <definition value="Communication languages support the healthcare service can provide" />
+      <definition value="Languages supported by a healthcare service." />
       <base>
         <path value="Element" />
         <min value="0" />

--- a/resources/structuredefinition-healthcareservice-eligibility-detail.xml
+++ b/resources/structuredefinition-healthcareservice-eligibility-detail.xml
@@ -15,7 +15,7 @@
       <use value="work"/>
     </telecom>
   </contact>
-  <description value="Extension to support multiple eligiblities"/>
+  <description value="This extension applies to the HealthcareService resource and allows enhanced eligibility status value for a healthcare service to be recorded."/>
   <fhirVersion value="3.0.1"/>
   <kind value="complex-type"/>
   <abstract value="false"/>

--- a/resources/structuredefinition-ihi-record-status.xml
+++ b/resources/structuredefinition-ihi-record-status.xml
@@ -15,7 +15,7 @@
       <use value="work"/>
     </telecom>
   </contact>
-  <description value="IHI record status extension." />
+  <description value="This IHI record status extension describes whether verification of the individual identifier has occurred and is based on the evidence available for a person’s identity." />
   <fhirVersion value="3.0.1" />
   <kind value="complex-type" />
   <abstract value="false" />

--- a/resources/structuredefinition-ihi-status.xml
+++ b/resources/structuredefinition-ihi-status.xml
@@ -15,7 +15,7 @@
       <use value="work"/>
     </telecom>
   </contact>
-  <description value="IHI number status extension." />
+  <description value="This IHI status extension describes the status of the associated IHI identifier and also indicates whether the status of the identifier is active or otherwise." />
   <fhirVersion value="3.0.1" />
   <kind value="complex-type" />
   <abstract value="false" />

--- a/resources/structuredefinition-indigenous-status.xml
+++ b/resources/structuredefinition-indigenous-status.xml
@@ -15,7 +15,7 @@
       <use value="work" />
     </telecom>
   </contact>
-  <description value="Administrative indigenous status for an Australian patient." />
+  <description value="This extension applies to the Patient resource and provides a coding for Australian indigenous status of the patient." />
   <purpose value="Recording an indigenous status for an Australian patient." />
   <fhirVersion value="3.0.1" />
   <kind value="complex-type" />

--- a/resources/structuredefinition-information-recipient.xml
+++ b/resources/structuredefinition-information-recipient.xml
@@ -15,7 +15,7 @@
       <use value="work" />
     </telecom>
   </contact>
-  <description value="A recipient who should receive a copy of the composition. A recipient is an entity to whom a copy of the composition is directed at the time of authoring of the composition." />
+  <description value="This extension applies to the Composition resource and allows recording of intended recipients of the composition." />
   <fhirVersion value="3.0.1" />
   <kind value="complex-type" />
   <abstract value="false" />

--- a/resources/structuredefinition-list-source-role.xml
+++ b/resources/structuredefinition-list-source-role.xml
@@ -15,7 +15,7 @@
       <use value="work" />
     </telecom>
   </contact>
-  <description value="A practitioner role that authored this list. This is the practitioner role responsible for deciding the contents of the list." />
+  <description value="This extension applies to the List resource and provides provides a practitioner role that authored this list. This is the practitioner role responsible for deciding the contents of the list. " />
   <fhirVersion value="3.0.1" />
   <kind value="complex-type" />
   <abstract value="false" />

--- a/resources/structuredefinition-medication-administration-witness.xml
+++ b/resources/structuredefinition-medication-administration-witness.xml
@@ -7,6 +7,15 @@
   <title value="Medication Administration Witness" />
   <status value="draft" />
   <date value="2018-11-14" />
+  <publisher value="Health Level Seven Australia (Medications WG)" />
+  <contact>
+    <telecom>
+      <system value="url" />
+      <value value="http://hl7.org.au/fhir" />
+      <use value="work" />
+    </telecom>
+  </contact>
+  <description value="This extension applies to the MedicationAdministration resource and provides a reference to a practitioner (perhaps in a role) that witnessed the administration of a medication." />
   <fhirVersion value="3.0.1" />
   <kind value="complex-type" />
   <abstract value="false" />

--- a/resources/structuredefinition-medication-batch-serialnumber.xml
+++ b/resources/structuredefinition-medication-batch-serialnumber.xml
@@ -15,7 +15,7 @@
       <use value="work" />
     </telecom>
   </contact>
-  <description value="An identifier assigned to a drug at the point of manufacturing and repackaging (at the package or pallet level), sufficient to facilitate the identification, validation, authentication, and tracking and tracking of drugs." />
+  <description value="This extension applies to the Medication resource and provides an identifier assigned to a drug at the time of manufacture." />
   <fhirVersion value="3.0.1" />
   <kind value="complex-type" />
   <abstract value="false" />

--- a/resources/structuredefinition-medication-brand-name.xml
+++ b/resources/structuredefinition-medication-brand-name.xml
@@ -15,6 +15,7 @@
       <use value="work" />
     </telecom>
   </contact>
+  <description value="This extension applies to the Medication, MedicationRequest, MedicationDispense amd MedicationStatement resources and provides text brand name of a medication." />
   <fhirVersion value="3.0.1" />
   <kind value="complex-type" />
   <abstract value="false" />

--- a/resources/structuredefinition-medication-generic-name.xml
+++ b/resources/structuredefinition-medication-generic-name.xml
@@ -15,6 +15,7 @@
       <use value="work" />
     </telecom>
   </contact>  
+  <description value="This extension applies to the Medication, MedicationRequest, MedicationDispense and MedicationStatement resources and provides generic name of a medication." />
   <fhirVersion value="3.0.1" />
   <kind value="complex-type" />
   <abstract value="false" />

--- a/resources/structuredefinition-medication-long-term.xml
+++ b/resources/structuredefinition-medication-long-term.xml
@@ -15,7 +15,7 @@
       <use value="work" />
     </telecom>
   </contact>
-  <description value="An indicator of whether the medication will be re-prescribed, re-dispensed, or re-administered, over a period of time." />
+  <description value="This extension applies to the MedicationStatement resource and provides an indicator of long term medication use." />
   <fhirVersion value="3.0.1" />
   <kind value="complex-type" />
   <abstract value="false" />

--- a/resources/structuredefinition-medication-strength-text.xml
+++ b/resources/structuredefinition-medication-strength-text.xml
@@ -7,6 +7,15 @@
   <title value="Medication Strength Text" />
   <status value="draft" />
   <date value="2018-11-14" />
+  <publisher value="Health Level Seven Australia (Medications WG)" />
+  <contact>
+    <telecom>
+      <system value="url" />
+      <value value="http://hl7.org.au/fhir" />
+      <use value="work" />
+    </telecom>
+  </contact>
+  <description value="This extension applies to the Medication resource and provides a textual representation of medication strength to support systems with limited atomic ingredient data support." />
   <fhirVersion value="3.0.1" />
   <kind value="complex-type" />
   <abstract value="false" />

--- a/resources/structuredefinition-medication-type.xml
+++ b/resources/structuredefinition-medication-type.xml
@@ -15,7 +15,8 @@
       <use value="work" />
     </telecom>
   </contact>
-  <description value="To indicate a classification of the type of medication." />
+  <description value="This extension applies to the Coding datatype and provides a value to indicate a classification of the type of medication the parent coding. This is useful
+    when there are multiple codings from the same CodingSystem at different levels/classifications." />
   <fhirVersion value="3.0.1" />
   <kind value="complex-type" />
   <abstract value="false" />

--- a/resources/structuredefinition-meta-source.xml
+++ b/resources/structuredefinition-meta-source.xml
@@ -15,6 +15,7 @@
       <use value="work" />
     </telecom>
   </contact>
+  <description value="This pre-adopts (from STU4) the Meta.source element which: Identifies where the resource comes from." />
   <fhirVersion value="3.0.1" />
   <kind value="complex-type" />
   <abstract value="false" />

--- a/resources/structuredefinition-minimum-interval-between-repeats.xml
+++ b/resources/structuredefinition-minimum-interval-between-repeats.xml
@@ -15,7 +15,7 @@
       <use value="work" />
     </telecom>
   </contact>  
-  <description value="Minimum time between dispensing repeats of medication." />
+  <description value="This extension applies to MedicationRequest resource and allows the definition of a duration indicating the minimum allowed time period between dispensing repeats." />
   <fhirVersion value="3.0.1" />
   <kind value="complex-type" />
   <abstract value="false" />

--- a/resources/structuredefinition-no-fixed-address.xml
+++ b/resources/structuredefinition-no-fixed-address.xml
@@ -15,7 +15,7 @@
       <use value="work"/>
     </telecom>
   </contact>
-  <description value="Indicator flag for no fixed address." />
+  <description value="This extension applies to the Address datatype and indicates that there is an assertion that there is no fixed address." />
   <fhirVersion value="3.0.1" />
   <kind value="complex-type" />
   <abstract value="false" />

--- a/resources/structuredefinition-pbs-sponsor.xml
+++ b/resources/structuredefinition-pbs-sponsor.xml
@@ -8,7 +8,7 @@
   <status value="draft" />
   <date value="2018-10-03" />
   <publisher value="Health Level Seven Australia (Medications WG)" />
-  <description value="Reference to the sponsor organisation that is responsible for the supply of the medicine." />
+  <description value="This extension applies to the Medication resource and is defining organisation administration details structure including core localisation concepts for use as a PBS sponsor in an Australian context. A PBS sponsor is an organisation with a PBS-assigned code responsible for the supply of medication." />
   <fhirVersion value="3.0.1" />
   <kind value="complex-type" />
   <abstract value="false" />

--- a/resources/structuredefinition-recorder-related-person.xml
+++ b/resources/structuredefinition-recorder-related-person.xml
@@ -14,7 +14,7 @@
       <use value="work" />
     </telecom>
   </contact>
-  <description value="Reference to related person that recorded the record and takes responsibility for its content." />
+  <description value="This pre-adopts (from STU4) a recorder who is a related person for the AllergyIntolerance resource intending to extend the set of referenceable resources to include a RelatedPerson for the recorder element. " />
   <fhirVersion value="3.0.1" />
   <kind value="complex-type" />
   <abstract value="false" />

--- a/resources/structuredefinition-recorder.xml
+++ b/resources/structuredefinition-recorder.xml
@@ -14,7 +14,7 @@
       <use value="work" />
     </telecom>
   </contact>
-  <description value="Reference to an individual who recorded the record and takes responsibility for its content." />
+  <description value="This pre-adopts (from R4) the recorder element for the Condition resource which identifies who recorded this record and is responsible for its content." />
   <fhirVersion value="3.0.1" />
   <kind value="complex-type" />
   <abstract value="false" />

--- a/resources/structuredefinition-section-author.xml
+++ b/resources/structuredefinition-section-author.xml
@@ -15,7 +15,7 @@
       <use value="work" />
     </telecom>
   </contact>
-  <description value="Identifies who is responsible for the information in this section, not necessarily who typed it in." />
+  <description value="This extension applies to the Composition resource and identifies who is responsible for the information in this section." />
   <fhirVersion value="3.0.1" />
   <kind value="complex-type" />
   <abstract value="false" />

--- a/resources/structuredefinition-shs-v1.xml
+++ b/resources/structuredefinition-shs-v1.xml
@@ -6,6 +6,14 @@
 	<name value="Shared Health Summary (discussion)"/>
 	<status value="draft"/>
 	<date value="2017-05-02T21:19:08.0657855+10:00"/>
+	<publisher value="Health Level Seven Australia (Patient Administration WG)" />
+	<contact>
+		<telecom>
+			<system value="url" />
+			<value value="http://hl7.org.au" />
+			<use value="work" />
+		</telecom>
+	</contact>
 	<description value="SHS example"/>
 	<fhirVersion value="3.0.1"/>
 	<kind value="resource"/>


### PR DESCRIPTION
A QA fix to the HL7 AU Base Implementation where all HL7 AU Base profile StructureDefinition.description were replaced by copying the applicable introductory sentence from the intro.md file, e.g. "This profile defines a patient administration details structure that includes core localisation concepts for use in an Australian context."