### PR TITLE
repair invalid FHIRPath in au-medlist invariant

### DIFF
--- a/resources/au-medlist.xml
+++ b/resources/au-medlist.xml
@@ -33,7 +33,7 @@
         <key value="inv-lst-0" />
         <severity value="error" />
         <human value="Source role and source shall not coexist" />
-        <expression value="(extension('http://hl7.org.au/fhir/StructureDefinition/list-source-role').exists() and source()).not()" />
+        <expression value="(extension('http://hl7.org.au/fhir/StructureDefinition/list-source-role').exists() and source.exists()).not()" />
       </constraint>
     </element>
     <element id="List.extension">


### PR DESCRIPTION
The FHIRPath error crashes the IG publisher when an example uses the profile.