### PR TITLE
HL7 AU extension associated healthcare service - fixed the valueReference to STU3 Healthcare Service

### DIFF
--- a/pages/_includes/associated-healthcareservice-summary.md
+++ b/pages/_includes/associated-healthcareservice-summary.md
@@ -1,4 +1,4 @@
 This profile contains the following variations from [Extension](http://hl7.org/fhir/STU3/Extension):
 
 1. <span style='color:green'> url </span> 
-   * <span style='color:green'> valueReference </span>  (Reference as: AU Base HealthcareService)
+   * <span style='color:green'> valueReference </span>  (Reference as: HealthcareService)

--- a/resources/structuredefinition-associated-healthcareservice.xml
+++ b/resources/structuredefinition-associated-healthcareservice.xml
@@ -42,7 +42,7 @@
       <min value="1"/>
       <type>
         <code value="Reference"/>
-        <targetProfile value="http://hl7.org.au/fhir/StructureDefinition/au-healthcareservice"/>
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/HealthcareService"/>
       </type>
     </element>
   </differential>


### PR DESCRIPTION
Hello Brett, 

Please accept the pull request to change the valueReference of HL7AU extension for associated health service to STU3 HealthCare Service.

Thanks, 
Uday