### PR TITLE
HL7 AU Performer Party - proposed extension

### DIFF
--- a/ig.json
+++ b/ig.json
@@ -140,7 +140,7 @@
             "base": "StructureDefinition-ihi-record-status.html",
             "defns": "StructureDefinition-ihi-record-status-definitions.html"
         },
-        "StructureDefinition/performer-partys": {
+        "StructureDefinition/performer-party": {
             "base": "StructureDefinition-performer-party.html",
             "defns": "StructureDefinition-performer-party-definitions.html"
         },

--- a/ig.json
+++ b/ig.json
@@ -140,6 +140,10 @@
             "base": "StructureDefinition-ihi-record-status.html",
             "defns": "StructureDefinition-ihi-record-status-definitions.html"
         },
+        "StructureDefinition/performer-partys": {
+            "base": "StructureDefinition-performer-party.html",
+            "defns": "StructureDefinition-performer-party-definitions.html"
+        },
         "StructureDefinition/no-fixed-address": {
             "base": "StructureDefinition-no-fixed-address.html",
             "defns": "StructureDefinition-no-fixed-address-definitions.html"

--- a/pages/_includes/extensions.md
+++ b/pages/_includes/extensions.md
@@ -17,6 +17,7 @@ Related to administration records such as patient, practitioner, practitioner ro
 * [Encounter Destination Organisation](StructureDefinition-encounter-destination-organisation.html) - Encounter hospitalization destination as an organisation (R4 preadopt)
 * [Associated Practitioner Role](StructureDefinition-associated-practitionerrole.html) - Associated practitioner role
 * [Associated Healthcare Service](StructureDefinition-associated-healthcareservice.html) - Healthcare service associated with a resource
+* [Performer Party](StructureDefinition-performer-party.html) - Performing practitioner role or care team (R4 preadopt)
 
 ## Medication
 * [Medication Type](StructureDefinition-medication-type.html) - drug code classification
@@ -63,3 +64,4 @@ Related to administration records such as patient, practitioner, practitioner ro
 * [Authoring Practitioner Role](StructureDefinition-author-role.html) - PractitonerRole support as per R4
 * [Encounter Origin Organisation](StructureDefinition-encounter-origin-organisation.html) - Encounter hospitalization origin as an organisation as per R4
 * [Encounter Destination Organisation](StructureDefinition-encounter-destination-organisation.html) - Encounter hospitalization destination as an organisation as per R4
+* [Performer Party](StructureDefinition-performer-party.html) - Performing practitioner role or care team as per R4

--- a/pages/_includes/performer-party-intro.md
+++ b/pages/_includes/performer-party-intro.md
@@ -1,4 +1,4 @@
-**Extension: Performing practitioner role or care team** *[[FMM Level 1](guidance.html)]*
+**Extension: Performing practitioner role or care team** *[[FMM Level 0](guidance.html)]*
 
 This extension applies to ProcedureRequest and DiagnosticReport, providing a practitioner role or care team who is responsible for the diagnostic report. 
 

--- a/pages/_includes/performer-party-intro.md
+++ b/pages/_includes/performer-party-intro.md
@@ -1,0 +1,5 @@
+**Extension: Performing practitioner role or care team** *[[FMM Level 1](guidance.html)]*
+
+This extension applies to ProcedureRequest and DiagnosticReport, providing a practitioner role or care team who is responsible for the diagnostic report. 
+
+This pre-adopts from R4 a performer who is a practitioner role or a care team for the ProcedureRequest and DiagnosticReport resource intending to extend the set of referenceable resources to include a PractitionerRole or CareTeam for the performer element.

--- a/pages/_includes/performer-party-search.md
+++ b/pages/_includes/performer-party-search.md
@@ -1,0 +1,1 @@
+none defined

--- a/resources/au-medication.xml
+++ b/resources/au-medication.xml
@@ -87,6 +87,12 @@
       <path value="Medication.code" />
       <short value="Coding for the medicine" />
       <definition value="Australian coding slices are typical medicine/product concept codes.&#xD;&#xA;&#xD;&#xA;A code (or set of codes) that specify this medication, or a textual description if no code is available. Usage note: This could be a standard medication code such as a code from RxNorm, SNOMED CT, IDMP etc. It could also be a national or local formulary code, optionally with translations to other code systems." />
+      <constraint>
+        <key value="inv-amt-tpp" />
+        <severity value="error" />
+        <human value="AMT TPP valueset membership required" />
+        <expression value="coding.where(system='http://snomed.info/sct' and extention.where(url='http://hl7.org.au/fhir/CodeSystem/medication-type').valueCoding='BPDSF').code in 'http://hl7.org.au/fhir/ValueSet/amt-tpp-codes'" />
+      </constraint>
     </element>
     <element id="Medication.code.coding">
       <path value="Medication.code.coding" />
@@ -148,7 +154,6 @@
     <element id="Medication.code.coding:amt.extension:medicationClass">
       <path value="Medication.code.coding.extension" />
       <sliceName value="medicationClass" />
-      <min value="0" />
       <max value="1" />
       <type>
         <code value="Extension" />

--- a/resources/au-medication.xml
+++ b/resources/au-medication.xml
@@ -154,6 +154,7 @@
     <element id="Medication.code.coding:amt.extension:medicationClass">
       <path value="Medication.code.coding.extension" />
       <sliceName value="medicationClass" />
+      <min value="0" />
       <max value="1" />
       <type>
         <code value="Extension" />

--- a/resources/ig.xml
+++ b/resources/ig.xml
@@ -420,6 +420,12 @@
     <resource>
       <example value="false"/>
       <sourceReference>
+        <reference value="StructureDefinition/performer-party"/>
+      </sourceReference>
+    </resource>
+    <resource>
+      <example value="false"/>
+      <sourceReference>
         <reference value="ValueSet/snomed-healthcareservice-services"/>
       </sourceReference>
     </resource>

--- a/resources/structuredefinition-performer-party.xml
+++ b/resources/structuredefinition-performer-party.xml
@@ -7,7 +7,7 @@
   <title value="Performer Party" />
   <status value="draft" />
   <date value="2019-05-01" />
-  <publisher value="Health Level Seven Australia (Patient Administration WG)" />
+  <publisher value="Health Level Seven Australia (Orders and Observations WG)" />
   <contact>
     <telecom>
       <system value="url" />
@@ -29,18 +29,7 @@
     <element id="Extension">
       <path value="Extension" />
       <short value="Performing practitioner role or care team" />
-      <definition value="Optional Extension Element - found in all resources." />
-      <constraint>
-        <key value="ext-1" />
-        <severity value="error" />
-        <human value="Must have either extensions or value[x], not both" />
-        <expression value="extension.exists() != value.exists()" />
-        <xpath value="exists(f:extension)!=exists(f:*[starts-with(local-name(.), 'value')])" />
-      </constraint>
-      <mapping>
-        <identity value="rim" />
-        <map value="N/A" />
-      </mapping>
+      <definition value="The performing party (care team or practitioner role) associated with the service, e.g the diagnostic service responsible for issuing the report or the desired performer for doing the requested service." />
     </element>
     <element id="Extension.url">
       <path value="Extension.url" />

--- a/resources/structuredefinition-performer-party.xml
+++ b/resources/structuredefinition-performer-party.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="performer-party" />
+  <url value="http://hl7.org.au/fhir/StructureDefinition/performer-party" />
+  <version value="1.0.0" />
+  <name value="PerformerParty" />
+  <title value="Performer Party" />
+  <status value="draft" />
+  <publisher value="Health Level Seven Australia (Patient Administration WG)" />
+  <contact>
+    <telecom>
+      <system value="url" />
+      <value value="http://hl7.org.au" />
+      <use value="work" />
+    </telecom>
+  </contact>
+  <description value="Reference to a performing practitioner role or care team." />
+  <fhirVersion value="3.0.1" />
+  <kind value="complex-type" />
+  <abstract value="false" />
+  <contextType value="resource" />
+  <context value="ProcedureRequest" />
+  <context value="DiagnosticReport" />
+  <type value="Extension" />
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Extension" />
+  <derivation value="constraint" />
+  <differential>
+    <element id="Extension">
+      <path value="Extension" />
+      <short value="Performing practitioner role or care team" />
+      <definition value="Optional Extension Element - found in all resources." />
+      <constraint>
+        <key value="ext-1" />
+        <severity value="error" />
+        <human value="Must have either extensions or value[x], not both" />
+        <expression value="extension.exists() != value.exists()" />
+        <xpath value="exists(f:extension)!=exists(f:*[starts-with(local-name(.), 'value')])" />
+      </constraint>
+      <mapping>
+        <identity value="rim" />
+        <map value="N/A" />
+      </mapping>
+    </element>
+    <element id="Extension.url">
+      <path value="Extension.url" />
+      <fixedUri value="http://hl7.org.au/fhir/StructureDefinition/performer-party" />
+    </element>
+    <element id="Extension.value[x]:valueReference">
+      <path value="Extension.valueReference" />
+      <sliceName value="valueReference" />
+      <min value="1" />
+      <type>
+        <code value="Reference" />
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/PractitionerRole" />
+      </type>
+      <type>
+        <code value="Reference" />
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/CareTeam" />
+      </type>
+    </element>
+  </differential>
+</StructureDefinition>

--- a/resources/structuredefinition-performer-party.xml
+++ b/resources/structuredefinition-performer-party.xml
@@ -15,7 +15,7 @@
       <use value="work" />
     </telecom>
   </contact>
-  <description value="Reference to a performing practitioner role or care team." />
+  <description value="This extension applies to ProcedureRequest and DiagnosticReport, providing a practitioner role or care team who is responsible for the diagnostic report." />
   <fhirVersion value="3.0.1" />
   <kind value="complex-type" />
   <abstract value="false" />

--- a/resources/structuredefinition-performer-party.xml
+++ b/resources/structuredefinition-performer-party.xml
@@ -2,10 +2,11 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="performer-party" />
   <url value="http://hl7.org.au/fhir/StructureDefinition/performer-party" />
-  <version value="1.0.0" />
+  <version value="0.1" />
   <name value="PerformerParty" />
   <title value="Performer Party" />
   <status value="draft" />
+  <date value="2019-05-01" />
   <publisher value="Health Level Seven Australia (Patient Administration WG)" />
   <contact>
     <telecom>


### PR DESCRIPTION
Hi Brett, 

Please accept the pull request in regards to a new extension for Performer Party with below brief description.

- url with fixed value "http://hl7.org.au/fhir/StructureDefinition/performer-party"

- Short: "Performing practitioner role or care team"

- definition: "The performing party (care team or practitioner role) associated with the service, e.g the diagnostic service responsible for issuing the report or the desired performer for doing the requested service."

- 1..1 valueReference  Reference (PractitionerRole | CareTeam)

Thanks, 
Uday