### PR TITLE
Add new profile - AU Base Diagnostic Observation (phase 1)

### DIFF
--- a/ig.json
+++ b/ig.json
@@ -400,6 +400,10 @@
             "base": "StructureDefinition-category-additional.html",
             "defns": "StructureDefinition-category-additional-definitions.html"
         },
+        "StructureDefinition/au-diagnosticobservation": {
+            "base": "StructureDefinition-au-diagnosticobservation.html",
+            "defns": "StructureDefinition-au-diagnosticobservation-definitions.html"
+        },
         "CodeSystem/medication-type": {
             "base": "CodeSystem-medication-type.html",
             "defns": "CodeSystem-medication-type-definitions.html"

--- a/pages/_includes/au-diagnosticobservation-intro.md
+++ b/pages/_includes/au-diagnosticobservation-intro.md
@@ -1,0 +1,12 @@
+**AU Base Diagnostic Observation**  *[[FMM Level 0](guidance.html)]*
+
+This profile defines an observation structure that includes core localisation concepts for use as a diagnostic result observation in an Australian context.
+
+Forthcoming work around this profile is expected to result in a value set representing the Standard for Pathology Informatics in Australia - Reporting codes bound as a slice on the code element.
+
+The body-site-instance extension may be used when a coded concept does not provide the necessary detail needed for the use case.
+
+#### Extensions
+Extensions used in this profile:
+* Observation: performer-party [<sup>[1]</sup>](http://build.fhir.org/ig/hl7au/au-fhir-base/StructureDefinition-performer-party.html)
+* Observation: body-site-instance [<sup>[1]</sup>](http://hl7.org/fhir/STU3/extension-body-site-instance.html)

--- a/pages/_includes/au-diagnosticobservation-search.md
+++ b/pages/_includes/au-diagnosticobservation-search.md
@@ -1,0 +1,2 @@
+none defined
+

--- a/pages/_includes/au-diagnosticobservation-summary.md
+++ b/pages/_includes/au-diagnosticobservation-summary.md
@@ -1,0 +1,3 @@
+This profile contains the following variations from [Observation](http://hl7.org/fhir/STU3/Observation):
+
+tbd

--- a/pages/_includes/au-diagnosticobservation-watermark.md
+++ b/pages/_includes/au-diagnosticobservation-watermark.md
@@ -1,0 +1,1 @@
+DRAFT<br/>ONLY

--- a/pages/_includes/profiles.md
+++ b/pages/_includes/profiles.md
@@ -32,6 +32,7 @@ These Profiles have been defined for this implementation guide.
 * [AU Base Head Circumference](StructureDefinition-au-headcircum.html) - observation of head circumference
 * [AU Base Specimen](StructureDefinition-au-specimen.html) - specimen details with local coding
 * [AU Assertion of No Relevant Finding](StructureDefinition-au-norelevantfinding.html) - observation with assertion of no relevant finding
+* [AU Base Diagnostic Observation](StructureDefinition-au-diagnosticobservation.html) - observation for diagnostic reporting
 
 ## Clinical Profiles
 * [AU Base Condition](StructureDefinition-au-condition.html) - condition with local coding for clinical condition, body site and clinical finding.

--- a/resources/au-diagnosticobservation.xml
+++ b/resources/au-diagnosticobservation.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="utf-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="au-diagnosticobservation" />
+  <url value="http://hl7.org.au/fhir/StructureDefinition/au-diagnosticobservation" />
+  <version value="1.0.0" />
+  <name value="AUBaseDiagnosticObservation" />
+  <title value="AU Base Diagnostic Observation" />
+  <status value="draft" />
+  <date value="2019-05-20" />
+  <publisher value="Health Level Seven Australia (Orders and Observations WG)" />
+  <contact>
+    <telecom>
+      <system value="url" />
+      <value value="http://hl7.org.au/fhir" />
+      <use value="work" />
+    </telecom>
+  </contact>
+  <description value="This profile defines an observation structure that includes core localisation concepts for use as a diagnostic result observation in an Australian context." />
+  <fhirVersion value="3.0.1" />
+  <kind value="resource" />
+  <abstract value="false" />
+  <type value="Observation" />
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Observation" />
+  <derivation value="constraint" />
+  <differential>
+    <element id="Observation">
+      <path value="Observation" />
+      <short value="An observation for diagnostic reporting in an Australian healthcare context" />
+    </element>
+    <element id="Observation.extension">
+      <path value="Observation.extension" />
+      <slicing>
+        <discriminator>
+          <type value="value" />
+          <path value="url" />
+        </discriminator>
+        <rules value="open" />
+      </slicing>
+    </element>
+    <element id="Observation.extension:performerParty">
+      <path value="Observation.extension" />
+      <sliceName value="performerParty" />
+      <type>
+        <code value="Extension" />
+        <profile value="http://hl7.org.au/fhir/StructureDefinition/performer-party" />
+      </type>
+    </element>
+    <element id="Observation.extension:bodySiteInstance">
+      <path value="Observation.extension" />
+      <sliceName value="bodySiteInstance" />
+      <max value="1"/>
+      <type>
+        <code value="Extension" />
+        <profile value="http://hl7.org/fhir/StructureDefinition/body-site-instance" />
+      </type>
+    </element>
+    <element id="Observation.code">
+      <path value="Observation.code"/>
+    </element>
+    <element id="Observation.code.coding">
+      <path value="Observation.code.coding" />
+      <slicing>
+        <discriminator>
+          <type value="value" />
+          <path value="system" />
+        </discriminator>
+        <rules value="open" />
+      </slicing>
+    </element>
+    <element id="Observation.code.coding:snomedImagingProcedure">
+      <path value="Observation.code.coding" />
+      <sliceName value="snomedImagingProcedure" />
+      <short value="Imaging Procedure (SNOMED CT)" />
+      <max value="1" />
+      <binding>
+        <strength value="required" />
+        <valueSetUri value="https://healthterminologies.gov.au/fhir/ValueSet/imaging-procedure-1" />
+      </binding>
+    </element>
+    <element id="Observation.specimen">
+      <path value="Observation.specimen" />
+      <type>
+        <code value="Reference" />
+        <targetProfile value="http://hl7.org.au/fhir/StructureDefinition/au-specimen" />
+      </type>
+    </element>
+  </differential>
+</StructureDefinition>

--- a/resources/core-extensions/extension-body-site-instance.xml
+++ b/resources/core-extensions/extension-body-site-instance.xml
@@ -1,0 +1,186 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="body-site-instance"/>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-wg">
+    <valueCode value="fhir"/>
+  </extension>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
+    <valueInteger value="1"/>
+  </extension>
+  <url value="http://hl7.org/fhir/StructureDefinition/body-site-instance"/>
+  <name value="Body Site Instance"/>
+  <status value="draft"/>
+  <date value="2013-12-05"/>
+  <publisher value="Health Level Seven International (FHIR Infrastructure)"/>
+  <contact>
+    <telecom>
+      <system value="url"/>
+      <value value="http://www.hl7.org/Special/committees/fiwg"/>
+    </telecom>
+  </contact>
+  <description value="Record details about the anatomical location of a specimen or body part. This resource may be used when a coded concept does not provide the necessary detail needed for the use case."/>
+  <fhirVersion value="3.0.1"/>
+  <mapping>
+    <identity value="rim"/>
+    <uri value="http://hl7.org/v3"/>
+    <name value="RIM Mapping"/>
+  </mapping>
+  <kind value="complex-type"/>
+  <abstract value="false"/>
+  <contextType value="resource"/>
+  <context value="*"/>
+  <type value="Extension"/>
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Extension"/>
+  <derivation value="constraint"/>
+  <snapshot>
+    <element id="Extension">
+      <path value="Extension"/>
+      <short value="Target anatomic location or structure"/>
+      <definition value="Record details about the anatomical location of a specimen or body part. This resource may be used when a coded concept does not provide the necessary detail needed for the use case."/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="Extension"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
+      <condition value="ele-1"/>
+      <constraint>
+        <key value="ele-1"/>
+        <severity value="error"/>
+        <human value="All FHIR elements must have a @value or children"/>
+        <expression value="hasValue() | (children().count() &gt; id.count())"/>
+        <xpath value="@value|f:*|h:div"/>
+        <source value="Element"/>
+      </constraint>
+      <constraint>
+        <key value="ext-1"/>
+        <severity value="error"/>
+        <human value="Must have either extensions or value[x], not both"/>
+        <expression value="extension.exists() != value.exists()"/>
+        <xpath value="exists(f:extension)!=exists(f:*[starts-with(local-name(.), &#39;value&#39;)])"/>
+        <source value="Extension"/>
+      </constraint>
+    </element>
+    <element id="Extension.id">
+      <path value="Extension.id"/>
+      <representation value="xmlAttr"/>
+      <short value="xml:id (or equivalent in JSON)"/>
+      <definition value="unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces."/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="Element.id"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="string"/>
+      </type>
+      <mapping>
+        <identity value="rim"/>
+        <map value="n/a"/>
+      </mapping>
+    </element>
+    <element id="Extension.extension">
+      <path value="Extension.extension"/>
+      <slicing>
+        <discriminator>
+          <type value="value"/>
+          <path value="url"/>
+        </discriminator>
+        <description value="Extensions are always sliced by (at least) url"/>
+        <rules value="open"/>
+      </slicing>
+      <short value="Additional Content defined by implementations"/>
+      <definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension."/>
+      <comment value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone."/>
+      <alias value="extensions"/>
+      <alias value="user content"/>
+      <min value="0"/>
+      <max value="*"/>
+      <base>
+        <path value="Element.extension"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
+      <type>
+        <code value="Extension"/>
+      </type>
+      <mapping>
+        <identity value="rim"/>
+        <map value="n/a"/>
+      </mapping>
+    </element>
+    <element id="Extension.url">
+      <path value="Extension.url"/>
+      <representation value="xmlAttr"/>
+      <short value="identifies the meaning of the extension"/>
+      <definition value="Source of the definition for the extension code - a logical name or a URL."/>
+      <comment value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition SHALL be a URI for the Structure Definition defining the extension."/>
+      <min value="1"/>
+      <max value="1"/>
+      <base>
+        <path value="Extension.url"/>
+        <min value="1"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="uri"/>
+      </type>
+      <fixedUri value="http://hl7.org/fhir/StructureDefinition/body-site-instance"/>
+      <mapping>
+        <identity value="rim"/>
+        <map value="N/A"/>
+      </mapping>
+    </element>
+    <element id="Extension.valueReference">
+      <path value="Extension.valueReference"/>
+      <short value="Value of extension"/>
+      <definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)."/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="Extension.value[x]"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="Reference"/>
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/BodySite"/>
+      </type>
+      <mapping>
+        <identity value="rim"/>
+        <map value="N/A"/>
+      </mapping>
+    </element>
+  </snapshot>
+  <differential>
+    <element id="Extension">
+      <path value="Extension"/>
+      <short value="Target anatomic location or structure"/>
+      <definition value="Record details about the anatomical location of a specimen or body part. This resource may be used when a coded concept does not provide the necessary detail needed for the use case."/>
+      <min value="0"/>
+      <max value="1"/>
+    </element>
+    <element id="Extension.extension">
+      <path value="Extension.extension"/>
+      <max value="0"/>
+    </element>
+    <element id="Extension.url">
+      <path value="Extension.url"/>
+      <type>
+        <code value="uri"/>
+      </type>
+      <fixedUri value="http://hl7.org/fhir/StructureDefinition/body-site-instance"/>
+    </element>
+    <element id="Extension.valueReference">
+      <path value="Extension.valueReference"/>
+      <type>
+        <code value="Reference"/>
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/BodySite"/>
+      </type>
+    </element>
+  </differential>
+</StructureDefinition>

--- a/resources/ig.xml
+++ b/resources/ig.xml
@@ -1305,6 +1305,13 @@
         <reference value="StructureDefinition/au-encounter"/>
       </sourceReference>
     </resource>
+    <resource>
+      <example value="false"/>
+      <name value="AU Base Diagnostic Observation"/>
+      <sourceReference>
+        <reference value="StructureDefinition/au-diagnosticobservation"/>
+      </sourceReference>
+    </resource>
   </package>
   <page>
     <source value="index.html"/>


### PR DESCRIPTION
Hi Brett, 

New profile for Diagnostic Observation added with its usual complement of supporting file and file changes.

A copy of the STU3 body-site-instance extension has been added into the resources/core-extensions folder, in line with other extensions.

Note there is a pending change for this profile to add another slice on Observation.code.coding for Standards for Pathology Informatics in Australia - Test Result (LOINC) - this is awaiting NCTS development.

Cheers
Rob