### PR TITLE
Add new profile -Au Base Diagnostic ProcedureRequest phase 1

### DIFF
--- a/ig.json
+++ b/ig.json
@@ -99,10 +99,10 @@
             "template-format": "ex-format.html"
         },
         "Observation": {
-		        "template-base": "ex.html",
-		        "template-format": "ex-format.html"
-	      }
-	   },
+            "template-base": "ex.html",
+            "template-format": "ex-format.html"
+        }
+    },
     "tool": "jekyll",
     "license": "CC0-1.0",
     "canonicalBase": "http://hl7.org.au/fhir",
@@ -254,12 +254,12 @@
         },
         "StructureDefinition/au-observation-age": {
             "base": "StructureDefinition-au-observation-age.html",
-             "defns": "StructureDefinition-au-observation-age-definitions.html"           
-         },
-         "StructureDefinition/au-norelevantfinding": {
+            "defns": "StructureDefinition-au-observation-age-definitions.html"
+        },
+        "StructureDefinition/au-norelevantfinding": {
             "base": "StructureDefinition-au-norelevantfinding.html",
-             "defns": "StructureDefinition-au-norelevantfinding-definitions.html"           
-         },
+            "defns": "StructureDefinition-au-norelevantfinding-definitions.html"
+        },
         "StructureDefinition/au-patient": {
             "base": "StructureDefinition-au-patient.html",
             "defns": "StructureDefinition-au-patient-definitions.html"
@@ -376,15 +376,15 @@
             "base": "StructureDefinition-encounter-origin-organisation.html",
             "defns": "StructureDefinition-encounter-origin-organisation-definitions.html"
         },
-		"StructureDefinition/encounter-destination-organisation": {
+        "StructureDefinition/encounter-destination-organisation": {
             "base": "StructureDefinition-encounter-destination-organisation.html",
             "defns": "StructureDefinition-encounter-destination-organisation-definitions.html"
         },
-		"StructureDefinition/associated-practitionerrole": {
+        "StructureDefinition/associated-practitionerrole": {
             "base": "StructureDefinition-associated-practitionerrole.html",
             "defns": "StructureDefinition-associated-practitionerrole-definitions.html"
         },
-		"StructureDefinition/encounter-description": {
+        "StructureDefinition/encounter-description": {
             "base": "StructureDefinition-encounter-description.html",
             "defns": "StructureDefinition-encounter-description-definitions.html"
         },
@@ -399,6 +399,10 @@
         "StructureDefinition/category-additional": {
             "base": "StructureDefinition-category-additional.html",
             "defns": "StructureDefinition-category-additional-definitions.html"
+        },
+        "StructureDefinition/au-diagnosticprocedurerequest": {
+            "base": "StructureDefinition-au-diagnosticprocedurerequest.html",
+            "defns": "StructureDefinition-au-diagnosticprocedurerequest-definitions.html"
         },
         "CodeSystem/medication-type": {
             "base": "CodeSystem-medication-type.html",
@@ -495,20 +499,20 @@
         "ValueSet/pbs-item": {
             "base": "ValueSet-pbs-item.html",
             "defns": "ValueSet-pbs-item-definitions.html"
-            },
+        },
         "CodeSystem/medicine-item-change": {
             "base": "CodeSystem-medicine-item-change.html",
             "defns": "CodeSystem-medicine-item-change-definitions.html"
-            },
+        },
         "ValueSet/medicine-item-change": {
             "base": "ValueSet-medicine-item-change.html",
             "defns": "ValueSet-medicine-item-change-definitions.html"
-            },
+        },
         "ValueSet/snomed-healthcareservice-services": {
             "base": "ValueSet-snomed-healthcareservice-services.html",
             "defns": "ValueSet-snomed-healthcareservice-services-definitions.html"
-			},
-		"ValueSet/snomed-healthcareservice-roles": {
+        },
+        "ValueSet/snomed-healthcareservice-roles": {
             "base": "ValueSet-snomed-healthcareservice-roles.html",
             "defns": "ValueSet-snomed-healthcareservice-roles-definitions.html"
         }

--- a/pages/_includes/au-diagnosticprocedurerequest-intro.md
+++ b/pages/_includes/au-diagnosticprocedurerequest-intro.md
@@ -2,9 +2,9 @@
 
 This profile defines a procedure request structure that includes core localisation concepts for use in an Australian context.
 
-Note:  The targetBodyStructure extensions is only used if not implicit in the code found in ProcedureRequest.code. If the use case requires BodySite to be handled as a separate resource instead of an inline coded element (e.g. to identify and track separately) then use the standard extension procedure-targetBodyStructure. 
+Note:  The targetBodyStructure extensions is only used if not implicit in the code found in ProcedureRequest.code. If the use case requires BodySite to be handled as a separate resource instead of an inline coded element (e.g. to identify and track separately) then use the standard extension [procedurerequest-targetBodyStructure](http://hl7.org/fhir/STU3/extension-procedurerequest-targetbodysite.html). 
 
-Forthcoming work around this profile is expected to result in a value set representing the Standard for Pathology Informatics in Australia - Requesting codes bound as a slice on the code element in addition to the existing slice for diagnostic imaging requests in SNOMED CT<sup>[TM]</sup>.
+Forthcoming work around this profile is expected to result in a value set representing the Standard for Pathology Informatics in Australia - Requesting codes bound as a slice on the code element in addition to the existing slice for diagnostic imaging requests in SNOMED CT<sup>TM</sup>.
 
 #### Identifiers
 These definitions represent common data held in the ProcedureRequest.identifier element:

--- a/pages/_includes/au-diagnosticprocedurerequest-intro.md
+++ b/pages/_includes/au-diagnosticprocedurerequest-intro.md
@@ -1,8 +1,8 @@
-**AU Base Diagnostic Procedure Request Profile** *[[FMM Level 0](guidance.html)]*
+**AU Base Diagnostic Procedure Request** *[[FMM Level 0](guidance.html)]*
 
-This profile defines a procedure request structure that includes core localisation concepts for use in an Australian context.
+This profile defines a procedure request structure that includes core localisation concepts for use in diagnostic procedure request in an Australian context.
 
-Note:  The targetBodyStructure extensions is only used if not implicit in the code found in ProcedureRequest.code. If the use case requires BodySite to be handled as a separate resource instead of an inline coded element (e.g. to identify and track separately) then use the standard extension [procedurerequest-targetBodyStructure](http://hl7.org/fhir/STU3/extension-procedurerequest-targetbodysite.html). 
+Note: The targetBodyStructure extension should only be used if not implicit in the code found in ProcedureRequest.code. If the use case requires BodySite to be handled as a separate resource instead of an inline coded element (e.g. to identify and track separately) then use the standard extension [procedurerequest-targetBodyStructure](http://hl7.org/fhir/STU3/extension-procedurerequest-targetbodysite.html). 
 
 Forthcoming work around this profile is expected to result in a value set representing the Standard for Pathology Informatics in Australia - Requesting codes bound as a slice on the code element in addition to the existing slice for diagnostic imaging requests in SNOMED CT<sup>TM</sup>.
 
@@ -13,5 +13,5 @@ These definitions represent common data held in the ProcedureRequest.identifier 
 #### Extensions
 Extensions used in this profile:
 * ProcedureRequest: performer-party [<sup>[1]</sup>](http://build.fhir.org/ig/hl7au/au-fhir-base/StructureDefinition-performer-party.html)
-* ProcedureRequest: targetBodySite [<sup>[1]</sup>](http://hl7.org/fhir/STU3/extension-procedurerequest-targetbodysite.html)
+* ProcedureRequest: procedurerequest-targetBodyStructure [<sup>[1]</sup>](http://hl7.org/fhir/STU3/extension-procedurerequest-targetbodysite.html)
 <!-- * ProcedureRequest: patientInstruction [<sup>[1]</sup>](http://hl7.org/fhir/4.0/StructureDefinition/extension-ServiceRequest.patientInstruction.html)  -->

--- a/pages/_includes/au-diagnosticprocedurerequest-intro.md
+++ b/pages/_includes/au-diagnosticprocedurerequest-intro.md
@@ -1,8 +1,8 @@
 **AU Base Diagnostic Procedure Request** *[[FMM Level 0](guidance.html)]*
 
-This profile defines a procedure request structure that includes core localisation concepts for use in diagnostic procedure request in an Australian context.
+This profile defines a procedure request structure that includes core localisation concepts for use as a diagnostic procedure request in an Australian context.
 
-Note: The targetBodyStructure extension should only be used if not implicit in the code found in ProcedureRequest.code. If the use case requires BodySite to be handled as a separate resource instead of an inline coded element (e.g. to identify and track separately) then use the standard extension [procedurerequest-targetBodyStructure](http://hl7.org/fhir/STU3/extension-procedurerequest-targetbodysite.html). 
+Note: The targetBodyStructure extension should only be used if not implicit in the code found in ProcedureRequest.code. If the use case requires BodySite to be handled as a separate resource instead of an inline coded element (e.g. to identify and track separately) then use the standard extension [procedurerequest-targetBodySite](http://hl7.org/fhir/STU3/extension-procedurerequest-targetbodysite.html). 
 
 Forthcoming work around this profile is expected to result in a value set representing the Standard for Pathology Informatics in Australia - Requesting codes bound as a slice on the code element in addition to the existing slice for diagnostic imaging requests in SNOMED CT<sup>TM</sup>.
 
@@ -13,5 +13,5 @@ These definitions represent common data held in the ProcedureRequest.identifier 
 #### Extensions
 Extensions used in this profile:
 * ProcedureRequest: performer-party [<sup>[1]</sup>](http://build.fhir.org/ig/hl7au/au-fhir-base/StructureDefinition-performer-party.html)
-* ProcedureRequest: procedurerequest-targetBodyStructure [<sup>[1]</sup>](http://hl7.org/fhir/STU3/extension-procedurerequest-targetbodysite.html)
+* ProcedureRequest: procedurerequest-targetBodySite [<sup>[1]</sup>](http://hl7.org/fhir/STU3/extension-procedurerequest-targetbodysite.html)
 <!-- * ProcedureRequest: patientInstruction [<sup>[1]</sup>](http://hl7.org/fhir/4.0/StructureDefinition/extension-ServiceRequest.patientInstruction.html)  -->

--- a/pages/_includes/au-diagnosticprocedurerequest-intro.md
+++ b/pages/_includes/au-diagnosticprocedurerequest-intro.md
@@ -1,0 +1,17 @@
+**AU Base Diagnostic Procedure Request Profile** *[[FMM Level 0](guidance.html)]*
+
+This profile defines a procedure request structure that includes core localisation concepts for use in an Australian context.
+
+Note:  The targetBodyStructure extensions is only used if not implicit in the code found in ProcedureRequest.code. If the use case requires BodySite to be handled as a separate resource instead of an inline coded element (e.g. to identify and track separately) then use the standard extension procedure-targetBodyStructure. 
+
+Forthcoming work around this profile is expected to result in a value set representing the Standard for Pathology Informatics in Australia - Requesting codes bound as a slice on the code element in addition to the existing slice for diagnostic imaging requests in SNOMED CT<sup>[TM]</sup>.
+
+#### Identifiers
+These definitions represent common data held in the ProcedureRequest.identifier element:
+* Placer order number [<sup>[1]</sup>](https://confluence.hl7australia.com/display/OOADRM20181/5+Observation+Ordering#id-5ObservationOrdering-5.4.1.2ORC-2Placerordernumber(EI)00216)
+
+#### Extensions
+Extensions used in this profile:
+* ProcedureRequest: performer-party [<sup>[1]</sup>](http://build.fhir.org/ig/hl7au/au-fhir-base/StructureDefinition-performer-party.html)
+* ProcedureRequest: targetBodySite [<sup>[1]</sup>](http://hl7.org/fhir/STU3/extension-procedurerequest-targetbodysite.html)
+<!-- * ProcedureRequest: patientInstruction [<sup>[1]</sup>](http://hl7.org/fhir/4.0/StructureDefinition/extension-ServiceRequest.patientInstruction.html)  -->

--- a/pages/_includes/au-diagnosticprocedurerequest-intro.md
+++ b/pages/_includes/au-diagnosticprocedurerequest-intro.md
@@ -2,7 +2,7 @@
 
 This profile defines a procedure request structure that includes core localisation concepts for use as a diagnostic procedure request in an Australian context.
 
-Note: The targetBodyStructure extension should only be used if not implicit in the code found in ProcedureRequest.code. If the use case requires BodySite to be handled as a separate resource instead of an inline coded element (e.g. to identify and track separately) then use the standard extension [procedurerequest-targetBodySite](http://hl7.org/fhir/STU3/extension-procedurerequest-targetbodysite.html). 
+Note: The targetBodySite extension should only be used if not implicit in the code found in ProcedureRequest.code. If the use case requires BodySite to be handled as a separate resource instead of an inline coded element (e.g. to identify and track separately) then use the standard extension [procedurerequest-targetBodySite](http://hl7.org/fhir/STU3/extension-procedurerequest-targetbodysite.html). 
 
 Forthcoming work around this profile is expected to result in a value set representing the Standard for Pathology Informatics in Australia - Requesting codes bound as a slice on the code element in addition to the existing slice for diagnostic imaging requests in SNOMED CT<sup>TM</sup>.
 

--- a/pages/_includes/au-diagnosticprocedurerequest-search.md
+++ b/pages/_includes/au-diagnosticprocedurerequest-search.md
@@ -1,0 +1,2 @@
+none defined
+

--- a/pages/_includes/au-diagnosticprocedurerequest-summary.md
+++ b/pages/_includes/au-diagnosticprocedurerequest-summary.md
@@ -1,0 +1,3 @@
+This profile contains the following variations from [ProcedureRequest](http://hl7.org/fhir/STU3/ProcedureRequest):
+
+tbd

--- a/pages/_includes/au-diagnosticprocedurerequest-watermark.md
+++ b/pages/_includes/au-diagnosticprocedurerequest-watermark.md
@@ -1,0 +1,1 @@
+DRAFT<br/>ONLY

--- a/pages/_includes/profiles.md
+++ b/pages/_includes/profiles.md
@@ -32,6 +32,7 @@ These Profiles have been defined for this implementation guide.
 * [AU Base Head Circumference](StructureDefinition-au-headcircum.html) - observation of head circumference
 * [AU Base Specimen](StructureDefinition-au-specimen.html) - specimen details with local coding
 * [AU Assertion of No Relevant Finding](StructureDefinition-au-norelevantfinding.html) - observation with assertion of no relevant finding
+* [AU Base Diagnostic Procedure Request](StructureDefinition-au-diagnosticprocedurerequest.html) - diagnostic procedure request with localisation concepts
 
 ## Clinical Profiles
 * [AU Base Condition](StructureDefinition-au-condition.html) - condition with local coding for clinical condition, body site and clinical finding.

--- a/resources/au-diagnosticprocedurerequest.xml
+++ b/resources/au-diagnosticprocedurerequest.xml
@@ -128,10 +128,11 @@
         <rules value="open" />
       </slicing>
     </element>
-    <element id="ProcedureRequest.code.coding:snomedImagingProcedures">
+    <element id="ProcedureRequest.code.coding:snomedImagingProcedure">
       <path value="ProcedureRequest.code.coding" />
-      <sliceName value="snomedImagingProcedures" />
+      <sliceName value="snomedImagingProcedure" />
       <short value="Imaging Procedure (SNOMED CT)" />
+      <max value="1"/>
       <binding>
         <strength value="required" />
         <valueSetUri value="https://healthterminologies.gov.au/fhir/ValueSet/imaging-procedure-1" />

--- a/resources/au-diagnosticprocedurerequest.xml
+++ b/resources/au-diagnosticprocedurerequest.xml
@@ -137,6 +137,9 @@
         <valueSetUri value="https://healthterminologies.gov.au/fhir/ValueSet/imaging-procedure-1" />
       </binding>
     </element>
+    <element id="ProcedureRequest.performerType">
+      <path value="ProcedureRequest.performerType"/>
+    </element>
     <element id="ProcedureRequest.performerType.coding">
       <path value="ProcedureRequest.performerType.coding" />
       <slicing>

--- a/resources/au-diagnosticprocedurerequest.xml
+++ b/resources/au-diagnosticprocedurerequest.xml
@@ -131,7 +131,7 @@
     <element id="ProcedureRequest.code.coding:snomedImagingProcedures">
       <path value="ProcedureRequest.code.coding" />
       <sliceName value="snomedImagingProcedures" />
-      <short value="Diagnostic Imaging Procedures (SNOMED CT)" />
+      <short value="Imaging Procedure (SNOMED CT)" />
       <binding>
         <strength value="required" />
         <valueSetUri value="https://healthterminologies.gov.au/fhir/ValueSet/imaging-procedure-1" />

--- a/resources/au-diagnosticprocedurerequest.xml
+++ b/resources/au-diagnosticprocedurerequest.xml
@@ -97,7 +97,7 @@
       <min value="1" />
       <max value="1" />
       <patternCoding>
-        <system value="http://hl7.org.au/fhir/v2/0203" />
+        <system value="http://hl7.org/fhir/identifier-type" />
         <code value="PLAC" />
       </patternCoding>
     </element>

--- a/resources/au-diagnosticprocedurerequest.xml
+++ b/resources/au-diagnosticprocedurerequest.xml
@@ -14,7 +14,7 @@
       <use value="work" />
     </telecom>
   </contact>
-  <description value="This profile defines a procedure request structure that includes core localisation concepts for use in diagnostic procedure request in an Australian context." />
+  <description value="This profile defines a procedure request structure that includes core localisation concepts for use as a diagnostic procedure request in an Australian context." />
   <fhirVersion value="3.0.1" />
   <kind value="resource" />
   <abstract value="false" />

--- a/resources/au-diagnosticprocedurerequest.xml
+++ b/resources/au-diagnosticprocedurerequest.xml
@@ -14,7 +14,7 @@
       <use value="work" />
     </telecom>
   </contact>
-  <description value="This profile defines a procedure request structure that includes core localisation concepts for use in an Australian context." />
+  <description value="This profile defines a procedure request structure that includes core localisation concepts for use in diagnostic procedure request in an Australian context." />
   <fhirVersion value="3.0.1" />
   <kind value="resource" />
   <abstract value="false" />
@@ -24,7 +24,7 @@
   <differential>
     <element id="ProcedureRequest">
       <path value="ProcedureRequest" />
-      <short value="A procedure request in an Australian healthcare context" />
+      <short value="A diagnostic procedure request in an Australian healthcare context" />
     </element>
     <element id="ProcedureRequest.extension:performerParty">
       <path value="ProcedureRequest.extension" />
@@ -62,10 +62,6 @@
         <discriminator>
           <type value="pattern" />
           <path value="type" />
-        </discriminator>
-        <discriminator>
-          <type value="value" />
-          <path value="system" />
         </discriminator>
         <rules value="open" />
       </slicing>

--- a/resources/core-extensions/extension-procedurerequest-targetbodysite.xml
+++ b/resources/core-extensions/extension-procedurerequest-targetbodysite.xml
@@ -1,0 +1,187 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="procedurerequest-targetBodySite"/>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-wg">
+    <valueCode value="oo"/>
+  </extension>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
+    <valueInteger value="1"/>
+  </extension>
+  <url value="http://hl7.org/fhir/StructureDefinition/procedurerequest-targetBodySite"/>
+  <name value="targetBodySite"/>
+  <title value="targetBodySite"/>
+  <status value="draft"/>
+  <date value="2015-02-12"/>
+  <publisher value="Health Level Seven, Inc. - FHIR WG"/>
+  <contact>
+    <telecom>
+      <system value="url"/>
+      <value value="HL7"/>
+    </telecom>
+  </contact>
+  <description value="The requested target body site for this procedure. Multiple locations are allowed."/>
+  <fhirVersion value="3.0.1"/>
+  <mapping>
+    <identity value="rim"/>
+    <uri value="http://hl7.org/v3"/>
+    <name value="RIM Mapping"/>
+  </mapping>
+  <kind value="complex-type"/>
+  <abstract value="false"/>
+  <contextType value="resource"/>
+  <context value="ProcedureRequest"/>
+  <type value="Extension"/>
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Extension"/>
+  <derivation value="constraint"/>
+  <snapshot>
+    <element id="Extension">
+      <path value="Extension"/>
+      <short value="The requested target point for this procedure"/>
+      <definition value="The requested target body site for this procedure. Multiple locations are allowed."/>
+      <min value="0"/>
+      <max value="*"/>
+      <base>
+        <path value="Extension"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
+      <condition value="ele-1"/>
+      <constraint>
+        <key value="ele-1"/>
+        <severity value="error"/>
+        <human value="All FHIR elements must have a @value or children"/>
+        <expression value="hasValue() | (children().count() &gt; id.count())"/>
+        <xpath value="@value|f:*|h:div"/>
+        <source value="Element"/>
+      </constraint>
+      <constraint>
+        <key value="ext-1"/>
+        <severity value="error"/>
+        <human value="Must have either extensions or value[x], not both"/>
+        <expression value="extension.exists() != value.exists()"/>
+        <xpath value="exists(f:extension)!=exists(f:*[starts-with(local-name(.), &#39;value&#39;)])"/>
+        <source value="Extension"/>
+      </constraint>
+    </element>
+    <element id="Extension.id">
+      <path value="Extension.id"/>
+      <representation value="xmlAttr"/>
+      <short value="xml:id (or equivalent in JSON)"/>
+      <definition value="unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces."/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="Element.id"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="string"/>
+      </type>
+      <mapping>
+        <identity value="rim"/>
+        <map value="n/a"/>
+      </mapping>
+    </element>
+    <element id="Extension.extension">
+      <path value="Extension.extension"/>
+      <slicing>
+        <discriminator>
+          <type value="value"/>
+          <path value="url"/>
+        </discriminator>
+        <description value="Extensions are always sliced by (at least) url"/>
+        <rules value="open"/>
+      </slicing>
+      <short value="Additional Content defined by implementations"/>
+      <definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension."/>
+      <comment value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone."/>
+      <alias value="extensions"/>
+      <alias value="user content"/>
+      <min value="0"/>
+      <max value="*"/>
+      <base>
+        <path value="Element.extension"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
+      <type>
+        <code value="Extension"/>
+      </type>
+      <mapping>
+        <identity value="rim"/>
+        <map value="n/a"/>
+      </mapping>
+    </element>
+    <element id="Extension.url">
+      <path value="Extension.url"/>
+      <representation value="xmlAttr"/>
+      <short value="identifies the meaning of the extension"/>
+      <definition value="Source of the definition for the extension code - a logical name or a URL."/>
+      <comment value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition SHALL be a URI for the Structure Definition defining the extension."/>
+      <min value="1"/>
+      <max value="1"/>
+      <base>
+        <path value="Extension.url"/>
+        <min value="1"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="uri"/>
+      </type>
+      <fixedUri value="http://hl7.org/fhir/StructureDefinition/procedurerequest-targetBodySite"/>
+      <mapping>
+        <identity value="rim"/>
+        <map value="N/A"/>
+      </mapping>
+    </element>
+    <element id="Extension.valueReference">
+      <path value="Extension.valueReference"/>
+      <short value="Value of extension"/>
+      <definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)."/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="Extension.value[x]"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="Reference"/>
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/BodySite"/>
+      </type>
+      <mapping>
+        <identity value="rim"/>
+        <map value="N/A"/>
+      </mapping>
+    </element>
+  </snapshot>
+  <differential>
+    <element id="Extension">
+      <path value="Extension"/>
+      <short value="The requested target point for this procedure"/>
+      <definition value="The requested target body site for this procedure. Multiple locations are allowed."/>
+      <min value="0"/>
+      <max value="*"/>
+    </element>
+    <element id="Extension.extension">
+      <path value="Extension.extension"/>
+      <max value="0"/>
+    </element>
+    <element id="Extension.url">
+      <path value="Extension.url"/>
+      <type>
+        <code value="uri"/>
+      </type>
+      <fixedUri value="http://hl7.org/fhir/StructureDefinition/procedurerequest-targetBodySite"/>
+    </element>
+    <element id="Extension.valueReference">
+      <path value="Extension.valueReference"/>
+      <type>
+        <code value="Reference"/>
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/BodySite"/>
+      </type>
+    </element>
+  </differential>
+</StructureDefinition>

--- a/resources/core-extensions/extension-serviceRequest-patientInstruction.xml
+++ b/resources/core-extensions/extension-serviceRequest-patientInstruction.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="ServiceRequest.patientInstruction" />
+  <url value="http://hl7.org/fhir/4.0/StructureDefinition/extension-ServiceRequest.patientInstruction" />
+  <name value="patientInstruction" />
+  <status value="draft" />
+  <description value="Instructions in terms that are understood by the patient or consumer." />
+  <fhirVersion value="3.0.1" />
+  <kind value="complex-type" />
+  <abstract value="false" />
+  <contextType value="resource" />
+  <context value="ProcedureRequest" />
+  <type value="Extension" />
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Extension" />
+  <derivation value="constraint" />
+  <differential>
+    <element id="Extension">
+      <path value="Extension" />
+      <short value="Patient or consumer-oriented instructions" />
+      <definition value="Instructions in terms that are understood by the patient or consumer." />
+      <max value="1" />
+      <constraint>
+        <key value="ext-1" />
+        <severity value="error" />
+        <human value="Must have either extensions or value[x], not both" />
+        <expression value="extension.exists() != value.exists()" />
+        <xpath value="exists(f:extension)!=exists(f:*[starts-with(local-name(.), 'value')])" />
+      </constraint>
+      <mapping>
+        <identity value="rim" />
+        <map value="N/A" />
+      </mapping>
+    </element>
+    <element id="Extension.url">
+      <path value="Extension.url" />
+      <fixedUri value="http://hl7.org/fhir/4.0/StructureDefinition/extension-ServiceRequest.patientInstruction" />
+    </element>
+    <element id="Extension.value[x]:valueString">
+      <path value="Extension.valueString" />
+      <sliceName value="valueString" />
+      <min value="1" />
+      <type>
+        <code value="string" />
+      </type>
+    </element>
+  </differential>
+</StructureDefinition>

--- a/resources/ig.xml
+++ b/resources/ig.xml
@@ -1305,6 +1305,13 @@
         <reference value="StructureDefinition/au-encounter"/>
       </sourceReference>
     </resource>
+    <resource>
+      <example value="false"/>
+      <name value="AU Base Diagnostic Procedure Request"/>
+      <sourceReference>
+        <reference value="StructureDefinition/au-diagnosticprocedurerequest"/>
+      </sourceReference>
+    </resource>
   </package>
   <page>
     <source value="index.html"/>

--- a/resources/structuredefinition-au-diagnosticprocedurerequest.xml
+++ b/resources/structuredefinition-au-diagnosticprocedurerequest.xml
@@ -1,0 +1,178 @@
+<?xml version="1.0" encoding="utf-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="au-diagnosticprocedurerequest" />
+  <url value="http://hl7.org.au/fhir/StructureDefinition/au-diagnosticprocedurerequest" />
+  <version value="1.0.0" />
+  <name value="AUBaseDiagnosticProcedureRequest" />
+  <title value="AU Base Diagnostic Procedure Request" />
+  <status value="draft" />
+  <publisher value="Health Level Seven Australia (Orders and Observations WG)" />
+  <contact>
+    <telecom>
+      <system value="url" />
+      <value value="http://hl7.org.au/fhir" />
+      <use value="work" />
+    </telecom>
+  </contact>
+  <description value="This profile defines a procedure request structure that includes core localisation concepts for use in an Australian context." />
+  <fhirVersion value="3.0.1" />
+  <kind value="resource" />
+  <abstract value="false" />
+  <type value="ProcedureRequest" />
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/ProcedureRequest" />
+  <derivation value="constraint" />
+  <differential>
+    <element id="ProcedureRequest">
+      <path value="ProcedureRequest" />
+      <short value="A procedure request in an Australian healthcare context" />
+    </element>
+    <element id="ProcedureRequest.extension:performerParty">
+      <path value="ProcedureRequest.extension" />
+      <sliceName value="performerParty" />
+      <type>
+        <code value="Extension" />
+        <profile value="http://hl7.org.au/fhir/StructureDefinition/performer-party" />
+      </type>
+    </element>
+    <element id="ProcedureRequest.extension:targetBodySite">
+      <path value="ProcedureRequest.extension"/>
+      <sliceName value="targetBodySite"/>
+      <min value="0"/>
+      <max value="*"/>
+      <type>
+        <code value="Extension"/>
+        <profile value="http://hl7.org/fhir/StructureDefinition/procedurerequest-targetBodySite"/>
+      </type>
+    </element>
+    <!--<element id="ProcedureRequest.extension:patientInstruction">
+      <path value="ProcedureRequest.extension" />
+      <sliceName value="patientInstruction" />
+      <short value="Patient or consumer-oriented instructions" />
+      <definition value="Instructions in terms that are understood by the patient or consumer." />
+      <min value="0" />
+      <max value="1" />
+      <type>
+        <code value="Extension" />
+        <profile value="http://hl7.org/fhir/4.0/StructureDefinition/extension-ServiceRequest.patientInstruction" />
+      </type>
+    </element>-->
+    <element id="ProcedureRequest.identifier">
+      <path value="ProcedureRequest.identifier" />
+      <slicing>
+        <discriminator>
+          <type value="pattern" />
+          <path value="type" />
+        </discriminator>
+        <discriminator>
+          <type value="value" />
+          <path value="system" />
+        </discriminator>
+        <rules value="open" />
+      </slicing>
+    </element>
+    <element id="ProcedureRequest.identifier:placerIdentifier">
+      <path value="ProcedureRequest.identifier" />
+      <sliceName value="placerIdentifier" />
+      <short value="Placer identifier" />
+      <definition value="The identifier associated with the person or service that requests or places an order." />
+    </element>
+    <element id="ProcedureRequest.identifier:placerIdentifier.type">
+      <path value="ProcedureRequest.identifier.type" />
+      <min value="1" />
+      <binding>
+        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
+          <valueString value="IdentifierType" />
+        </extension>
+        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding">
+          <valueBoolean value="true" />
+        </extension>
+        <strength value="required" />
+        <valueSetReference>
+          <reference value="http://hl7.org.au/fhir/ValueSet/au-hl7v2-0203" />
+        </valueSetReference>
+      </binding>
+    </element>
+    <element id="ProcedureRequest.identifier:placerIdentifier.type.coding">
+      <path value="ProcedureRequest.identifier.type.coding" />
+      <min value="1" />
+      <max value="1" />
+      <patternCoding>
+        <system value="http://hl7.org.au/fhir/v2/0203" />
+        <code value="PLAC" />
+      </patternCoding>
+    </element>
+    <element id="ProcedureRequest.identifier:placerIdentifier.system">
+      <path value="ProcedureRequest.identifier.system" />
+      <short value="Placer identifier system namespace" />
+      <min value="1" />
+    </element>
+    <element id="ProcedureRequest.identifier:placerIdentifier.value">
+      <path value="ProcedureRequest.identifier.value" />
+      <short value="Placer identifier" />
+      <min value="1" />
+    </element>
+    <element id="ProcedureRequest.code">
+      <path value="ProcedureRequest.code"/>
+    </element>
+    <element id="ProcedureRequest.code.coding">
+      <path value="ProcedureRequest.code.coding" />
+      <slicing>
+        <discriminator>
+          <type value="value" />
+          <path value="system" />
+        </discriminator>
+        <discriminator>
+          <type value="value" />
+          <path value="code" />
+        </discriminator>
+        <rules value="open" />
+      </slicing>
+    </element>
+    <element id="ProcedureRequest.code.coding:snomedImagingProcedures">
+      <path value="ProcedureRequest.code.coding" />
+      <sliceName value="snomedImagingProcedures" />
+      <short value="Diagnostic Imaging Procedures (SNOMED CT)" />
+      <binding>
+        <strength value="required" />
+        <valueSetUri value="https://healthterminologies.gov.au/fhir/ValueSet/imaging-procedure-1" />
+      </binding>
+    </element>
+    <element id="ProcedureRequest.performerType.coding">
+      <path value="ProcedureRequest.performerType.coding" />
+      <slicing>
+        <discriminator>
+          <type value="value" />
+          <path value="system" />
+        </discriminator>
+        <rules value="open" />
+      </slicing>
+    </element>
+    <element id="ProcedureRequest.performerType.coding:anzscoPerformerType">
+      <path value="ProcedureRequest.performerType.coding" />
+      <sliceName value="anzscoPerformerType" />
+      <short value="Australian and New Zealand Standard Classification of Occupations" />
+      <max value="1" />
+      <binding>
+        <strength value="required" />
+        <valueSetUri value="https://healthterminologies.gov.au/fhir/ValueSet/anzsco-1" />
+      </binding>
+    </element>
+    <element id="ProcedureRequest.performerType.coding:snomedPerformerType">
+      <path value="ProcedureRequest.performerType.coding" />
+      <sliceName value="snomedPerformerType" />
+      <short value="Practitioner Role (SNOMED CT)" />
+      <max value="1" />
+      <binding>
+        <strength value="required" />
+        <valueSetUri value="https://healthterminologies.gov.au/fhir/ValueSet/practitioner-role-1" />
+      </binding>
+    </element>
+    <element id="ProcedureRequest.specimen">
+      <path value="ProcedureRequest.specimen" />
+      <type>
+        <code value="Reference" />
+        <targetProfile value="http://hl7.org.au/fhir/StructureDefinition/au-specimen" />
+      </type>
+    </element>
+  </differential>
+</StructureDefinition>


### PR DESCRIPTION
Hi Brett,

New profile for Diagnostic Procedure Request added with its usual complement of supporting file and file changes.

Note there are pending changes for this profile to:
1) Add another slice on ProcedureRequest.code.coding for Standards for Pathology Informatics in Australia - Test Result (LOINC) - this is awaiting NCTS development.
2) Add R4 pre-adopt element instruction - "patientInstruction" - refer to https://chat.fhir.org/#narrow/stream/179166-implementers/topic/Syntax.20for.20canonical.20pre-adoption.20convention
3) Include NCTS terminology for "reasonCode" is about to be released.

Cheers
D Mc