### PR TITLE
Added Observation as a ContextOfUse in the Performer Party Extension.…

### DIFF
--- a/resources/structuredefinition-performer-party.xml
+++ b/resources/structuredefinition-performer-party.xml
@@ -22,6 +22,7 @@
   <contextType value="resource" />
   <context value="ProcedureRequest" />
   <context value="DiagnosticReport" />
+  <context value="Observation" />
   <type value="Extension" />
   <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Extension" />
   <derivation value="constraint" />


### PR DESCRIPTION
Hi,

**Background**:
The HL7 AU extension for Performer Party has the two context of use as 'ProcedureRequest' and 'DiagnosticReport'. 

However, the proposed profile for Base Diagnostic Observation, which derives directly from STU3 Observation, also seeks to use this extension.

The profile cannot include this extension until the extension's context of use includes Observation.

**The change**:
Added 'Observation' as a third context of use into the extension for Performer Party

Submitting for your review. Thanks.