### PR TITLE
AU Base Practitioner - improvements to profile and examples

### DIFF
--- a/examples/practitioner-example0.xml
+++ b/examples/practitioner-example0.xml
@@ -6,7 +6,7 @@
   <identifier>
     <type>
       <coding>
-        <system value="http://hl7.org/fhir/v2/0203"/>
+        <system value="http://terminology.hl7.org/CodeSystem/v2-0203"/>
         <code value="NPI"/>
         <display value="National provider identifier"/>
       </coding>
@@ -18,7 +18,7 @@
   <identifier>
     <type>
       <coding>
-        <system value="http://hl7.org.au/fhir/v2/0203"/>
+        <system value="http://terminology.hl7.org.au/CodeSystem/v2-0203"/>
         <code value="PRES"/>
         <display value="Prescriber Number"/>
       </coding>
@@ -50,7 +50,7 @@
     <identifier>
       <type>
         <coding>
-          <system value="http://hl7.org.au/fhir/v2/0203"/>
+          <system value="http://terminology.hl7.org.au/CodeSystem/v2-0203"/>
           <code value="AHPRA"/>
           <display value="Australian Health Practitioner Regulation Agency Registration Number"/>
         </coding>

--- a/examples/practitioner-example1.xml
+++ b/examples/practitioner-example1.xml
@@ -5,7 +5,7 @@
 	</meta>
 	<identifier>
 		<type>
-			<text value="Care Agency Employee Identifierx"/>
+			<text value="Care Agency Employee Identifier"/>
 		</type>
 		<system value="http://ns.electronichealth.net.au/id/pcehr/caei/1.0"/>
 		<value value="9003600003999997"/>

--- a/examples/practitioner-example1.xml
+++ b/examples/practitioner-example1.xml
@@ -19,7 +19,7 @@
 		<identifier>
 			<type>
 				<coding>
-					<system value="http://hl7.org.au/fhir/v2/0203"/>
+					<system value="http://terminology.hl7.org.au/CodeSystem/v2-0203"/>
 					<code value="AHPRA"/>
 					<display value="Australian Health Practitioner Regulation Agency Registration Number"/>
 				</coding>

--- a/examples/practitioner-example2.xml
+++ b/examples/practitioner-example2.xml
@@ -12,7 +12,7 @@
 		<identifier>
 			<type>
 				<coding>
-					<system value="http://hl7.org.au/fhir/v2/0203"/>
+					<system value="http://terminology.hl7.org.au/CodeSystem/v2-0203"/>
 					<code value="AHPRA"/>
 					<display value="Australian Health Practitioner Regulation Agency Registration Number"/>
 				</coding>

--- a/examples/practitioner-example3.xml
+++ b/examples/practitioner-example3.xml
@@ -6,7 +6,7 @@
 	<identifier>
 		<type>
 			<coding>
-				<system value="http://hl7.org/fhir/v2/0203"/>
+				<system value="http://terminology.hl7.org/CodeSystem/v2-0203"/>
 				<code value="NPI"/>
 				<display value="National provider identifier"/>
 			</coding>
@@ -24,7 +24,7 @@
 		<identifier>
 			<type>
 				<coding>
-					<system value="http://hl7.org.au/fhir/v2/0203"/>
+					<system value="http://terminology.hl7.org.au/CodeSystem/v2-0203"/>
 					<code value="AHPRA"/>
 					<display value="Australian Health Practitioner Regulation Agency Registration Number"/>
 				</coding>

--- a/pages/_includes/au-practitioner-intro.md
+++ b/pages/_includes/au-practitioner-intro.md
@@ -6,7 +6,7 @@ This profile defines a practitioner administration details structure that includ
 These definitions represent common data held in the Practitioner.identifier element:
 
 * Healthcare Provider Identifier - Individual - HPI-I [<sup>[1]</sup>](http://ns.electronichealth.net.au/id/hi/hpii/1.0/index.html){:target="_blank"} 
-* Medicare Prescriber Number [<sup>[1]</sup>](http://ns.electronichealth.net.au/id/medicare-prescriber-number/index.html){:target="_blank"} [<sup>[2]</sup>](http://meteor.aihw.gov.au/content/index.phtml/itemId/600762){:target="_blank"}
+* Medicare Prescriber Number [<sup>[1]</sup>](http://ns.electronichealth.net.au/id/medicare-prescriber-number/index.html){:target="_blank"}
 * Care Agency Employee (CAE) Identifier [<sup>[1]</sup>](http://ns.electronichealth.net.au/id/pcehr/caei/1.0/index.html){:target="_blank"} 
 
 #### Qualifications

--- a/pages/_includes/au-practitioner-intro.md
+++ b/pages/_includes/au-practitioner-intro.md
@@ -7,12 +7,13 @@ These definitions represent common data held in the Practitioner.identifier elem
 
 * Healthcare Provider Identifier - Individual - HPI-I [<sup>[1]</sup>](http://ns.electronichealth.net.au/id/hi/hpii/1.0/index.html){:target="_blank"} 
 * Medicare Prescriber Number [<sup>[1]</sup>](http://ns.electronichealth.net.au/id/medicare-prescriber-number/index.html){:target="_blank"}
-* Care Agency Employee (CAE) Identifier [<sup>[1]</sup>](http://ns.electronichealth.net.au/id/pcehr/caei/1.0/index.html){:target="_blank"} 
+* Care Agency Employee (CAE) Identifier [<sup>[1]</sup>](http://ns.electronichealth.net.au/id/pcehr/caei/1.0/index.html){:target="_blank"}
+* Australian Health Practitioner Regulation Agency (AHPRA) Registration Number [<sup>[1]</sup>](https://www.ahpra.gov.au){:target="_blank"} [<sup>[2]</sup>](https://www.ahpra.gov.au/Support/Glossary.aspx#Registration%20Number){:target="_blank"}
 
 #### Qualifications
 These definitions represent common data held in the Practitioner.qualification element:
 
-* Australian Health Practitioner Regulation Agency (AHPRA) Registration Number [<sup>[1]</sup>](https://www.ahpra.gov.au/Support/Glossary.aspx#Registration%20Number)
+* Australian Health Practitioner Regulation Agency (AHPRA) Registration Number [<sup>[1]</sup>](https://www.ahpra.gov.au){:target="_blank"} [<sup>[2]</sup>](https://www.ahpra.gov.au/Support/Glossary.aspx#Registration%20Number){:target="_blank"}
 
 
 **Examples**

--- a/pages/_includes/au-practitioner-intro.md
+++ b/pages/_includes/au-practitioner-intro.md
@@ -15,6 +15,9 @@ These definitions represent common data held in the Practitioner.qualification e
 
 * Australian Health Practitioner Regulation Agency (AHPRA) Registration Number [<sup>[1]</sup>](https://www.ahpra.gov.au){:target="_blank"} [<sup>[2]</sup>](https://www.ahpra.gov.au/Support/Glossary.aspx#Registration%20Number){:target="_blank"}
 
+#### Usage Notes
+Where a sending system includes a practitioner's qualification using their AHPRA Registration Number, this should be done using Practitioner.qualification(ahpraRegistration). 
+A practitioner's AHPRA Registration Number may also be included as an identifier, using Practitioner.identifier(ahpraRegistration).
 
 **Examples**
 

--- a/resources/au-practitioner.xml
+++ b/resources/au-practitioner.xml
@@ -6,7 +6,7 @@
   <name value="AUBasePractitioner" />
   <title value="AU Base Practitioner" />
   <status value="draft" />
-  <date value="2017-03-11T06:30:54+00:00" />
+  <date value="2019-07-26"/>
   <publisher value="Health Level Seven Australia (Patient Administration WG)" />
   <contact>
     <telecom>

--- a/resources/au-practitioner.xml
+++ b/resources/au-practitioner.xml
@@ -51,20 +51,20 @@
       <definition value="National identifier Healthcare Provider Identifier for Individuals (HPI-I)." />
       <max value="1" />
       <constraint>
-        <key value="inv-hpii-value-0" />
+        <key value="inv-hpii-0" />
         <requirements value="The value shall be 16 digits." />
         <severity value="error" />
         <human value="HPI-I shall be 16 digits" />
         <expression value="value.matches('^([0-9]{16})$')" />
       </constraint>
       <constraint>
-        <key value="inv-hpii-value-1" />
+        <key value="inv-hpii-1" />
         <severity value="error" />
         <human value="HPI-I prefix shall be 800361"/>
         <expression value="value.startsWith('800361')" />
       </constraint>
       <constraint>
-        <key value="inv-hpii-value-2" />
+        <key value="inv-hpii-2" />
         <requirements value="HPI-I shall pass the Luhn algorithm check" />
         <severity value="error" />
         <human value="HPI-I shall pass the Luhn algorithm check"/>
@@ -171,20 +171,20 @@
       <short value="Care Agency Employee (CAE) Identifier" />
       <definition value="An identifier that applies to this person in this role. This identifier is used for qualified identifiers to represent a My Health Record Care Agency Employees Identifier (CAE-I) numbers." />
       <constraint>
-        <key value="inv-caei-value-0" />
+        <key value="inv-caei-0" />
         <requirements value="The value shall be 16 digits." />
         <severity value="error" />
         <human value="CAE identifier shall be 16 digits" />
         <expression value="value.matches('^([0-9]{16})$')" />
       </constraint>
       <constraint>
-        <key value="inv-caei-value-1" />
+        <key value="inv-caei-1" />
         <severity value="error" />
         <human value="CAE identifier prefix shall be 900360"/>
         <expression value="value.startsWith('900360')" />
       </constraint>
       <constraint>
-        <key value="inv-caei-value-2" />
+        <key value="inv-caei-2" />
         <severity value="error" />
         <human value="CAE identifier shall pass the Luhn algorithm check" />
         <expression value="(((select(value.substring(0,1).toInteger()).select(iif($this&lt;5, $this*2, (($this*2)-9))))+(value.substring(1,1).toInteger())+(select(value.substring(2,1).toInteger()).select(iif($this&lt;5, $this*2, (($this*2)-9))))+(value.substring(3,1).toInteger())+(select(value.substring(4,1).toInteger()).select(iif($this&lt;5, $this*2, (($this*2)-9))))+(value.substring(5,1).toInteger())+(select(value.substring(6,1).toInteger()).select(iif($this&lt;5, $this*2, (($this*2)-9))))+(value.substring(7,1).toInteger())+(select(value.substring(8,1).toInteger()).select(iif($this&lt;5, $this*2, (($this*2)-9))))+(value.substring(9,1).toInteger())+(select(value.substring(10,1).toInteger()).select(iif($this&lt;5, $this*2, (($this*2)-9))))+(value.substring(11,1).toInteger())+(select(value.substring(12,1).toInteger()).select(iif($this&lt;5, $this*2, (($this*2)-9))))+(value.substring(13,1).toInteger())+(select(value.substring(14,1).toInteger()).select(iif($this&lt;5, $this*2, (($this*2)-9))))+(value.substring(15,1).toInteger()))mod 10=0)" />
@@ -229,7 +229,7 @@
       <short value="Australian Health Practitioner Regulation Agency (AHPRA) registration as identifier" />
       <definition value="Details of registration identifier of the Australian Health Practitioner Regulation Authority (AHPRA)." />
       <constraint>
-        <key value="inv-ahpra-value-id-0" />
+        <key value="inv-ahpra-0" />
         <severity value="error" />
         <human value="AHPRA identifier shall be 3 uppercase letters, followed by 10 digits"/>
         <expression value="value.matches('^[A-Z]{3}[0-9]{10}$')" />
@@ -299,7 +299,7 @@
       <min value="1" />
       <max value="1" />
       <constraint>
-        <key value="inv-ahpra-qual-value-0" />
+        <key value="inv-ahpra-1" />
         <severity value="error" />
         <human value="AHPRA registration value shall be 3 uppercase letters, followed by 10 digits"/>
         <expression value="value.matches('^[A-Z]{3}[0-9]{10}$')" />

--- a/resources/au-practitioner.xml
+++ b/resources/au-practitioner.xml
@@ -52,22 +52,22 @@
       <max value="1" />
       <constraint>
         <key value="inv-hpii-value-0" />
-        <requirements value="The value shall be a 16 digit number." />
+        <requirements value="The value shall be 16 digits." />
         <severity value="error" />
-        <human value="HPI-I shall be an exactly 16 digit number" />
+        <human value="HPI-I shall be 16 digits" />
         <expression value="value.matches('^([0-9]{16})$')" />
       </constraint>
       <constraint>
         <key value="inv-hpii-value-1" />
         <severity value="error" />
-        <human value="HPI-I prefix is 800361" />
+        <human value="HPI-I prefix shall be 800361"/>
         <expression value="value.startsWith('800361')" />
       </constraint>
       <constraint>
         <key value="inv-hpii-value-2" />
         <requirements value="HPI-I shall pass the Luhn algorithm check" />
         <severity value="error" />
-        <human value="The identifier shall pass the Luhn algorithm check" />
+        <human value="HPI-I shall pass the Luhn algorithm check"/>
         <expression value="(((select(value.substring(0,1).toInteger()).select(iif($this&lt;5, $this*2, (($this*2)-9))))+(value.substring(1,1).toInteger())+(select(value.substring(2,1).toInteger()).select(iif($this&lt;5, $this*2, (($this*2)-9))))+(value.substring(3,1).toInteger())+(select(value.substring(4,1).toInteger()).select(iif($this&lt;5, $this*2, (($this*2)-9))))+(value.substring(5,1).toInteger())+(select(value.substring(6,1).toInteger()).select(iif($this&lt;5, $this*2, (($this*2)-9))))+(value.substring(7,1).toInteger())+(select(value.substring(8,1).toInteger()).select(iif($this&lt;5, $this*2, (($this*2)-9))))+(value.substring(9,1).toInteger())+(select(value.substring(10,1).toInteger()).select(iif($this&lt;5, $this*2, (($this*2)-9))))+(value.substring(11,1).toInteger())+(select(value.substring(12,1).toInteger()).select(iif($this&lt;5, $this*2, (($this*2)-9))))+(value.substring(13,1).toInteger())+(select(value.substring(14,1).toInteger()).select(iif($this&lt;5, $this*2, (($this*2)-9))))+(value.substring(15,1).toInteger()))mod 10=0)" />
       </constraint>
     </element>
@@ -172,15 +172,15 @@
       <definition value="An identifier that applies to this person in this role. This identifier is used for qualified identifiers to represent a My Health Record Care Agency Employees Identifier (CAE-I) numbers." />
       <constraint>
         <key value="inv-caei-value-0" />
-        <requirements value="The value shall be a 16 digit number." />
+        <requirements value="The value shall be 16 digits." />
         <severity value="error" />
-        <human value="CAE identifier shall be an exactly 16 digit number" />
+        <human value="CAE identifier shall be 16 digits" />
         <expression value="value.matches('^([0-9]{16})$')" />
       </constraint>
       <constraint>
         <key value="inv-caei-value-1" />
         <severity value="error" />
-        <human value="CAE identifier shall contain a prefix of 900360" />
+        <human value="CAE identifier prefix shall be 900360"/>
         <expression value="value.startsWith('900360')" />
       </constraint>
       <constraint>
@@ -231,7 +231,7 @@
       <constraint>
         <key value="inv-ahpra-value-id-0" />
         <severity value="error" />
-        <human value="The AHPRA identifier value shall start with 3 uppercase letters, followed by 10 digits." />
+        <human value="AHPRA identifier shall be 3 uppercase letters, followed by 10 digits"/>
         <expression value="value.matches('^[A-Z]{3}[0-9]{10}$')" />
       </constraint>
     </element>
@@ -301,7 +301,7 @@
       <constraint>
         <key value="inv-ahpra-qual-value-0" />
         <severity value="error" />
-        <human value="The AHPRA registration value shall start with 3 uppercase letters, followed by 10 digits." />
+        <human value="AHPRA registration value shall be 3 uppercase letters, followed by 10 digits"/>
         <expression value="value.matches('^[A-Z]{3}[0-9]{10}$')" />
       </constraint>
     </element>

--- a/resources/au-practitioner.xml
+++ b/resources/au-practitioner.xml
@@ -2,7 +2,7 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="au-practitioner" />
   <url value="http://hl7.org.au/fhir/StructureDefinition/au-practitioner" />
-  <version value="1.0.0" />
+  <version value="2.0.0" />
   <name value="AUBasePractitioner" />
   <title value="AU Base Practitioner" />
   <status value="draft" />

--- a/resources/au-practitioner.xml
+++ b/resources/au-practitioner.xml
@@ -11,7 +11,7 @@
   <contact>
     <telecom>
       <system value="url" />
-      <value value="http://hl7.org.au" />
+      <value value="http://hl7.org.au/fhir" />
       <use value="work" />
     </telecom>
   </contact>


### PR DESCRIPTION
Hi Brett, this PR proposes a number of improvements related to the AU Base Practitioner profile:

### Profile StructureDefinition
- updated `StructureDefinition.date` to be recent (rather than 2017)
- corrected the `StructureDefinition.contact.telecom.value` with the correct URL
- updated all invariant keys to align with the convention (as recently discussed with Richard)
- simplified and standardised the invariant descriptions (eg "_HPI-I shall be an exactly 16 digit number_" changed to "_HPI-I shall be 16 digits_" etc)

### Profile intro.md content
- dot point re 'Medicare Prescriber Number - removed the 2nd link to a AIHW website with what looks like a different concept (at least from the perspective of the format anyway). This is associated with the recently added issue #304.
- dot point re AHPRA added into the list of identifiers and added a hyperlink to the AHPRA home page
- added _draft_ usage note regarding dual representation of AHPRA registration number (as identifier and qualification)

### Practitioner examples
- all examples updated regarding the new R4 v0203 codesystem URL (eliminating their respective QA errors)
- fixed a typo in the CAE identifier type text value
