### PR TITLE
AU Base Practitioner Role improvements

### DIFF
--- a/examples/practitionerrole-example1.xml
+++ b/examples/practitionerrole-example1.xml
@@ -6,17 +6,14 @@
 	<identifier>
 		<type>
 			<coding>
-				<system value="http://terminology.hl7.org/CodeSystem/v2-0203"/>
-				<code value="EI"/>
-				<display value="Employee number"/>				
-			</coding>	
-			<text value="Employee Number"/>
+				<system value="http://terminology.hl7.org.au/CodeSystem/v2-0203"/>
+				<code value="NPIO"/>
+				<display value="National Provider at Organisation Identifier"/>
+			</coding>
+			<text value="NPIO"/>
 		</type>
-		<system value="http://ns.electronichealth.net.au/id/abn-scoped/service-provider-individual/1.0/84425496912"/>
-		<value value="stevesmith33"/>
-		<assigner>
-			<display value="Australian Digital Health Agency"/>
-		</assigner>
+		<system value="http://hl7.org.au/id/npio"/>
+		<value value="8003619900015717@8003621566684455"/>
 	</identifier>	
 	<practitioner>
 		<reference value="Practitioner/example1"/>
@@ -39,30 +36,8 @@
 	</healthcareService> 
 	<telecom>
 		<system value="email"/>
-		<value value="steve.smith@amail.com.au"/>
+		<value value="helen.mayo@downunderhospital.com.au"/>
 		<use value="work"/>
 	</telecom>
-	<availableTime> 
-		<daysOfWeek value="mon"/> 
-		<daysOfWeek value="tue"/>
-		<daysOfWeek value="wed"/>
-		<daysOfWeek value="thu"/> 
-		<daysOfWeek value="fri"/> 
-		<availableStartTime value="08:30:00"/> 
-		<availableEndTime value="17:30:00"/> 
-	</availableTime> 
-	<notAvailable> 
-		<description value="New Years Day"/> 
-		<during> 
-			<start value="2019-01-01T00:01:00+10:00"/> 
-			<end value="2019-01-01T23:59:00+10:00"/> 
-		</during> 
-	</notAvailable> 
-	<notAvailable> 
-		<description value="Show Day"/> 
-		<during> 
-			<start value="2019-08-16T00:01:00+10:00"/> 
-			<end value="2019-08-16T23:59:00+10:00"/> 
-		</during>  
-	</notAvailable> 
+	<availabilityExceptions value="Availability on public holidays may vary, please contact the hospital directly to confirm."/>
 </PractitionerRole>

--- a/resources/au-healthcareservice.xml
+++ b/resources/au-healthcareservice.xml
@@ -24,22 +24,9 @@
   <derivation value="constraint" />
   <differential>
     <element id="HealthcareService">
-      <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
-        <valueCode value="trial-use" />
-      </extension>
       <path value="HealthcareService" />
       <short value="A healthcare service in an Australian healthcare context" />
       <definition value="The details of a healthcare service." />
-    </element>
-    <element id="HealthcareService.extension">
-      <path value="HealthcareService.extension" />
-      <slicing>
-        <discriminator>
-          <type value="value" />
-          <path value="url" />
-        </discriminator>
-        <rules value="open" />
-      </slicing>
     </element>
     <element id="HealthcareService.identifier">
       <path value="HealthcareService.identifier" />
@@ -66,18 +53,21 @@
         <severity value="error" />
         <human value="HPI-O shall be an exactly 16 digit number" />
         <expression value="value.matches('^([0-9]{16})$')" />
+        <source value="http://hl7.org.au/fhir/StructureDefinition/au-healthcareservice" />
       </constraint>
       <constraint>
         <key value="inv-hpio-1" />
         <severity value="error" />
         <human value="HPI-O prefix is 800362" />
         <expression value="value.startsWith('800362')" />
+        <source value="http://hl7.org.au/fhir/StructureDefinition/au-healthcareservice" />
       </constraint>
       <constraint>
         <key value="inv-hpio-2" />
         <severity value="error" />
         <human value="HPI-O shall pass the Luhn algorithm check" />
         <expression value="(((select(value.substring(0,1).toInteger()).select(iif($this&lt;5, $this*2, (($this*2)-9))))+(value.substring(1,1).toInteger())+(select(value.substring(2,1).toInteger()).select(iif($this&lt;5, $this*2, (($this*2)-9))))+(value.substring(3,1).toInteger())+(select(value.substring(4,1).toInteger()).select(iif($this&lt;5, $this*2, (($this*2)-9))))+(value.substring(5,1).toInteger())+(select(value.substring(6,1).toInteger()).select(iif($this&lt;5, $this*2, (($this*2)-9))))+(value.substring(7,1).toInteger())+(select(value.substring(8,1).toInteger()).select(iif($this&lt;5, $this*2, (($this*2)-9))))+(value.substring(9,1).toInteger())+(select(value.substring(10,1).toInteger()).select(iif($this&lt;5, $this*2, (($this*2)-9))))+(value.substring(11,1).toInteger())+(select(value.substring(12,1).toInteger()).select(iif($this&lt;5, $this*2, (($this*2)-9))))+(value.substring(13,1).toInteger())+(select(value.substring(14,1).toInteger()).select(iif($this&lt;5, $this*2, (($this*2)-9))))+(value.substring(15,1).toInteger())) mod 10 = 0)" />
+        <source value="http://hl7.org.au/fhir/StructureDefinition/au-healthcareservice" />
       </constraint>
     </element>
     <element id="HealthcareService.identifier:hpio.type">
@@ -91,21 +81,12 @@
         </coding>
       </patternCodeableConcept>
       <binding>
-        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
-          <valueString value="IdentifierType" />
-        </extension>
-        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding">
-          <valueBoolean value="true" />
-        </extension>
         <strength value="required" />
         <description value="Local identifier type" />
         <valueSet value="http://hl7.org.au/fhir/ValueSet/au-hl7v2-0203" />
       </binding>
     </element>
     <element id="HealthcareService.identifier:hpio.type.text">
-      <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable">
-        <valueBoolean value="true" />
-      </extension>
       <path value="HealthcareService.identifier.type.text" />
       <definition value="hpi-o" />
       <fixedString value="HPI-O" />
@@ -132,9 +113,6 @@
       <path value="HealthcareService.type" />
       <short value="Healthcare service types" />
       <binding>
-        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
-          <valueString value="service-type" />
-        </extension>
         <strength value="preferred" />
         <description value="A type of service that a healthcare service may provide." />
         <valueSet value="http://hl7.org.au/fhir/ValueSet/snomed-healthcareservice-services" />
@@ -144,9 +122,6 @@
       <path value="HealthcareService.specialty" />
       <short value="Healthcare service provided specialties" />
       <binding>
-        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
-          <valueString value="service-specialty" />
-        </extension>
         <strength value="preferred" />
         <description value="A specialty role that a healthcare service may provide." />
         <valueSet value="http://hl7.org.au/fhir/ValueSet/snomed-healthcareservice-specialties" />
@@ -156,9 +131,6 @@
       <path value="HealthcareService.serviceProvisionCode" />
       <short value="Healthcare service provision conditions" />
       <binding>
-        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
-          <valueString value="ServiceProvisionConditions" />
-        </extension>
         <strength value="preferred" />
         <valueSet value="http://hl7.org.au/fhir/ValueSet/service-provision-conditions" />
       </binding>

--- a/resources/au-practitionerrole.xml
+++ b/resources/au-practitionerrole.xml
@@ -93,6 +93,13 @@
       <sliceName value="nationalProviderAtOrganisation" />
       <short value="National Provider at Organisation Identifier" />
       <definition value="Combined Healthcare Provider Identifier – Individual (HPI-I) and Healthcare Provider Identifier – Organisation (HPI-O) identifier to use as unique organisation based identifier for a practitioner." />
+      <constraint>
+        <key value="inv-npio-0" />
+        <severity value="error" />
+        <human value="NPIO length is exactly 33 characters" />
+        <expression value="value.length() = 33" />
+        <source value="http://hl7.org.au/fhir/StructureDefinition/au-practitionerrole" />
+      </constraint>
     </element>
     <element id="PractitionerRole.identifier:nationalProviderAtOrganisation.type">
       <path value="PractitionerRole.identifier.type" />
@@ -127,13 +134,6 @@
       <path value="PractitionerRole.identifier.value" />
       <short value="National provider identifier at organisation in the form HPI-I@HPI-O" />
       <min value="1" />
-      <constraint>
-        <key value="inv-npio-0" />
-        <severity value="error" />
-        <human value="NPIO length is exactly 33 characters" />
-        <expression value="value.length() = 33" />
-        <source value="http://hl7.org.au/fhir/StructureDefinition/au-practitionerrole" />
-      </constraint>
     </element>
     <element id="PractitionerRole.identifier:employeeNumber">
       <path value="PractitionerRole.identifier" />

--- a/resources/au-practitionerrole.xml
+++ b/resources/au-practitionerrole.xml
@@ -2,16 +2,16 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="au-practitionerrole" />
   <url value="http://hl7.org.au/fhir/StructureDefinition/au-practitionerrole" />
-  <version value="1.0.0" />
+  <version value="2.0.0" />
   <name value="AUBasePractitionerRole" />
   <title value="AU Base Practitioner Role" />
   <status value="active" />
-  <date value="2017-03-11T06:30:54+00:00" />
+  <date value="2017-03-11" />
   <publisher value="Health Level Seven Australia (Patient Administration WG)" />
   <contact>
     <telecom>
       <system value="url" />
-      <value value="http://hl7.org.au" />
+      <value value="http://hl7.org.au/fhir" />
       <use value="work" />
     </telecom>
   </contact>

--- a/resources/au-practitionerrole.xml
+++ b/resources/au-practitionerrole.xml
@@ -24,9 +24,6 @@
   <derivation value="constraint" />
   <differential>
     <element id="PractitionerRole">
-      <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
-        <valueCode value="trial-use" />
-      </extension>
       <path value="PractitionerRole" />
       <short value="A practitioner in a healthcare role in an Australian healthcare context" />
     </element>
@@ -64,21 +61,12 @@
         </coding>
       </patternCodeableConcept>
       <binding>
-        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
-          <valueString value="IdentifierType" />
-        </extension>
-        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding">
-          <valueBoolean value="true" />
-        </extension>
         <strength value="required" />
         <description value="Local identifier type" />
         <valueSet value="http://hl7.org.au/fhir/ValueSet/au-hl7v2-0203" />
       </binding>
     </element>
     <element id="PractitionerRole.identifier:medicareProviderNumber.type.text">
-      <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable">
-        <valueBoolean value="true" />
-      </extension>
       <path value="PractitionerRole.identifier.type.text" />
       <definition value="Provider number identifier type descriptive text." />
       <fixedString value="Medicare Provider Number" />
@@ -118,21 +106,12 @@
         </coding>
       </patternCodeableConcept>
       <binding>
-        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
-          <valueString value="IdentifierType" />
-        </extension>
-        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding">
-          <valueBoolean value="true" />
-        </extension>
         <strength value="required" />
         <description value="Local identifier type" />
         <valueSet value="http://hl7.org.au/fhir/ValueSet/au-hl7v2-0203" />
       </binding>
     </element>
     <element id="PractitionerRole.identifier:nationalProviderAtOrganisation.type.text">
-      <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable">
-        <valueBoolean value="true" />
-      </extension>
       <path value="PractitionerRole.identifier.type.text" />
       <definition value="National provider at organisation identifer (NPI-O) type descriptive text." />
       <fixedString value="NPIO" />
@@ -153,6 +132,7 @@
         <severity value="error" />
         <human value="NPIO length is exactly 33 characters" />
         <expression value="value.length() = 33" />
+        <source value="http://hl7.org.au/fhir/StructureDefinition/au-practitionerrole" />
       </constraint>
     </element>
     <element id="PractitionerRole.identifier:employeeNumber">
@@ -172,21 +152,12 @@
         </coding>
       </patternCodeableConcept>
       <binding>
-        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
-          <valueString value="IdentifierType" />
-        </extension>
-        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding">
-          <valueBoolean value="true" />
-        </extension>
         <strength value="required" />
         <description value="Local identifier type" />
         <valueSet value="http://hl7.org.au/fhir/ValueSet/au-hl7v2-0203" />
       </binding>
     </element>
     <element id="PractitionerRole.identifier:employeeNumber.type.text">
-      <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable">
-        <valueBoolean value="true" />
-      </extension>
       <path value="PractitionerRole.identifier.type.text" />
       <min value="1" />
       <fixedString value="Employee Number" />
@@ -206,9 +177,6 @@
       <min value="1" />
     </element>
     <element id="PractitionerRole.identifier:employeeNumber.assigner.display">
-      <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable">
-        <valueBoolean value="true" />
-      </extension>
       <path value="PractitionerRole.identifier.assigner.display" />
       <short value="Employing organisation name" />
       <min value="1" />
@@ -217,9 +185,6 @@
       <path value="PractitionerRole.code" />
       <short value="Practitioner Roles" />
       <binding>
-        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
-          <valueString value="PractitionerRoles" />
-        </extension>
         <strength value="preferred" />
         <valueSet value="https://healthterminologies.gov.au/fhir/ValueSet/practitioner-role-1" />
       </binding>
@@ -228,9 +193,6 @@
       <path value="PractitionerRole.specialty" />
       <short value="Practitioner specialties" />
       <binding>
-        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
-          <valueString value="PractitionerSpecialty" />
-        </extension>
         <strength value="preferred" />
         <valueSet value="http://hl7.org.au/fhir/ValueSet/snomed-practitioner-specialties" />
       </binding>

--- a/resources/codesystem-au-hl7v2-0203.xml
+++ b/resources/codesystem-au-hl7v2-0203.xml
@@ -20,7 +20,11 @@
 	<date value="2019-02-13"/>
 	<publisher value="Health Level Seven Australia (Patient Administration)"/>
 	<contact>
-		<name value="hl7.org.au"/>
+		<telecom>
+			<system value="url" />
+			<value value="http://hl7.com.au/fhir" />
+			<use value="work" />
+		</telecom>
 	</contact>
 	<description value="Extended concept codes for identifier type for use in Australian context."/>
 	<caseSensitive value="true"/>

--- a/resources/codesystem-au-hl7v2-0203.xml
+++ b/resources/codesystem-au-hl7v2-0203.xml
@@ -22,7 +22,7 @@
 	<contact>
 		<telecom>
 			<system value="url" />
-			<value value="http://hl7.com.au/fhir" />
+			<value value="http://hl7.org.au/fhir" />
 			<use value="work" />
 		</telecom>
 	</contact>

--- a/resources/codesystem-au-hl7v2-0443.xml
+++ b/resources/codesystem-au-hl7v2-0443.xml
@@ -20,7 +20,11 @@
 	<date value="2019-10-22"/>
 	<publisher value="Health Level Seven Australia (Patient Administration)"/>
 	<contact>
-		<name value="hl7.org.au"/>
+		<telecom>
+			<system value="url" />
+			<value value="http://hl7.com.au/fhir" />
+			<use value="work" />
+		</telecom>
 	</contact>
 	<description value="Extended concept codes for identifier type for use in Australian context."/>
 	<caseSensitive value="true"/>

--- a/resources/codesystem-au-hl7v2-0443.xml
+++ b/resources/codesystem-au-hl7v2-0443.xml
@@ -22,7 +22,7 @@
 	<contact>
 		<telecom>
 			<system value="url" />
-			<value value="http://hl7.com.au/fhir" />
+			<value value="http://hl7.org.au/fhir" />
 			<use value="work" />
 		</telecom>
 	</contact>

--- a/resources/valueset-au-hl7v2-0203.xml
+++ b/resources/valueset-au-hl7v2-0203.xml
@@ -15,7 +15,7 @@
 	<contact>
 		<telecom>
 		  <system value="url" />
-		  <value value="http://hl7.com.au/fhir" />
+		  <value value="http://hl7.org.au/fhir" />
 		  <use value="work" />
 		</telecom>
 	</contact>

--- a/resources/valueset-au-hl7v2-0203.xml
+++ b/resources/valueset-au-hl7v2-0203.xml
@@ -15,7 +15,7 @@
 	<contact>
 		<telecom>
 		  <system value="url" />
-		  <value value="http://hl7.com.au" />
+		  <value value="http://hl7.com.au/fhir" />
 		  <use value="work" />
 		</telecom>
 	</contact>

--- a/resources/valueset-au-hl7v2-0443.xml
+++ b/resources/valueset-au-hl7v2-0443.xml
@@ -15,7 +15,7 @@
 	<contact>
 		<telecom>
 		  <system value="url" />
-		  <value value="http://hl7.com.au/fhir" />
+		  <value value="http://hl7.org.au/fhir" />
 		  <use value="work" />
 		</telecom>
 	</contact>

--- a/resources/valueset-au-hl7v2-0443.xml
+++ b/resources/valueset-au-hl7v2-0443.xml
@@ -15,7 +15,7 @@
 	<contact>
 		<telecom>
 		  <system value="url" />
-		  <value value="http://hl7.com.au" />
+		  <value value="http://hl7.com.au/fhir" />
 		  <use value="work" />
 		</telecom>
 	</contact>

--- a/resources/valueset-snomed-practitioner-specialties.xml
+++ b/resources/valueset-snomed-practitioner-specialties.xml
@@ -25,9 +25,9 @@
 		<include>
 			<system value="http://snomed.info/sct"/>
 			<filter>
-				<property value="concept"/>
-				<op value="descendent-of"/>
-				<value value="394658006"/>
+				<property value="constraint"/>
+				<op value="="/>
+				<value value="DescendantOf 394658006|Clinical speciality|"/>
 			</filter>
 		</include>
 	</compose>

--- a/resources/valueset-snomed-practitioner-specialties.xml
+++ b/resources/valueset-snomed-practitioner-specialties.xml
@@ -15,7 +15,7 @@
 	<contact>
 		<telecom>
 		  <system value="url" />
-		  <value value="http://hl7.com.au" />
+		  <value value="http://hl7.com.au/fhir" />
 		  <use value="work" />
 		</telecom>
 	</contact>


### PR DESCRIPTION
Improvements to au-practitionerole.xml include:
- moving inv-npio-0 from element to the parent to make it function as required.
- update version 1.0.0 to 2.0.0
- update contact.telcom.value to "http://hl7.org.au/fhir"
- Forge changes including adding <source> and removal of redundant extensions.

practitionertrole-example1.mxl:
- added example NPIO value
- updated telecom.value to match the organization
- deleted <availableTime> content as it is represented in another example.

Other changes related to AU Base Practitioner Role profile include:
- codesystem-au-hl7v2-0203.xml; codesystem-au-hl7v2-0443.xml; valueset-au-hl7v2-0203.xml; valueset-au-hl7v2-0443.xml:  updated the contact.telcom.value to "http://hl7.org.au/fhir"
- valueset-snomed-practitioner-specialties.xml :  updated the contact.telcom.value to "http://hl7.org.au/fhir" and corrected syntax of SCT filter.
- au-healthcareservice.xml : Forge changes.