### PR TITLE
Add DVA Number identifier profile

### DIFF
--- a/ig.json
+++ b/ig.json
@@ -171,6 +171,10 @@
             "base": "StructureDefinition-au-medicarenumber.html",
             "defns": "StructureDefinition-au-medicarenumber-definitions.html"
         },
+        "StructureDefinition/au-dvanumber": {
+            "base": "StructureDefinition-au-dvanumber.html",
+            "defns": "StructureDefinition-au-dvanumber-definitions.html"
+        },
         "StructureDefinition/grounds-for-concurrent-supply": {
             "base": "StructureDefinition-grounds-for-concurrent-supply.html",
             "defns": "StructureDefinition-grounds-for-concurrent-supply-definitions.html"

--- a/pages/_includes/au-dvanumber-intro.md
+++ b/pages/_includes/au-dvanumber-intro.md
@@ -1,7 +1,6 @@
-**AU DVA Number Profile**  *[[FMM Level 0](guidance.html)]*
+**AU DVA Number **  *[[FMM Level 0](guidance.html)]*
 
-This identifier profile defines a Departement of Veterans' Affairs (DVA) 
-Number[<sup>[1]</sup>](http://ns.electronichealth.net.au/id/dva/index.html){:target="_blank"} [<sup>[2]</sup>](http://meteor.aihw.gov.au/content/index.phtml/itemId/339127){:target="_blank"} 
+This identifier profile defines a Departement of Veterans' Affairs (DVA) Number[<sup>[1]</sup>](http://ns.electronichealth.net.au/id/dva/index.html){:target="_blank"} [<sup>[2]</sup>](http://meteor.aihw.gov.au/content/index.phtml/itemId/339127){:target="_blank"} in an Australian context.
 
 
 **Examples**

--- a/pages/_includes/au-dvanumber-intro.md
+++ b/pages/_includes/au-dvanumber-intro.md
@@ -1,4 +1,4 @@
-**AU DVA Number **  *[[FMM Level 0](guidance.html)]*
+**AU DVA Number**  *[[FMM Level 0](guidance.html)]*
 
 This identifier profile defines a Departement of Veterans' Affairs (DVA) Number[<sup>[1]</sup>](http://ns.electronichealth.net.au/id/dva/index.html){:target="_blank"} [<sup>[2]</sup>](http://meteor.aihw.gov.au/content/index.phtml/itemId/339127){:target="_blank"} in an Australian context.
 

--- a/pages/_includes/au-dvanumber-intro.md
+++ b/pages/_includes/au-dvanumber-intro.md
@@ -1,0 +1,10 @@
+**AU DVA Number Profile**  *[[FMM Level 0](guidance.html)]*
+
+This identifier profile defines a Departement of Veterans' Affairs (DVA) 
+Number[<sup>[1]</sup>](http://ns.electronichealth.net.au/id/dva/index.html){:target="_blank"} [<sup>[2]</sup>](http://meteor.aihw.gov.au/content/index.phtml/itemId/339127){:target="_blank"} 
+
+
+**Examples**
+
+[Patient with IHI and DVA Number](Patient-example1.html)
+

--- a/pages/_includes/au-dvanumber-search.md
+++ b/pages/_includes/au-dvanumber-search.md
@@ -1,0 +1,1 @@
+none defined

--- a/pages/_includes/au-dvanumber-summary.md
+++ b/pages/_includes/au-dvanumber-summary.md
@@ -1,0 +1,3 @@
+This profile contains the following variations from [Identifier](http://hl7.org/fhir/R4/Identifier):
+
+TBD

--- a/pages/_includes/profiles.md
+++ b/pages/_includes/profiles.md
@@ -42,4 +42,4 @@ These Profiles have been defined for this implementation guide.
 
 ### Profiles on Identifier Data Type
 * [AU Medicare Number](StructureDefinition-au-medicarenumber.html) - identifier profile for an Australian Medicare Number
-* [AU DVA Number](StructureDefinition-au-dvanumber.html) - identifier profile for an Australian Department of Veterans' Affairs Number
+* [AU DVA Number](StructureDefinition-au-dvanumber.html) - identifier profile for an Australian Department of Veterans' Affairs (DVA) Number

--- a/pages/_includes/profiles.md
+++ b/pages/_includes/profiles.md
@@ -42,3 +42,4 @@ These Profiles have been defined for this implementation guide.
 
 ### Profiles on Identifier Data Type
 * [AU Medicare Number](StructureDefinition-au-medicarenumber.html) - identifier profile for an Australian Medicare Number
+* [AU DVA Number](StructureDefinition-au-dvanumber.html) - identifier profile for an Australian Department of Veterans' Affairs Number

--- a/resources/au-dvanumber.xml
+++ b/resources/au-dvanumber.xml
@@ -17,7 +17,7 @@
   </contact>
   <description value="This identifier profile defines a Departement of Veterans' Affairs (DVA) Number in an Australian context." />
   <copyright value="HL7 Australia© 2018+; Licensed Under Creative Commons No Rights Reserved." />
-  <fhirVersion value="4.0.0" />
+  <fhirVersion value="4.0.1" />
   <mapping>
     <identity value="v2" />
     <uri value="http://hl7.org/v2" />

--- a/resources/au-dvanumber.xml
+++ b/resources/au-dvanumber.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="utf-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="au-dvanumber" />
+  <url value="http://hl7.org.au/fhir/StructureDefinition/au-dvanumber" />
+  <version value="1.0.0" />
+  <name value="AUDVANumber" />
+  <title value="AU DVA Number" />
+  <status value="draft" />
+  <date value="2020-03-10" />
+  <publisher value="Health Level Seven Australia (Patient Administration WG)" />
+  <contact>
+    <telecom>
+      <system value="url" />
+      <value value="http://hl7.com.au" />
+      <use value="work" />
+    </telecom>
+  </contact>
+  <description value="This identifier profile defines a Departement of Veterans' Affairs (DVA) Number in an Australian context." />
+  <copyright value="HL7 Australia© 2018+; Licensed Under Creative Commons No Rights Reserved." />
+  <fhirVersion value="4.0.0" />
+  <mapping>
+    <identity value="v2" />
+    <uri value="http://hl7.org/v2" />
+    <name value="HL7 v2 Mapping" />
+  </mapping>
+  <mapping>
+    <identity value="rim" />
+    <uri value="http://hl7.org/v3" />
+    <name value="RIM Mapping" />
+  </mapping>
+  <mapping>
+    <identity value="servd" />
+    <uri value="http://www.omg.org/spec/ServD/1.0/" />
+    <name value="ServD" />
+  </mapping>
+  <kind value="complex-type" />
+  <abstract value="false" />
+  <type value="Identifier" />
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Identifier" />
+  <derivation value="constraint" />
+  <differential>
+    <element id="Identifier">
+      <path value="Identifier" />
+      <short value="Department of Veterans' Affairs (DVA) Number" />
+      <definition value="Department of Veterans' Affairs (DVA) number." />
+      <constraint>
+        <key value="inv-dva-number-unspecified" />
+        <severity value="error" />
+        <human value="DVA number identifier type text must be 'DVA Number' when colour is not specified" />
+        <expression value="type.coding.empty() implies type.text = 'DVA Number'" />
+        <source value="http://hl7.org.au/fhir/StructureDefinition/au-dvanumber" />
+      </constraint>
+      <constraint>
+        <key value="inv-dva-number-gold" />
+        <severity value="error" />
+        <human value="DVA number identifier type text must be 'DVA Number (Gold)' when colour coding is DVG." />
+        <expression value="type.coding.code='DVG' implies type.text = 'DVA Number (Gold)'" />
+        <source value="http://hl7.org.au/fhir/StructureDefinition/au-dvanumber" />
+      </constraint>
+      <constraint>
+        <key value="inv-dva-number-white" />
+        <severity value="error" />
+        <human value="DVA number identifier type text must be 'DVA Number (White)' when colour coding is DVW." />
+        <expression value="type.coding.code='DVW' implies type.text = 'DVA Number (White)'" />
+        <source value="http://hl7.org.au/fhir/StructureDefinition/au-dvanumber" />
+      </constraint>
+      <constraint>
+        <key value="inv-dva-number-orange" />
+        <severity value="error" />
+        <human value="DVA number identifier type text must be 'DVA Number (Orange)' when colour coding is DVO." />
+        <expression value="type.coding.code='DVO' implies type.text = 'DVA Number (Orange)'" />
+        <source value="http://hl7.org.au/fhir/StructureDefinition/au-dvanumber" />
+      </constraint>
+      <constraint>
+        <key value="inv-dva-number-lilac" />
+        <severity value="error" />
+        <human value="DVA number identifier type text must be 'DVA Number (Lilac)' when colour coding is DVL." />
+        <expression value="type.coding.code='DVL' implies type.text = 'DVA Number (Lilac)'" />
+        <source value="http://hl7.org.au/fhir/StructureDefinition/au-dvanumber" />
+      </constraint>
+      <constraint>
+        <key value="inv-dva-number-text" />
+        <severity value="error" />
+        <human value="DVA number identifier type text must be one of 'DVA Number', 'DVA Number (Gold)',  'DVA Number (White), 'DVA Number (Orange), 'DVA Number (Lilac)'" />
+        <expression value="type.text = 'DVA Number' or type.text = 'DVA Number (Gold)' or type.text = 'DVA Number (White)' or type.text = 'DVA Number (Orange)' or type.text = 'DVA Number (Lilac)'" />
+        <source value="http://hl7.org.au/fhir/StructureDefinition/au-dvanumber" />
+      </constraint>
+    </element>
+    <element id="Identifier.type">
+      <path value="Identifier.type" />
+      <short value="Coded identifier type for DVA number" />
+      <definition value="Department of Veterans' Affairs (DVA) colour identifier type." />
+      <binding>
+        <strength value="required" />
+        <description value="Local Identifier Type" />
+        <valueSet value="http://hl7.org.au/fhir/ValueSet/au-hl7v2-0203" />
+      </binding>
+    </element>
+    <element id="Identifier.type.text">
+      <path value="Identifier.type.text" />
+      <definition value="Type of DVA card (specific colour may be provided)" />
+    </element>
+    <element id="Identifier.system">
+      <path value="Identifier.system" />
+      <short value="Namespace for DVA number" />
+      <definition value="DVA number assigned uri." />
+      <min value="1" />
+      <fixedUri value="http://ns.electronichealth.net.au/id/dva" />
+    </element>
+    <element id="Identifier.value">
+      <path value="Identifier.value" />
+      <short value="DVA number" />
+      <definition value="Up to 9 digit value in the form AAXXNNNN[A]." />
+      <comment value="Reference: http://meteor.aihw.gov.au/content/index.phtml/itemId/339127" />
+      <min value="1" />
+      <example>
+        <label value="Department of Veterans' Affairs (DVA) number" />
+        <valueString value="NBUR9080" />
+      </example>
+      <maxLength value="9" />
+    </element>
+  </differential>
+</StructureDefinition>

--- a/resources/ig.xml
+++ b/resources/ig.xml
@@ -287,6 +287,13 @@
     </resource>
     <resource>
       <reference>
+        <reference value="StructureDefinition/au-dvanumber"/>
+      </reference>
+      <exampleBoolean value="false"/>
+      <groupingId value="p1"/>
+    </resource>
+    <resource>
+      <reference>
         <reference value="StructureDefinition/au-medlist"/>
       </reference>
       <exampleBoolean value="false"/>


### PR DESCRIPTION
As recently discussed at the HL7 AU PA WG - this is the second identifier profile created.

As discussed this profile has not been hooked up to a "parent" profile eg au-patient.

Refer to HL7 AU Confluence page au-fhir-base - creation of Identifier datatype profiles.

See also Practitioner, PractitionerRole, Organization, HealthcareService DataType profiles #313