### PR TITLE
Base Patient and Base RelatedPerson - relax MedicareNumber constraint

### DIFF
--- a/resources/au-patient.xml
+++ b/resources/au-patient.xml
@@ -247,13 +247,11 @@
     <element id="Patient.identifier:medicareNumber.period">
       <path value="Patient.identifier.period" />
       <short value="Medicare number validity period" />
-      <min value="1" />
     </element>
     <element id="Patient.identifier:medicareNumber.period.end">
       <path value="Patient.identifier.period.end" />
       <short value="Medicare number expiry date" />
       <definition value="Expiry date for Medicare number. This is typically month and year only, but may incude day date part when this is a temporary Medicare number." />
-      <min value="1" />
     </element>
     <element id="Patient.identifier:dvaNumber">
       <path value="Patient.identifier" />

--- a/resources/au-relatedperson.xml
+++ b/resources/au-relatedperson.xml
@@ -199,13 +199,11 @@
     <element id="RelatedPerson.identifier:medicareNumber.period">
       <path value="RelatedPerson.identifier.period" />
       <short value="Medicare number validity period" />
-      <min value="1" />
     </element>
     <element id="RelatedPerson.identifier:medicareNumber.period.end">
       <path value="RelatedPerson.identifier.period.end" />
       <short value="Medicare number expiry date" />
       <definition value="Expiry date for Medicare number. This is typically month and year only but may include day date part when this is a temporary Medicare number." />
-      <min value="1" />
     </element>
     <element id="RelatedPerson.identifier:dvaNumber">
       <path value="RelatedPerson.identifier" />


### PR DESCRIPTION
The Medicare Number identifier slices for both [AU Base Patient](http://build.fhir.org/ig/hl7au/au-fhir-base/StructureDefinition-au-patient.html) and [AU Base RelatedPerson](http://build.fhir.org/ig/hl7au/au-fhir-base/StructureDefinition-au-relatedperson.html) were updated to remove the cardinality constraint on their respective `period` and `period.end` elements. 

That is, from `1..1` both were reverted to the default cardinality of `0..1`
Their short names were retained , as is.

This was discussed as desirable in a PAWG late last year; and also note that the same model was used in the recently developed [Medicare Number Identifier profile](http://build.fhir.org/ig/hl7au/au-fhir-base/StructureDefinition-au-medicarenumber.html).

Even though the profiles will likely move away from the identifier slices to identifier profiles, we thought it worthwhile keeping everything in sync.

This addresses ticket #322 