### PR TITLE
au-practitionerrole :: Fixed String text value "National provider at organisation identifier" change

### DIFF
--- a/resources/au-practitionerrole.xml
+++ b/resources/au-practitionerrole.xml
@@ -122,7 +122,7 @@
     <element id="PractitionerRole.identifier:nationalProviderAtOrganisation.type.text">
       <path value="PractitionerRole.identifier.type.text" />
       <definition value="National provider at organisation identifer (NPI-O) type descriptive text." />
-      <fixedString value="NPIO" />
+      <fixedString value="National provider at organisation identifier" />
     </element>
     <element id="PractitionerRole.identifier:nationalProviderAtOrganisation.system">
       <path value="PractitionerRole.identifier.system" />


### PR DESCRIPTION
Hi Brett, 

Please accept the which is a fix in regards to the GitHub issue https://github.com/hl7au/au-fhir-base/issues/361 which mentions about the anomaly which is present in "nationalProviderAtOrganisation" identifier for au-practitionerrole where type.text value has the code value (NPIO) instead of the value present in display column (National provider at organisation identifier).

Kind Regards, 
Uday

