### PR TITLE
au-practitionerrole :: An invariant performing the validation for @value for the NPIO slice

### DIFF
--- a/resources/au-practitionerrole.xml
+++ b/resources/au-practitionerrole.xml
@@ -101,6 +101,13 @@
         <expression value="value.length() = 33" />
         <source value="http://hl7.org.au/fhir/StructureDefinition/au-practitionerrole" />
       </constraint>
+      <constraint>
+        <key value="inv-npio-1" />
+        <severity value="error" />
+        <human value="NPIO value shall start with '800361', then 10 digits, then '@', then '800362' and ends with 10 digits" />
+        <expression value="value.matches('^(800361)([0-9]{10})(@)(800362)([0-9]{10})$')" />
+        <source value="http://hl7.org.au/fhir/StructureDefinition/au-practitionerrole" />
+      </constraint>
     </element>
     <element id="PractitionerRole.identifier:nationalProviderAtOrganisation.type">
       <path value="PractitionerRole.identifier.type" />


### PR DESCRIPTION
Hello Brett, 

This pull request address the GitHub request (https://github.com/hl7au/au-fhir-base/issues/348) which is in regards to having an invariant to validate the value element of NPIO slice.

"value.matches('^(800361)([0-9]{10})(@)(800362)([0-9]{10})$')"

Thanks, 
Uday