### PR TITLE
AU Base Diagnostic Report - removed 0..1 constraint on performer

### DIFF
--- a/resources/au-diagnosticreport.xml
+++ b/resources/au-diagnosticreport.xml
@@ -131,10 +131,6 @@
         <valueSet value="https://healthterminologies.gov.au/fhir/ValueSet/imaging-procedure-1" />
       </binding>
     </element>
-    <element id="DiagnosticReport.performer">
-      <path value="DiagnosticReport.performer" />
-      <max value="1" />
-    </element>
     <element id="DiagnosticReport.specimen">
       <path value="DiagnosticReport.specimen" />
       <type>


### PR DESCRIPTION
DiagnosticReport.performer now reverts to the default 0..* as is found in the DiagnosticReport resource.

Addresses Github ticket: #411