### PR TITLE
Update HL7 AU Base PA profiles except Organistation

### DIFF
--- a/examples/practitioner-example0.xml
+++ b/examples/practitioner-example0.xml
@@ -27,6 +27,18 @@
     <system value="http://ns.electronichealth.net.au/id/medicare-prescriber-number"/>
     <value value="453221"/>
   </identifier>
+  <identifier>
+    <type>
+      <coding>
+        <system value="http://terminology.hl7.org.au/CodeSystem/v2-0203"/>
+        <code value="AHPRA"/>
+        <display value="Australian Health Practitioner Regulation Agency Registration Number"/>
+      </coding>
+      <text value="AHPRA Registration Number"/>
+    </type>
+    <system value="http://hl7.org.au/id/ahpra-registration-number"/>
+    <value value="MED0000932945"/>
+  </identifier>
   <active value="true"/>
   <name>
     <family value="Mayo"/>
@@ -46,29 +58,11 @@
     <postalCode value="2148"/>
     <country value="Australia"/>
   </address>
-  <qualification>
-    <identifier>
-      <type>
-        <coding>
-          <system value="http://terminology.hl7.org.au/CodeSystem/v2-0203"/>
-          <code value="AHPRA"/>
-          <display value="Australian Health Practitioner Regulation Agency Registration Number"/>
-        </coding>
-        <text value="AHPRA Registration Number"/>
-      </type>
-      <system value="http://hl7.org.au/id/ahpra-registration-number"/>
-      <value value="MED0000932945"/>
-    </identifier>
-    <code>
-      <coding>
-        <system value="http://www.abs.gov.au/ausstats/abs@.nsf/mf/1220.0"/>
-        <code value="253111"/>
-        <display value="General Practitioner"/>
-      </coding>
-      <text value="General Practitioner"/>
-    </code>
-    <issuer>
-      <display value="AHPRA"/>
-    </issuer>
-  </qualification>
+  <communication>
+     <coding>
+      <system value="urn:ietf:bcp:47"/>
+      <code value="asf"/>
+      <display value="Auslan"/>
+    </coding>  
+  </communication>
 </Practitioner>

--- a/pages/_includes/au-healthcareservice-intro.md
+++ b/pages/_includes/au-healthcareservice-intro.md
@@ -1,6 +1,10 @@
-**AU Base Healthcare Service Profile** *[[FMM Level 3](guidance.html)]*
+**AU Base Healthcare Service** *[[FMM Level 3](guidance.html)]*
 
-This profile defines a healthcare service administration details structure that includes core localisation concepts for use in an Australian context.
+This profile defines a healthcare service structure that localises core concepts, including identifiers and terminology, for use in an Australian context.
+
+The purpose of this profile is to provide national level agreement on core localised concepts. 
+
+This profile does not force conformance to core localised concepts. It enables implementers and modellers to make their own rules, i.e. [profiling](http://hl7.org/fhir/profiling.html), about how to support these concepts for specific implementation needs.
 
 #### Identifiers
 These definitions, defined as profiles of [Identifier](http://hl7.org/fhir/R4/datatypes.html#Identifier), represent common data held in the HealthcareService.identifier element:

--- a/pages/_includes/au-location-intro.md
+++ b/pages/_includes/au-location-intro.md
@@ -1,6 +1,11 @@
-**AU Base Location Profile** *[[FMM Level 3](guidance.html)]*
+**AU Base Location** *[[FMM Level 3](guidance.html)]*
 
-This profile defines a location administration details structure that includes core localisation concepts for use in an Australian context.
+This profile defines a location structure that localises core concepts, including identifiers and terminology, for use in an Australian context.
+
+The purpose of this profile is to provide national level agreement on core localised concepts. 
+
+This profile does not force conformance to core localised concepts. It enables implementers and modellers to make their own rules, i.e. [profiling](http://hl7.org/fhir/profiling.html), about how to support these concepts for specific implementation needs.
+
 
 #### Identifiers
 These definitions, defined as profiles of [Identifier](http://hl7.org/fhir/R4/datatypes.html#Identifier), represent common data held in the Location.identifier element:

--- a/pages/_includes/au-patient-intro.md
+++ b/pages/_includes/au-patient-intro.md
@@ -1,6 +1,11 @@
-**AU Base Patient Profile** *[[FMM Level 3](guidance.html)]*
+**AU Base Patient** *[[FMM Level 3](guidance.html)]*
 
-This profile defines a patient administration details structure that includes core localisation concepts for use in an Australian context.
+This profile defines a patient structure that localises core concepts, including identifiers and terminology, for use in an Australian context.
+
+The purpose of this profile is to provide national level agreement on core localised concepts. 
+
+This profile does not force conformance to core localised concepts. It enables implementers and modellers to make their own rules, i.e. [profiling](http://hl7.org/fhir/profiling.html), about how to support these concepts for specific implementation needs.
+
 
 #### Identifiers
 These definitions, defined as profiles of [Identifier](http://hl7.org/fhir/R4/datatypes.html#Identifier), represent common data held in the Patient.identifier element:

--- a/pages/_includes/au-practitioner-intro.md
+++ b/pages/_includes/au-practitioner-intro.md
@@ -1,7 +1,10 @@
-**AU Base Practitioner Profile** *[[FMM Level 3](guidance.html)]*
+**AU Base Practitioner** *[[FMM Level 3](guidance.html)]*
 
-This profile defines a practitioner administration details structure that includes core localisation concepts for use in an Australian context.
+This profile defines a practitioner structure that localises core concepts, including identifiers and terminology, for use in an Australian context.
 
+The purpose of this profile is to provide national level agreement on core localised concepts. 
+
+This profile does not force conformance to core localised concepts. It enables implementers and modellers to make their own rules, i.e. [profiling](http://hl7.org/fhir/profiling.html), about how to support these concepts for specific implementation needs.
 #### Identifiers
 These definitions, defined as profiles of [Identifier](http://hl7.org/fhir/R4/datatypes.html#Identifier), represent common data held in the Practitioner.identifier element:
 * [Healthcare Provider Identifier - Individual (HPI-I)](StructureDefinition-au-hpiinumber.html) [<sup>[1]</sup>](http://ns.electronichealth.net.au/id/hi/hpii/1.0/index.html){:target="_blank"} 

--- a/pages/_includes/au-practitionerrole-intro.md
+++ b/pages/_includes/au-practitionerrole-intro.md
@@ -1,6 +1,10 @@
-**AU Base Practitioner Role Profile** *[[FMM Level 3](guidance.html)]*
+**AU Base Practitioner Role** *[[FMM Level 3](guidance.html)]*
 
-This profile defines a practitioner role administration details structure that includes core localisation concepts for use in an Australian context.
+This profile defines a practitioner role structure that localises core concepts, including identifiers and terminology, for use in an Australian context.
+
+The purpose of this profile is to provide national level agreement on core localised concepts. 
+
+This profile does not force conformance to core localised concepts. It enables implementers and modellers to make their own rules, i.e. [profiling](http://hl7.org/fhir/profiling.html), about how to support these concepts for specific implementation needs.
 
 #### Identifiers
 These definitions, defined as profiles of [Identifier](http://hl7.org/fhir/R4/datatypes.html#Identifier), represent common data held in the PractitionerRole.identifier element:

--- a/pages/_includes/au-relatedperson-intro.md
+++ b/pages/_includes/au-relatedperson-intro.md
@@ -1,6 +1,11 @@
-**AU Base RelatedPerson Profile** *[[FMM Level 2](guidance.html)]*
+**AU Base RelatedPerson** *[[FMM Level 2](guidance.html)]*
 
-This profile defines a related person administration details structure that includes core localisation concepts for use in an Australian context.
+This profile defines a related person structure that localises core concepts, including identifiers and terminology, for use in an Australian context.
+
+The purpose of this profile is to provide national level agreement on core localised concepts. 
+
+This profile does not force conformance to core localised concepts. It enables implementers and modellers to make their own rules, i.e. [profiling](http://hl7.org/fhir/profiling.html), about how to support these concepts for specific implementation needs.
+
 
 #### Identifiers
 These definitions, defined as profiles of [Identifier](http://hl7.org/fhir/R4/datatypes.html#Identifier), represent common data held in the RelatedPerson.identifier element:

--- a/pages/_includes/au-relatedperson-intro.md
+++ b/pages/_includes/au-relatedperson-intro.md
@@ -1,4 +1,4 @@
-**AU Base RelatedPerson** *[[FMM Level 2](guidance.html)]*
+**AU Base Related Person** *[[FMM Level 2](guidance.html)]*
 
 This profile defines a related person structure that localises core concepts, including identifiers and terminology, for use in an Australian context.
 

--- a/resources/au-healthcareservice.xml
+++ b/resources/au-healthcareservice.xml
@@ -15,7 +15,7 @@
       <use value="work" />
     </telecom>
   </contact>
-  <description value="This profile defines a healthcare service administration details structure that includes core localisation concepts for use in an Australian context." />
+  <description value="This profile defines a healthcare service structure that localises core concepts, including identifiers and terminology, for use in an Australian context." />
   <jurisdiction>
     <coding>
       <code value="AU"/>

--- a/resources/au-location.xml
+++ b/resources/au-location.xml
@@ -16,9 +16,15 @@
     </telecom>
   </contact>
   <description
-    value="This profile defines a location administration details structure that includes core localisation concepts for use in an Australian context."/>
+    value="This profile defines a location structure that localises core concepts, including identifiers and terminology, for use in an Australian context."/>
+  <jurisdiction>
+    <coding>
+      <code value="AU"/>
+      <system value="urn:iso:std:iso:3166"/>
+    </coding>
+  </jurisdiction>
   <copyright value="HL7 Australia© 2018+; Licensed Under Creative Commons No Rights Reserved."/>
-  <fhirVersion value="4.0.0"/>
+  <fhirVersion value="4.0.1"/>
   <kind value="resource"/>
   <abstract value="false"/>
   <type value="Location"/>

--- a/resources/au-patient.xml
+++ b/resources/au-patient.xml
@@ -15,7 +15,13 @@
       <use value="work" />
     </telecom>
   </contact>
-  <description value="This profile defines a patient administration details structure that includes core localisation concepts for use in an Australian context." />
+  <description value="This profile defines a patient structure that localises core concepts, including identifiers and terminology, for use in an Australian context." />
+  <jurisdiction>
+    <coding>
+      <code value="AU"/>
+      <system value="urn:iso:std:iso:3166"/>
+    </coding>
+  </jurisdiction>
   <copyright value="HL7 Australia© 2018+; Licensed Under Creative Commons No Rights Reserved." />
   <fhirVersion value="4.0.1" />
   <kind value="resource" />
@@ -204,6 +210,7 @@
       <type>
         <code value="Address" />
         <profile value="http://hl7.org/fhir/StructureDefinition/Address" />
+        <profile value="http://hl7.org.au/fhir/StructureDefinition/au-address" />
       </type>
     </element>
     <element id="Patient.contact.address">
@@ -211,6 +218,7 @@
       <type>
         <code value="Address" />
         <profile value="http://hl7.org/fhir/StructureDefinition/Address" />
+        <profile value="http://hl7.org.au/fhir/StructureDefinition/au-address" />
       </type>
     </element>
     <element id="Patient.communication">

--- a/resources/au-practitioner.xml
+++ b/resources/au-practitioner.xml
@@ -15,9 +15,15 @@
       <use value="work" />
     </telecom>
   </contact>
-  <description value="This profile defines a practitioner administration details structure that includes core localisation concepts for use in an Australian context." />
+  <description value="This profile defines a practitioner structure that localises core concepts, including identifiers and terminology, for use in an Australian context." />
+  <jurisdiction>
+    <coding>
+      <code value="AU"/>
+      <system value="urn:iso:std:iso:3166"/>
+    </coding>
+  </jurisdiction>
   <copyright value="HL7 Australia© 2018+; Licensed Under Creative Commons No Rights Reserved."/>
-  <fhirVersion value="4.0.0" />
+  <fhirVersion value="4.0.1" />
   <kind value="resource" />
   <abstract value="false" />
   <type value="Practitioner" />

--- a/resources/au-practitionerrole.xml
+++ b/resources/au-practitionerrole.xml
@@ -15,9 +15,15 @@
       <use value="work" />
     </telecom>
   </contact>
-  <description value="This profile defines a practitioner role administration details structure that includes core localisation concepts for use in an Australian context." />
+  <description value="This profile defines a practitioner role structure that localises core concepts, including identifiers and terminology, for use in an Australian context." />
+  <jurisdiction>
+    <coding>
+      <code value="AU"/>
+      <system value="urn:iso:std:iso:3166"/>
+    </coding>
+  </jurisdiction>
   <copyright value="HL7 Australia© 2018+; Licensed Under Creative Commons No Rights Reserved."/>
-  <fhirVersion value="4.0.0" />
+  <fhirVersion value="4.0.1" />
   <kind value="resource" />
   <abstract value="false" />
   <type value="PractitionerRole" />

--- a/resources/au-relatedperson.xml
+++ b/resources/au-relatedperson.xml
@@ -15,9 +15,15 @@
       <use value="work" />
     </telecom>
   </contact>
-  <description value="This profile defines a related person administration details structure that includes core localisation concepts for use in an Australian context." />
+  <description value="This profile defines a related person structure that localises core concepts, including identifiers and terminology, for use in an Australian context." />
+  <jurisdiction>
+    <coding>
+      <code value="AU"/>
+      <system value="urn:iso:std:iso:3166"/>
+    </coding>
+  </jurisdiction>
   <copyright value="HL7 Australia© 2018+; Licensed Under Creative Commons No Rights Reserved."/>
-  <fhirVersion value="4.0.0" />
+  <fhirVersion value="4.0.1" />
   <kind value="resource" />
   <abstract value="false" />
   <type value="RelatedPerson" />


### PR DESCRIPTION
Updated HL7 AU Base PA Profiles except Organisation and encounter.
Changes made include:
A) Intro.md:
1)  update of introductory sentences
2)  Remolval of "Profile" from title"

B)StructureDefinition changes:
1)  Align definition to opening sentence in intro.md
2) Added jurisdiction
3) updated FHIR version to 4.0.1

C)  Updated Practitioner-example0 
