### PR TITLE
Added codes - HL7 table 0203 code for NATA identifiers & LSPN

### DIFF
--- a/resources/codesystem-au-hl7v2-0203.xml
+++ b/resources/codesystem-au-hl7v2-0203.xml
@@ -29,8 +29,8 @@
 	<description value="Extended concept codes for identifier type for use in Australian context."/>
 	<jurisdiction>
 		<coding>
-			<code value="AU"/>
 			<system value="urn:iso:std:iso:3166"/>
+			<code value="AU"/>
 		</coding>
 	</jurisdiction>
 	<copyright value="HL7 Australia© 2018+; Licensed Under Creative Commons No Rights Reserved."/>

--- a/resources/codesystem-au-hl7v2-0203.xml
+++ b/resources/codesystem-au-hl7v2-0203.xml
@@ -73,6 +73,21 @@
 		<definition value="Local requester system identifier for prescriptions"/>
 	</concept>	
 	<concept>
+		<code value="LSPN"/>
+		<display value="Location Specific Practice Numbers"/>
+		<definition value="An identifier used by the Department of Human Services to uniquely identify practice sites that provide diagnostic imaging and radiation oncology services."/>
+	</concept>	
+	<concept>
+		<code value="NATAA"/>
+		<display value="National Association of Testing Authority Accreditation Number"/>
+		<definition value="A unique NATA identifier for an organisation."/>
+	</concept>	
+	<concept>
+		<code value="NATAS"/>
+		<display value="National Association of Testing Authority Site Number"/>
+		<definition value="A NATA identifier used for a specific site or location."/>
+	</concept>	
+	<concept>
 		<code value="NDI"/>
 		<display value="National Device Identifier"/>
 		<definition value="Nationally assigned device identifier, that is commonly a PAI-D"/>

--- a/resources/codesystem-au-hl7v2-0203.xml
+++ b/resources/codesystem-au-hl7v2-0203.xml
@@ -27,6 +27,12 @@
 		</telecom>
 	</contact>
 	<description value="Extended concept codes for identifier type for use in Australian context."/>
+	<jurisdiction>
+		<coding>
+			<code value="AU"/>
+			<system value="urn:iso:std:iso:3166"/>
+		</coding>
+	</jurisdiction>
 	<copyright value="HL7 Australia© 2018+; Licensed Under Creative Commons No Rights Reserved."/>
 	<caseSensitive value="true"/>
 	<compositional value="false"/>

--- a/resources/codesystem-au-hl7v2-0203.xml
+++ b/resources/codesystem-au-hl7v2-0203.xml
@@ -74,18 +74,18 @@
 	</concept>	
 	<concept>
 		<code value="LSPN"/>
-		<display value="Location Specific Practice Numbers"/>
-		<definition value="An identifier used by the Department of Human Services to uniquely identify practice sites that provide diagnostic imaging and radiation oncology services."/>
+		<display value="Location Specific Practice Number"/>
+		<definition value="An identifier assigned by Services Australia to uniquely identify practice sites that provide diagnostic imaging and radiation oncology services."/>
 	</concept>	
 	<concept>
 		<code value="NATAA"/>
-		<display value="National Association of Testing Authority Accreditation Number"/>
-		<definition value="A unique NATA identifier for an organisation."/>
+		<display value="NATA Accreditation Number"/>
+		<definition value="A National Association of Testing Authorities (NATA) accreditation number associated with an accredited facility. A NATA accreditation number is associated with an organisation."/>
 	</concept>	
 	<concept>
 		<code value="NATAS"/>
-		<display value="National Association of Testing Authority Site Number"/>
-		<definition value="A NATA identifier used for a specific site or location."/>
+		<display value="NATA Site Number"/>
+		<definition value="A National Association of Testing Authorities (NATA) site number associated with an accredited facility. A NATA site number represents a specific location associated with an accredited facility, i.e. an organisation with a NATA accredication number."/>
 	</concept>	
 	<concept>
 		<code value="NDI"/>


### PR DESCRIPTION
The following codes have been added to the code system 
[http://terminology.hl7.org.au/CodeSystem/v2-0203](http://build.fhir.org/ig/hl7au/au-fhir-base/CodeSystem-au-hl7v2-0203.html):

Code | Display | Definition
-- | -- | --
NATAA | National Association of Testing Authority Accreditation Number | A National Association of Testing Authorities (NATA) accreditation number associated with an accredited facility. A NATA accreditation number is associated with an organisation.
NATAS | National Association of Testing Authority Site Number | A National Association of Testing Authorities (NATA) site number associated with an accredited facility. A NATA site number represents a specific location associated with an accredited facility, i.e. an organisation with a NATA accredication number.
LSPN | Location Specific Practice Numbers | An identifier assigned by Services Australia to uniquely identify practice sites that provide diagnostic imaging and radiation oncology services.





Fixes #368 