### PR TITLE
Typo correction

### DIFF
--- a/resources/codesystem-au-hl7v2-0203.xml
+++ b/resources/codesystem-au-hl7v2-0203.xml
@@ -91,7 +91,7 @@
 	<concept>
 		<code value="NATAS"/>
 		<display value="NATA Site Number"/>
-		<definition value="A National Association of Testing Authorities (NATA) site number associated with an accredited facility. A NATA site number represents a specific location associated with an accredited facility, i.e. an organisation with a NATA accredication number."/>
+		<definition value="A National Association of Testing Authorities (NATA) site number associated with an accredited facility. A NATA site number represents a specific location associated with an accredited facility, i.e. an organisation with a NATA accreditation number."/>
 	</concept>	
 	<concept>
 		<code value="NDI"/>


### PR DESCRIPTION
In  HL7 0203 code system (AU extended) the typo in the NATAS description has been corrected from "accredication" to "accreditation".