### PR TITLE
Fix Condition example QA errors

### DIFF
--- a/examples/condition-example0.xml
+++ b/examples/condition-example0.xml
@@ -1,7 +1,17 @@
 <Condition xmlns="http://hl7.org/fhir">
   <id value="example0"/>
-  <clinicalStatus value="active"/> 
-  <verificationStatus value="confirmed"/> 
+  <clinicalStatus>
+    <coding>
+      <system value="http://terminology.hl7.org/CodeSystem/condition-clinical"/>
+      <code value="active"/>
+    </coding>
+  </clinicalStatus>
+  <verificationStatus>
+    <coding>
+      <system value="http://terminology.hl7.org/CodeSystem/condition-ver-status"/>
+      <code value="confirmed"/>
+    </coding>
+  </verificationStatus>
   <code>
     <coding>
       <system value="http://snomed.info/sct"/>


### PR DESCRIPTION
For example [Condition-example0](http://build.fhir.org/ig/hl7au/au-fhir-base/Condition-example0.html), this PR fixes QA errors re `Condition.clinicalStatus` and `Condition.verificationStatus` - both needed to be converted to have the CodeableConcept structure.

As a by product of this change, the generated narrative for this example then populated their respective values, which were previously missing.

Fixes #475 
