### PR TITLE
QA fixes - add missing jurisdiction for #484 & other Metadata fixes 

### DIFF
--- a/resources/au-allergyintolerance.xml
+++ b/resources/au-allergyintolerance.xml
@@ -6,18 +6,24 @@
   <name value="AUBaseAllergyIntolerance" />
   <title value="AU Base Allergy Intolerance" />
   <status value="draft" />
-  <date value="2018-08-20" />
+  <date value="2020-08-20" />
   <publisher value="Health Level Seven Australia" />
   <contact>
     <telecom>
       <system value="url" />
-      <value value="http://hl7.org.au" />
+      <value value="http://hl7.com.au" />
       <use value="work" />
     </telecom>
   </contact>
   <description value="This profile defines an allergy intolerance structure including core localisation concepts for use in an Australian context." />
+  <jurisdiction>
+    <coding>
+      <system value="urn:iso:std:iso:3166"/>
+      <code value="AU"/>
+    </coding>
+  </jurisdiction>
   <copyright value="HL7 Australia© 2018+; Licensed Under Creative Commons No Rights Reserved."/>
-  <fhirVersion value="4.0.0" />
+  <fhirVersion value="4.0.1" />
   <kind value="resource" />
   <abstract value="false" />
   <type value="AllergyIntolerance" />

--- a/resources/au-condition.xml
+++ b/resources/au-condition.xml
@@ -1,75 +1,84 @@
 <?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
-  <id value="au-condition" />
-  <url value="http://hl7.org.au/fhir/StructureDefinition/au-condition" />
+  <id value="au-condition"/>
+  <url value="http://hl7.org.au/fhir/StructureDefinition/au-condition"/>
   <version value="2.1.0"/>
-  <name value="AUBaseCondition" />
-  <title value="AU Base Condition" />
-  <status value="draft" />
-  <date value="2018-11-05" />
-  <publisher value="Health Level Seven Australia" />
+  <name value="AUBaseCondition"/>
+  <title value="AU Base Condition"/>
+  <status value="draft"/>
+  <date value="2020-08-05"/>
+  <publisher value="Health Level Seven Australia"/>
   <contact>
     <telecom>
-      <system value="url" />
-      <value value="http://hl7.com.au" />
-      <use value="work" />
+      <system value="url"/>
+      <value value="http://hl7.com.au"/>
+      <use value="work"/>
     </telecom>
   </contact>
-  <description value="This profile defines a condition structure including core localisation concepts for use in an Australian context." />
+  <description
+    value="This profile defines a condition structure including core localisation concepts for use in an Australian context."/>
+  <jurisdiction>
+    <coding>
+      <system value="urn:iso:std:iso:3166"/>
+      <code value="AU"/>
+    </coding>
+  </jurisdiction>
   <copyright value="HL7 Australia© 2018+; Licensed Under Creative Commons No Rights Reserved."/>
-  <fhirVersion value="4.0.0" />
-  <kind value="resource" />
-  <abstract value="false" />
-  <type value="Condition" />
-  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Condition" />
-  <derivation value="constraint" />
+  <fhirVersion value="4.0.1"/>
+  <kind value="resource"/>
+  <abstract value="false"/>
+  <type value="Condition"/>
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Condition"/>
+  <derivation value="constraint"/>
   <differential>
     <element id="Condition">
-      <path value="Condition" />
-      <short value="A condition, problem or diagnosis statement in an Australian healthcare context" />
+      <path value="Condition"/>
+      <short value="A condition, problem or diagnosis statement in an Australian healthcare context"
+      />
     </element>
     <element id="Condition.extension">
-      <path value="Condition.extension" />
+      <path value="Condition.extension"/>
       <slicing>
         <discriminator>
-          <type value="value" />
-          <path value="url" />
+          <type value="value"/>
+          <path value="url"/>
         </discriminator>
-        <rules value="open" />
+        <rules value="open"/>
       </slicing>
     </element>
     <element id="Condition.code">
-      <path value="Condition.code" />
+      <path value="Condition.code"/>
       <binding>
         <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
-          <valueString value="ConditionKind" />
+          <valueString value="ConditionKind"/>
         </extension>
-        <strength value="preferred" />
-        <description value="Preferred SNOMED-CT Identification of the condition or diagnosis." />
-        <valueSet value="https://healthterminologies.gov.au/fhir/ValueSet/clinical-condition-1" />
+        <strength value="preferred"/>
+        <description value="Preferred SNOMED-CT Identification of the condition or diagnosis."/>
+        <valueSet value="https://healthterminologies.gov.au/fhir/ValueSet/clinical-condition-1"/>
       </binding>
     </element>
     <element id="Condition.bodySite">
-      <path value="Condition.bodySite" />
+      <path value="Condition.bodySite"/>
       <binding>
-        <strength value="preferred" />
-        <valueSet value="https://healthterminologies.gov.au/fhir/ValueSet/body-site-1" />
+        <strength value="preferred"/>
+        <valueSet value="https://healthterminologies.gov.au/fhir/ValueSet/body-site-1"/>
       </binding>
     </element>
     <element id="Condition.evidence">
-      <path value="Condition.evidence" />
-      <short value="Supporting evidence for condition" />
+      <path value="Condition.evidence"/>
+      <short value="Supporting evidence for condition"/>
     </element>
     <element id="Condition.evidence.code">
-      <path value="Condition.evidence.code" />
-      <short value="Evidence manifestation/symptom" />
+      <path value="Condition.evidence.code"/>
+      <short value="Evidence manifestation/symptom"/>
       <binding>
         <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
-          <valueString value="ManifestationOrSymptom" />
+          <valueString value="ManifestationOrSymptom"/>
         </extension>
-        <strength value="preferred" />
-        <description value="Preferred SNOMED-CT Codes that describe the manifestation or symptoms of a condition." />
-        <valueSet value="https://healthterminologies.gov.au/fhir/ValueSet/clinical-finding-1" />
+        <strength value="preferred"/>
+        <description
+          value="Preferred SNOMED-CT Codes that describe the manifestation or symptoms of a condition."/>
+        <valueSet value="https://healthterminologies.gov.au/fhir/ValueSet/clinical-finding-1"/>
       </binding>
     </element>
   </differential>

--- a/resources/au-dosage.xml
+++ b/resources/au-dosage.xml
@@ -1,101 +1,110 @@
 <?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
-  <id value="au-dosage" />
-  <url value="http://hl7.org.au/fhir/StructureDefinition/au-dosage" />
+  <id value="au-dosage"/>
+  <url value="http://hl7.org.au/fhir/StructureDefinition/au-dosage"/>
   <version value="2.1.0"/>
-  <name value="AUBaseDosage" />
-  <title value="AU Base Dosage" />
-  <status value="draft" />
-  <publisher value="Health Level Seven Australia (Medications WG)" />
+  <name value="AUBaseDosage"/>
+  <title value="AU Base Dosage"/>
+  <status value="draft"/>
+  <date value="2020-01-22"/>
+  <publisher value="Health Level Seven Australia (Medications WG)"/>
   <contact>
     <telecom>
-      <system value="url" />
-      <value value="http://hl7.org.au" />
-      <use value="work" />
+      <system value="url"/>
+      <value value="http://hl7.org.au"/>
+      <use value="work"/>
     </telecom>
   </contact>
-  <description value="This profile defines a dosage structure including core localisation concepts for use in an Australian context." />
+  <description
+    value="This profile defines a dosage structure including core localisation concepts for use in an Australian context."/>
+  <jurisdiction>
+    <coding>
+      <system value="urn:iso:std:iso:3166"/>
+      <code value="AU"/>
+    </coding>
+  </jurisdiction>
   <copyright value="HL7 Australia© 2018+; Licensed Under Creative Commons No Rights Reserved."/>
-  <fhirVersion value="4.0.0" />
-  <kind value="complex-type" />
-  <abstract value="false" />
-  <type value="Dosage" />
-  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Dosage" />
-  <derivation value="constraint" />
+  <fhirVersion value="4.0.1"/>
+  <kind value="complex-type"/>
+  <abstract value="false"/>
+  <type value="Dosage"/>
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Dosage"/>
+  <derivation value="constraint"/>
   <differential>
     <element id="Dosage">
-      <path value="Dosage" />
-      <short value="Dosage information in an Australian healthcare context" />
+      <path value="Dosage"/>
+      <short value="Dosage information in an Australian healthcare context"/>
     </element>
     <element id="Dosage.additionalInstruction">
-      <path value="Dosage.additionalInstruction" />
+      <path value="Dosage.additionalInstruction"/>
       <slicing>
         <discriminator>
-          <type value="value" />
-          <path value="coding.system" />
+          <type value="value"/>
+          <path value="coding.system"/>
         </discriminator>
-        <rules value="open" />
+        <rules value="open"/>
       </slicing>
     </element>
     <element id="Dosage.additionalInstruction:snomedAdditionalInstruction">
-      <path value="Dosage.additionalInstruction" />
-      <sliceName value="snomedAdditionalInstruction" />
-      <short value="SNOMED CT Additional Instruction" />
+      <path value="Dosage.additionalInstruction"/>
+      <sliceName value="snomedAdditionalInstruction"/>
+      <short value="SNOMED CT Additional Instruction"/>
       <binding>
-        <strength value="preferred" />
-        <valueSet value="http://hl7.org/fhir/ValueSet/additional-instruction-codes" />
+        <strength value="preferred"/>
+        <valueSet value="http://hl7.org/fhir/ValueSet/additional-instruction-codes"/>
       </binding>
     </element>
     <element id="Dosage.asNeeded[x]">
-      <path value="Dosage.asNeeded[x]" />
+      <path value="Dosage.asNeeded[x]"/>
       <slicing>
         <discriminator>
-          <type value="type" />
-          <path value="$this" />
+          <type value="type"/>
+          <path value="$this"/>
         </discriminator>
-        <rules value="closed" />
+        <rules value="closed"/>
       </slicing>
     </element>
     <element id="Dosage.asNeeded[x]:asNeededCodeableConcept">
-      <path value="Dosage.asNeeded[x]" />
-      <sliceName value="asNeededCodeableConcept" />
-      <short value="Clinical Finding (SNOMED CT)" />
+      <path value="Dosage.asNeeded[x]"/>
+      <sliceName value="asNeededCodeableConcept"/>
+      <short value="Clinical Finding (SNOMED CT)"/>
       <binding>
-        <strength value="preferred" />
-        <valueSet value="https://healthterminologies.gov.au/fhir/ValueSet/clinical-finding-1" />
+        <strength value="preferred"/>
+        <valueSet value="https://healthterminologies.gov.au/fhir/ValueSet/clinical-finding-1"/>
       </binding>
       <type>
         <code value="CodeableConcept"/>
       </type>
     </element>
     <element id="Dosage.asNeeded[x]:asNeededBoolean">
-      <path value="Dosage.asNeeded[x]" />
-      <sliceName value="asNeededBoolean" />
+      <path value="Dosage.asNeeded[x]"/>
+      <sliceName value="asNeededBoolean"/>
       <type>
         <code value="boolean"/>
       </type>
     </element>
     <element id="Dosage.site">
-      <path value="Dosage.site" />
+      <path value="Dosage.site"/>
       <binding>
-        <strength value="preferred" />
-        <valueSet value="https://healthterminologies.gov.au/fhir/ValueSet/body-site-1" />
+        <strength value="preferred"/>
+        <valueSet value="https://healthterminologies.gov.au/fhir/ValueSet/body-site-1"/>
       </binding>
     </element>
     <element id="Dosage.route">
-      <path value="Dosage.route" />
-      <short value="Route of Administration (SNOMED CT)" />
+      <path value="Dosage.route"/>
+      <short value="Route of Administration (SNOMED CT)"/>
       <binding>
-        <strength value="preferred" />
-        <valueSet value="https://healthterminologies.gov.au/fhir/ValueSet/route-of-administration-1" />
+        <strength value="preferred"/>
+        <valueSet value="https://healthterminologies.gov.au/fhir/ValueSet/route-of-administration-1"
+        />
       </binding>
     </element>
     <element id="Dosage.method">
-      <path value="Dosage.method" />
-      <short value="SNOMED CT Administration Method" />
+      <path value="Dosage.method"/>
+      <short value="SNOMED CT Administration Method"/>
       <binding>
-        <strength value="preferred" />
-        <valueSet value="http://hl7.org/fhir/ValueSet/administration-method-codes" />
+        <strength value="preferred"/>
+        <valueSet value="http://hl7.org/fhir/ValueSet/administration-method-codes"/>
       </binding>
     </element>
   </differential>

--- a/resources/au-dosage.xml
+++ b/resources/au-dosage.xml
@@ -10,9 +10,9 @@
   <publisher value="Health Level Seven Australia (Medications WG)"/>
   <contact>
     <telecom>
-      <system value="url"/>
-      <value value="http://hl7.org.au"/>
-      <use value="work"/>
+      <system value="url" />
+      <value value="http://hl7.com.au" />
+      <use value="work" />
     </telecom>
   </contact>
   <description

--- a/resources/au-immunization.xml
+++ b/resources/au-immunization.xml
@@ -1,253 +1,271 @@
 <?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
-  <id value="au-immunization" />
-  <url value="http://hl7.org.au/fhir/StructureDefinition/au-immunization" />
+  <id value="au-immunization"/>
+  <url value="http://hl7.org.au/fhir/StructureDefinition/au-immunization"/>
   <version value="2.1.0"/>
-  <name value="AUBaseImmunisation" />
-  <title value="AU Base Immunisation" />
-  <status value="active" />
-  <date value="2019-10-22" />
-  <publisher value="Health Level Seven Australia (Medications WG)" />
+  <name value="AUBaseImmunisation"/>
+  <title value="AU Base Immunisation"/>
+  <status value="active"/>
+  <date value="2020-01-22"/>
+  <publisher value="Health Level Seven Australia (Medications WG)"/>
   <contact>
     <telecom>
-      <system value="url" />
-      <value value="http://hl7.com.au" />
-      <use value="work" />
+      <system value="url"/>
+      <value value="http://hl7.com.au"/>
+      <use value="work"/>
     </telecom>
   </contact>
-  <description value="This profile defines an immunisation structure including core localisation concepts for use in an Australian context." />
+  <description
+    value="This profile defines an immunisation structure including core localisation concepts for use in an Australian context."/>
+  <jurisdiction>
+    <coding>
+      <system value="urn:iso:std:iso:3166"/>
+      <code value="AU"/>
+    </coding>
+  </jurisdiction>
   <copyright value="HL7 Australia© 2018+; Licensed Under Creative Commons No Rights Reserved."/>
-  <fhirVersion value="4.0.0" />
-  <kind value="resource" />
-  <abstract value="false" />
-  <type value="Immunization" />
-  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Immunization" />
-  <derivation value="constraint" />
+  <fhirVersion value="4.0.1"/>
+  <kind value="resource"/>
+  <abstract value="false"/>
+  <type value="Immunization"/>
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Immunization"/>
+  <derivation value="constraint"/>
   <differential>
     <element id="Immunization">
-      <path value="Immunization" />
-      <short value="An immunisation statement in an Australian healthcare context" />
+      <path value="Immunization"/>
+      <short value="An immunisation statement in an Australian healthcare context"/>
     </element>
     <element id="Immunization.statusReason">
-      <path value="Immunization.statusReason" />
+      <path value="Immunization.statusReason"/>
       <binding>
-        <strength value="preferred" />
-        <valueSet value="https://healthterminologies.gov.au/fhir/ValueSet/reason-vaccine-not-administered-1" />
+        <strength value="preferred"/>
+        <valueSet
+          value="https://healthterminologies.gov.au/fhir/ValueSet/reason-vaccine-not-administered-1"
+        />
       </binding>
     </element>
     <element id="Immunization.vaccineCode">
-      <path value="Immunization.vaccineCode" />
-      <short value="Vaccine product for administration" />
+      <path value="Immunization.vaccineCode"/>
+      <short value="Vaccine product for administration"/>
     </element>
     <element id="Immunization.vaccineCode.coding">
-      <path value="Immunization.vaccineCode.coding" />
+      <path value="Immunization.vaccineCode.coding"/>
       <slicing>
         <discriminator>
-          <type value="value" />
-          <path value="system" />
+          <type value="value"/>
+          <path value="system"/>
         </discriminator>
-        <ordered value="false" />
-        <rules value="open" />
+        <ordered value="false"/>
+        <rules value="open"/>
       </slicing>
     </element>
     <element id="Immunization.vaccineCode.coding:amtVaccineCode">
-      <path value="Immunization.vaccineCode.coding" />
-      <sliceName value="amtVaccineCode" />
-      <short value="AMT Vaccine" />
-      <max value="1" />
+      <path value="Immunization.vaccineCode.coding"/>
+      <sliceName value="amtVaccineCode"/>
+      <short value="AMT Vaccine"/>
+      <max value="1"/>
       <binding>
-        <strength value="preferred" />
-        <valueSet value="https://healthterminologies.gov.au/fhir/ValueSet/amt-vaccine-1" />
+        <strength value="preferred"/>
+        <valueSet value="https://healthterminologies.gov.au/fhir/ValueSet/amt-vaccine-1"/>
       </binding>
     </element>
     <element id="Immunization.vaccineCode.coding:amtVaccineCode.system">
-      <path value="Immunization.vaccineCode.coding.system" />
-      <min value="1" />
-      <fixedUri value="http://snomed.info/sct" />
+      <path value="Immunization.vaccineCode.coding.system"/>
+      <min value="1"/>
+      <fixedUri value="http://snomed.info/sct"/>
     </element>
     <element id="Immunization.vaccineCode.coding:airVaccineCode">
-      <path value="Immunization.vaccineCode.coding" />
-      <sliceName value="airVaccineCode" />
-      <short value="AIR Vaccine" />
-      <max value="1" />
+      <path value="Immunization.vaccineCode.coding"/>
+      <sliceName value="airVaccineCode"/>
+      <short value="AIR Vaccine"/>
+      <max value="1"/>
       <binding>
-        <strength value="required" />
-        <valueSet value="https://healthterminologies.gov.au/fhir/ValueSet/australian-immunisation-register-vaccine-1" />
+        <strength value="required"/>
+        <valueSet
+          value="https://healthterminologies.gov.au/fhir/ValueSet/australian-immunisation-register-vaccine-1"
+        />
       </binding>
     </element>
     <element id="Immunization.vaccineCode.coding:airVaccineCode.system">
-      <path value="Immunization.vaccineCode.coding.system" />
-      <min value="1" />
-      <fixedUri value="https://www.humanservices.gov.au/organisations/health-professionals/enablers/air-vaccine-code-formats" />
+      <path value="Immunization.vaccineCode.coding.system"/>
+      <min value="1"/>
+      <fixedUri
+        value="https://www.humanservices.gov.au/organisations/health-professionals/enablers/air-vaccine-code-formats"
+      />
     </element>
     <element id="Immunization.patient">
-      <path value="Immunization.patient" />
-      <short value="Patient immunised" />
+      <path value="Immunization.patient"/>
+      <short value="Patient immunised"/>
     </element>
     <element id="Immunization.primarySource">
-      <path value="Immunization.primarySource" />
-      <short value="Optional information source" />
+      <path value="Immunization.primarySource"/>
+      <short value="Optional information source"/>
     </element>
     <element id="Immunization.manufacturer">
-      <path value="Immunization.manufacturer" />
-      <short value="Vaccine product manufacturer" />
-      <definition value="Physical vaccine product administered manufacturer." />
+      <path value="Immunization.manufacturer"/>
+      <short value="Vaccine product manufacturer"/>
+      <definition value="Physical vaccine product administered manufacturer."/>
     </element>
     <element id="Immunization.site">
-      <path value="Immunization.site" />
-      <short value="Body site vaccine was administered" />
+      <path value="Immunization.site"/>
+      <short value="Body site vaccine was administered"/>
     </element>
     <element id="Immunization.site.coding">
-      <path value="Immunization.site.coding" />
-      <max value="1" />
+      <path value="Immunization.site.coding"/>
+      <max value="1"/>
       <binding>
-        <strength value="required" />
-        <valueSet value="https://healthterminologies.gov.au/fhir/ValueSet/immunisation-anatomical-site-1" />
+        <strength value="required"/>
+        <valueSet
+          value="https://healthterminologies.gov.au/fhir/ValueSet/immunisation-anatomical-site-1"/>
       </binding>
     </element>
     <element id="Immunization.route">
-      <path value="Immunization.route" />
-      <short value="Route of vaccination" />
+      <path value="Immunization.route"/>
+      <short value="Route of vaccination"/>
     </element>
     <element id="Immunization.route.coding">
-      <path value="Immunization.route.coding" />
+      <path value="Immunization.route.coding"/>
       <slicing>
         <discriminator>
-          <type value="value" />
-          <path value="system" />
+          <type value="value"/>
+          <path value="system"/>
         </discriminator>
-        <rules value="open" />
+        <rules value="open"/>
       </slicing>
     </element>
     <element id="Immunization.route.coding:snomedRoute">
-      <path value="Immunization.route.coding" />
-      <sliceName value="snomedRoute" />
-      <short value="Immunisation Route of Administration (SNOMED CT)" />
-      <max value="1" />
+      <path value="Immunization.route.coding"/>
+      <sliceName value="snomedRoute"/>
+      <short value="Immunisation Route of Administration (SNOMED CT)"/>
+      <max value="1"/>
       <binding>
-        <strength value="required" />
-        <valueSet value="https://healthterminologies.gov.au/fhir/ValueSet/immunisation-route-of-administration-1" />
+        <strength value="required"/>
+        <valueSet
+          value="https://healthterminologies.gov.au/fhir/ValueSet/immunisation-route-of-administration-1"
+        />
       </binding>
     </element>
     <element id="Immunization.performer">
-      <path value="Immunization.performer" />
+      <path value="Immunization.performer"/>
       <slicing>
         <discriminator>
-          <type value="value" />
-          <path value="function" />
+          <type value="value"/>
+          <path value="function"/>
         </discriminator>
-        <rules value="open" />
+        <rules value="open"/>
       </slicing>
     </element>
     <element id="Immunization.performer.function">
-      <path value="Immunization.performer.function" />
+      <path value="Immunization.performer.function"/>
       <binding>
-        <strength value="extensible" />
-        <valueSet value="http://hl7.org.au/fhir/ValueSet/au-hl7v2-0443" />
+        <strength value="extensible"/>
+        <valueSet value="http://hl7.org.au/fhir/ValueSet/au-hl7v2-0443"/>
       </binding>
     </element>
     <element id="Immunization.performer:administeredBy">
-      <path value="Immunization.performer" />
-      <sliceName value="administeredBy" />
-      <short value="Immunisation Administered By" />
-      <max value="1" />
+      <path value="Immunization.performer"/>
+      <sliceName value="administeredBy"/>
+      <short value="Immunisation Administered By"/>
+      <max value="1"/>
     </element>
     <element id="Immunization.performer:administeredBy.function">
-      <path value="Immunization.performer.function" />
-      <short value="Administering role" />
-      <min value="1" />
+      <path value="Immunization.performer.function"/>
+      <short value="Administering role"/>
+      <min value="1"/>
     </element>
     <element id="Immunization.performer:administeredBy.function.coding">
-      <path value="Immunization.performer.function.coding" />
-      <min value="1" />
+      <path value="Immunization.performer.function.coding"/>
+      <min value="1"/>
       <fixedCoding>
-        <system value="http://hl7.org/fhir/v2/0443" />
-        <code value="AP" />
-        <display value="Administering Provider" />
+        <system value="http://hl7.org/fhir/v2/0443"/>
+        <code value="AP"/>
+        <display value="Administering Provider"/>
       </fixedCoding>
     </element>
     <element id="Immunization.performer:administeredBy.function.text">
-      <path value="Immunization.performer.function.text" />
-      <min value="1" />
-      <fixedString value="Administering Provider" />
+      <path value="Immunization.performer.function.text"/>
+      <min value="1"/>
+      <fixedString value="Administering Provider"/>
     </element>
     <element id="Immunization.performer:administeredBy.actor">
-      <path value="Immunization.performer.actor" />
-      <short value="Administering performer" />
+      <path value="Immunization.performer.actor"/>
+      <short value="Administering performer"/>
     </element>
     <element id="Immunization.performer:approvedBy">
-      <path value="Immunization.performer" />
-      <sliceName value="approvedBy" />
-      <short value="Immunisation Approved By" />
-      <max value="1" />
+      <path value="Immunization.performer"/>
+      <sliceName value="approvedBy"/>
+      <short value="Immunisation Approved By"/>
+      <max value="1"/>
     </element>
     <element id="Immunization.performer:approvedBy.function">
-      <path value="Immunization.performer.function" />
-      <short value="Approver role" />
-      <min value="1" />
+      <path value="Immunization.performer.function"/>
+      <short value="Approver role"/>
+      <min value="1"/>
     </element>
     <element id="Immunization.performer:approvedBy.function.coding">
-      <path value="Immunization.performer.function.coding" />
-      <min value="1" />
+      <path value="Immunization.performer.function.coding"/>
+      <min value="1"/>
       <fixedCoding>
-        <system value="http://hl7.org/fhir/v2/0443" />
-        <code value="OP" />
-        <display value="Ordering Provider" />
+        <system value="http://hl7.org/fhir/v2/0443"/>
+        <code value="OP"/>
+        <display value="Ordering Provider"/>
       </fixedCoding>
     </element>
     <element id="Immunization.performer:approvedBy.function.text">
-      <path value="Immunization.performer.function.text" />
-      <min value="1" />
-      <fixedString value="Ordering Provider" />
+      <path value="Immunization.performer.function.text"/>
+      <min value="1"/>
+      <fixedString value="Ordering Provider"/>
     </element>
     <element id="Immunization.performer:approvedBy.actor">
-      <path value="Immunization.performer.actor" />
-      <short value="Approving practitioner" />
+      <path value="Immunization.performer.actor"/>
+      <short value="Approving practitioner"/>
     </element>
     <element id="Immunization.reasonCode">
-      <path value="Immunization.reasonCode" />
+      <path value="Immunization.reasonCode"/>
       <binding>
-        <strength value="preferred" />
-        <valueSet value="https://healthterminologies.gov.au/fhir/ValueSet/reason-vaccine-administered-1" />
+        <strength value="preferred"/>
+        <valueSet
+          value="https://healthterminologies.gov.au/fhir/ValueSet/reason-vaccine-administered-1"/>
       </binding>
     </element>
     <element id="Immunization.protocolApplied">
-      <path value="Immunization.protocolApplied" />
-      <short value="Vaccination protocol" />
+      <path value="Immunization.protocolApplied"/>
+      <short value="Vaccination protocol"/>
     </element>
-       <element id="Immunization.protocolApplied.targetDisease">
-      <path value="Immunization.protocolApplied.targetDisease" />
-      <short value="Vaccine disease target" />
+    <element id="Immunization.protocolApplied.targetDisease">
+      <path value="Immunization.protocolApplied.targetDisease"/>
+      <short value="Vaccine disease target"/>
     </element>
     <element id="Immunization.protocolApplied.targetDisease.coding">
-      <path value="Immunization.protocolApplied.targetDisease.coding" />
+      <path value="Immunization.protocolApplied.targetDisease.coding"/>
       <slicing>
         <discriminator>
-          <type value="value" />
-          <path value="system" />
+          <type value="value"/>
+          <path value="system"/>
         </discriminator>
-        <rules value="open" />
+        <rules value="open"/>
       </slicing>
     </element>
     <element id="Immunization.protocolApplied.targetDisease.coding:snomedTargetDisease">
-      <path value="Immunization.protocolApplied.targetDisease.coding" />
-      <sliceName value="snomedTargetDisease" />
-      <short value="Vaccination Target Disease (SNOMED CT)" />
-      <max value="1" />
+      <path value="Immunization.protocolApplied.targetDisease.coding"/>
+      <sliceName value="snomedTargetDisease"/>
+      <short value="Vaccination Target Disease (SNOMED CT)"/>
+      <max value="1"/>
       <binding>
-        <strength value="required" />
-        <valueSet value="https://healthterminologies.gov.au/fhir/ValueSet/vaccination-target-disease-1" />
+        <strength value="required"/>
+        <valueSet
+          value="https://healthterminologies.gov.au/fhir/ValueSet/vaccination-target-disease-1"/>
       </binding>
     </element>
     <element id="Immunization.protocolApplied.targetDisease.coding:targetDiseaseNoInformation">
-      <path value="Immunization.protocolApplied.targetDisease.coding" />
-      <sliceName value="targetDiseaseNoInformation" />
-      <short value="No Information for Target Disease" />
-      <max value="1" />
+      <path value="Immunization.protocolApplied.targetDisease.coding"/>
+      <sliceName value="targetDiseaseNoInformation"/>
+      <short value="No Information for Target Disease"/>
+      <max value="1"/>
       <fixedCoding>
-        <system value="http://hl7.org/fhir/v3/NullFlavor" />
-        <code value="NI" />
-        <display value="NoInformation" />
+        <system value="http://hl7.org/fhir/v3/NullFlavor"/>
+        <code value="NI"/>
+        <display value="NoInformation"/>
       </fixedCoding>
     </element>
   </differential>

--- a/resources/au-medication.xml
+++ b/resources/au-medication.xml
@@ -1,88 +1,100 @@
 <?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
-  <id value="au-medication" />
+  <id value="au-medication"/>
   <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-wg">
-    <valueCode value="phx" />
+    <valueCode value="phx"/>
   </extension>
-  <url value="http://hl7.org.au/fhir/StructureDefinition/au-medication" />
+  <url value="http://hl7.org.au/fhir/StructureDefinition/au-medication"/>
   <version value="2.1.0"/>
-  <name value="AUBaseMedication" />
-  <title value="AU Base Medication" />
-  <status value="active" />
-  <date value="2017-05-11T10:06:07.8160426+10:00" />
-  <publisher value="Health Level Seven Australia (Medications WG)" />
+  <name value="AUBaseMedication"/>
+  <title value="AU Base Medication"/>
+  <status value="active"/>
+  <date value="2020-05-11"/>
+  <publisher value="Health Level Seven Australia (Medications WG)"/>
   <contact>
     <telecom>
-      <system value="url" />
-      <value value="http://hl7.com.au" />
-      <use value="work" />
+      <system value="url"/>
+      <value value="http://hl7.com.au"/>
+      <use value="work"/>
     </telecom>
   </contact>
-  <description value="This profile defines a medication structure including core localisation concepts for use in an Australian context." />
+  <description
+    value="This profile defines a medication structure including core localisation concepts for use in an Australian context."/>
+  <jurisdiction>
+    <coding>
+      <system value="urn:iso:std:iso:3166"/>
+      <code value="AU"/>
+    </coding>
+  </jurisdiction>
   <copyright value="HL7 Australia© 2018+; Licensed Under Creative Commons No Rights Reserved."/>
-  <fhirVersion value="4.0.0" />
-  <kind value="resource" />
-  <abstract value="false" />
-  <type value="Medication" />
-  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Medication" />
-  <derivation value="constraint" />
+  <fhirVersion value="4.0.1"/>
+  <kind value="resource"/>
+  <abstract value="false"/>
+  <type value="Medication"/>
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Medication"/>
+  <derivation value="constraint"/>
   <differential>
     <element id="Medication">
-      <path value="Medication" />
-      <short value="A medication in an Australian healthcare context" />
-      <definition value="Medication content use in an Australian context.  Includes concepts that are specific to Australian usage." />
+      <path value="Medication"/>
+      <short value="A medication in an Australian healthcare context"/>
+      <definition
+        value="Medication content use in an Australian context.  Includes concepts that are specific to Australian usage."
+      />
     </element>
     <element id="Medication.extension">
-      <path value="Medication.extension" />
+      <path value="Medication.extension"/>
       <slicing>
         <discriminator>
-          <type value="value" />
-          <path value="url" />
+          <type value="value"/>
+          <path value="url"/>
         </discriminator>
-        <rules value="open" />
+        <rules value="open"/>
       </slicing>
     </element>
     <element id="Medication.extension:brandName">
-      <path value="Medication.extension" />
-      <sliceName value="brandName" />
-      <short value="Medication Brand Name" />
+      <path value="Medication.extension"/>
+      <sliceName value="brandName"/>
+      <short value="Medication Brand Name"/>
       <type>
-        <code value="Extension" />
-        <profile value="http://hl7.org.au/fhir/StructureDefinition/medication-brand-name" />
+        <code value="Extension"/>
+        <profile value="http://hl7.org.au/fhir/StructureDefinition/medication-brand-name"/>
       </type>
     </element>
     <element id="Medication.extension:genericName">
-      <path value="Medication.extension" />
-      <sliceName value="genericName" />
-      <short value="Medication Generic Drug Name" />
+      <path value="Medication.extension"/>
+      <sliceName value="genericName"/>
+      <short value="Medication Generic Drug Name"/>
       <type>
-        <code value="Extension" />
-        <profile value="http://hl7.org.au/fhir/StructureDefinition/medication-generic-name" />
+        <code value="Extension"/>
+        <profile value="http://hl7.org.au/fhir/StructureDefinition/medication-generic-name"/>
       </type>
     </element>
     <element id="Medication.code">
-      <path value="Medication.code" />
-      <short value="Coding for the medicine" />
-      <definition value="Australian coding slices are typical medicine/product concept codes.&#xD;&#xA;&#xD;&#xA;A code (or set of codes) that specify this medication, or a textual description if no code is available. Usage note: This could be a standard medication code such as a code from RxNorm, SNOMED CT, IDMP etc. It could also be a national or local formulary code, optionally with translations to other code systems." />
+      <path value="Medication.code"/>
+      <short value="Coding for the medicine"/>
+      <definition
+        value="Australian coding slices are typical medicine/product concept codes.&#xD;&#xA;&#xD;&#xA;A code (or set of codes) that specify this medication, or a textual description if no code is available. Usage note: This could be a standard medication code such as a code from RxNorm, SNOMED CT, IDMP etc. It could also be a national or local formulary code, optionally with translations to other code systems."
+      />
     </element>
     <element id="Medication.code.coding">
-      <path value="Medication.code.coding" />
+      <path value="Medication.code.coding"/>
       <slicing>
         <discriminator>
-          <type value="value" />
-          <path value="system" />
+          <type value="value"/>
+          <path value="system"/>
         </discriminator>
-        <rules value="open" />
+        <rules value="open"/>
       </slicing>
     </element>
     <element id="Medication.code.coding:pbs">
-      <path value="Medication.code.coding" />
-      <sliceName value="pbs" />
-      <short value="PBS Item Code" />
-      <definition value="PBS code from http://pbs.gov.au/code/item. Use of PBS as a code to refer to a type of medication, this excludes implication of context based on the PBS code. Where context is to be implied or stated PBS code needs to be associated with recording a prescription (MedicationRequest) or dispense record(MedicationDispense)" />
+      <path value="Medication.code.coding"/>
+      <sliceName value="pbs"/>
+      <short value="PBS Item Code"/>
+      <definition
+        value="PBS code from http://pbs.gov.au/code/item. Use of PBS as a code to refer to a type of medication, this excludes implication of context based on the PBS code. Where context is to be implied or stated PBS code needs to be associated with recording a prescription (MedicationRequest) or dispense record(MedicationDispense)"/>
       <binding>
-        <strength value="preferred" />
-        <valueSet value="http://hl7.org.au/fhir/ValueSet/pbs-item" />
+        <strength value="preferred"/>
+        <valueSet value="http://hl7.org.au/fhir/ValueSet/pbs-item"/>
       </binding>
     </element>
     <element id="Medication.code.coding:pbs.system">
@@ -91,13 +103,13 @@
       <fixedUri value="http://pbs.gov.au/code/item"/>
     </element>
     <element id="Medication.code.coding:gtin">
-      <path value="Medication.code.coding" />
-      <sliceName value="gtin" />
-      <short value="Medication Package Global Trade Item Number (GTIN)" />
-      <definition value="GTIN value from http://www.gs1.org/gtin." />
+      <path value="Medication.code.coding"/>
+      <sliceName value="gtin"/>
+      <short value="Medication Package Global Trade Item Number (GTIN)"/>
+      <definition value="GTIN value from http://www.gs1.org/gtin."/>
       <binding>
-        <strength value="preferred" />
-        <valueSet value="http://hl7.org.au/fhir/ValueSet/gtin" />
+        <strength value="preferred"/>
+        <valueSet value="http://hl7.org.au/fhir/ValueSet/gtin"/>
       </binding>
     </element>
     <element id="Medication.code.coding:gtin.system">
@@ -106,31 +118,31 @@
       <fixedUri value="http://www.gs1.org/gtin"/>
     </element>
     <element id="Medication.code.coding:amt">
-      <path value="Medication.code.coding" />
-      <sliceName value="amt" />
-      <short value="AMT Medicines" />
+      <path value="Medication.code.coding"/>
+      <sliceName value="amt"/>
+      <short value="AMT Medicines"/>
       <binding>
-        <strength value="preferred" />
-        <valueSet value="https://healthterminologies.gov.au/fhir/ValueSet/australian-medication-1" />
+        <strength value="preferred"/>
+        <valueSet value="https://healthterminologies.gov.au/fhir/ValueSet/australian-medication-1"/>
       </binding>
     </element>
     <element id="Medication.code.coding:amt.extension">
-      <path value="Medication.code.coding.extension" />
+      <path value="Medication.code.coding.extension"/>
       <slicing>
         <discriminator>
-          <type value="value" />
-          <path value="url" />
+          <type value="value"/>
+          <path value="url"/>
         </discriminator>
-        <rules value="open" />
+        <rules value="open"/>
       </slicing>
     </element>
     <element id="Medication.code.coding:amt.extension:medicationClass">
-      <path value="Medication.code.coding.extension" />
-      <sliceName value="medicationClass" />
-      <max value="1" />
+      <path value="Medication.code.coding.extension"/>
+      <sliceName value="medicationClass"/>
+      <max value="1"/>
       <type>
-        <code value="Extension" />
-        <profile value="http://hl7.org.au/fhir/StructureDefinition/medication-type" />
+        <code value="Extension"/>
+        <profile value="http://hl7.org.au/fhir/StructureDefinition/medication-type"/>
       </type>
     </element>
     <element id="Medication.code.coding:amt.system">
@@ -139,13 +151,13 @@
       <fixedUri value="http://snomed.info/sct"/>
     </element>
     <element id="Medication.code.coding:mimsPackage">
-      <path value="Medication.code.coding" />
-      <sliceName value="mimsPackage" />
-      <short value="MIMS Package" />
-      <max value="1" />
+      <path value="Medication.code.coding"/>
+      <sliceName value="mimsPackage"/>
+      <short value="MIMS Package"/>
+      <max value="1"/>
       <binding>
-        <strength value="preferred" />
-        <valueSet value="http://hl7.org.au/fhir/ValueSet/mims" />
+        <strength value="preferred"/>
+        <valueSet value="http://hl7.org.au/fhir/ValueSet/mims"/>
       </binding>
     </element>
     <element id="Medication.code.coding:mimsPackage.system">
@@ -154,56 +166,61 @@
       <fixedUri value="http://www.mims.com.au/codes"/>
     </element>
     <element id="Medication.code.text">
-      <path value="Medication.code.text" />
-      <short value="Medication primary text" />
-      <definition value="A human language representation of the concept as seen/selected/uttered by the user who entered the data and/or which represents the intended meaning of the user.&#xD;&#xA;&#xD;&#xA;This may be a brand or generic name as suitable for the intent of the entry." />
+      <path value="Medication.code.text"/>
+      <short value="Medication primary text"/>
+      <definition
+        value="A human language representation of the concept as seen/selected/uttered by the user who entered the data and/or which represents the intended meaning of the user.&#xD;&#xA;&#xD;&#xA;This may be a brand or generic name as suitable for the intent of the entry."
+      />
     </element>
     <element id="Medication.manufacturer">
-      <path value="Medication.manufacturer" />
-      <short value="Physical product manufacturer organisation" />
-      <definition value="Manufacturer of the actual physical medicine product" />
+      <path value="Medication.manufacturer"/>
+      <short value="Physical product manufacturer organisation"/>
+      <definition value="Manufacturer of the actual physical medicine product"/>
     </element>
     <element id="Medication.form">
-      <path value="Medication.form" />
-      <max value="1" />
-         <binding>
-        <strength value="preferred" />
-        <valueSet value="https://healthterminologies.gov.au/fhir/ValueSet/medication-form-1" />
+      <path value="Medication.form"/>
+      <max value="1"/>
+      <binding>
+        <strength value="preferred"/>
+        <valueSet value="https://healthterminologies.gov.au/fhir/ValueSet/medication-form-1"/>
       </binding>
     </element>
 
     <element id="Medication.ingredient">
-      <path value="Medication.ingredient" />
-      <definition value="Identifies a particular constituent of interest in the product. Can be coded with AMT." />
+      <path value="Medication.ingredient"/>
+      <definition
+        value="Identifies a particular constituent of interest in the product. Can be coded with AMT."
+      />
     </element>
     <element id="Medication.ingredient.item[x]">
-      <path value="Medication.ingredient.item[x]" />
+      <path value="Medication.ingredient.item[x]"/>
       <slicing>
         <discriminator>
-          <type value="type" />
-          <path value="$this" />
+          <type value="type"/>
+          <path value="$this"/>
         </discriminator>
-        <rules value="closed" />
+        <rules value="closed"/>
       </slicing>
-      <short value="Medication ingredient" />
+      <short value="Medication ingredient"/>
     </element>
     <element id="Medication.ingredient.item[x]:itemCodeableConcept">
-      <path value="Medication.ingredient.item[x]" />
-      <sliceName value="itemCodeableConcept" />
-      <short value="Coded Ingredient Product" />
-      <definition value="Coding for a substance or medicinal product  that is an ingredient of the medication." />
+      <path value="Medication.ingredient.item[x]"/>
+      <sliceName value="itemCodeableConcept"/>
+      <short value="Coded Ingredient Product"/>
+      <definition
+        value="Coding for a substance or medicinal product  that is an ingredient of the medication."/>
       <min value="0"/>
       <type>
-        <code value="CodeableConcept" />
+        <code value="CodeableConcept"/>
       </type>
       <binding>
-        <strength value="preferred" />
-        <valueSet value="http://hl7.org.au/fhir/ValueSet/amt-mp-codes" />
+        <strength value="preferred"/>
+        <valueSet value="http://hl7.org.au/fhir/ValueSet/amt-mp-codes"/>
       </binding>
     </element>
     <element id="Medication.ingredient.strength">
-      <path value="Medication.ingredient.strength" />
-      <short value="Quantity/strength of ingredient present" />
+      <path value="Medication.ingredient.strength"/>
+      <short value="Quantity/strength of ingredient present"/>
     </element>
   </differential>
 </StructureDefinition>

--- a/resources/au-medicationadministration.xml
+++ b/resources/au-medicationadministration.xml
@@ -1,74 +1,84 @@
 <?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
-  <url value="http://hl7.org.au/fhir/StructureDefinition/au-medicationadministration" />
+  <url value="http://hl7.org.au/fhir/StructureDefinition/au-medicationadministration"/>
   <version value="2.1.0"/>
-  <name value="AUBaseMedicationAdministration" />
-  <title value="AUBaseMedicationAdministration" />
-  <status value="draft" />
-  <date value="2019-10-22" />
-  <publisher value="Health Level Seven Australia (Medications WG)" />
+  <name value="AUBaseMedicationAdministration"/>
+  <title value="AUBaseMedicationAdministration"/>
+  <status value="draft"/>
+  <date value="2020-01-22"/>
+  <publisher value="Health Level Seven Australia (Medications WG)"/>
   <contact>
     <telecom>
-      <system value="url" />
-      <value value="http://hl7.com.au" />
-      <use value="work" />
+      <system value="url"/>
+      <value value="http://hl7.com.au"/>
+      <use value="work"/>
     </telecom>
   </contact>
-  <description value="This profile defines a medication administration structure including core localisation concepts for use in an Australian context." />
+  <description
+    value="This profile defines a medication administration structure including core localisation concepts for use in an Australian context."/>
+  <jurisdiction>
+    <coding>
+      <system value="urn:iso:std:iso:3166"/>
+      <code value="AU"/>
+    </coding>
+  </jurisdiction>
   <copyright value="HL7 Australia© 2018+; Licensed Under Creative Commons No Rights Reserved."/>
-  <fhirVersion value="4.0.0" />
-  <kind value="resource" />
-  <abstract value="false" />
-  <type value="MedicationAdministration" />
-  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/MedicationAdministration" />
-  <derivation value="constraint" />
+  <fhirVersion value="4.0.1"/>
+  <kind value="resource"/>
+  <abstract value="false"/>
+  <type value="MedicationAdministration"/>
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/MedicationAdministration"/>
+  <derivation value="constraint"/>
   <differential>
     <element id="MedicationAdministration">
       <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
-        <valueCode value="draft" />
+        <valueCode value="draft"/>
       </extension>
-      <path value="MedicationAdministration" />
-      <short value="A record of medication administered to a patient in an Australian healthcare context" />
+      <path value="MedicationAdministration"/>
+      <short
+        value="A record of medication administered to a patient in an Australian healthcare context"
+      />
     </element>
     <element id="MedicationAdministration.medication[x]">
-      <path value="MedicationAdministration.medication[x]" />
+      <path value="MedicationAdministration.medication[x]"/>
       <slicing>
         <discriminator>
-          <type value="type" />
-          <path value="$this" />
+          <type value="type"/>
+          <path value="$this"/>
         </discriminator>
-        <rules value="closed" />
+        <rules value="closed"/>
       </slicing>
-      <short value="Medication Detail" />
+      <short value="Medication Detail"/>
     </element>
     <element id="MedicationAdministration.medication[x]:medicationCodeableConcept">
-      <path value="MedicationAdministration.medication[x]" />
-      <sliceName value="medicationCodeableConcept" />
-      <short value="Coded Medication" />
-      <min value="0" />
+      <path value="MedicationAdministration.medication[x]"/>
+      <sliceName value="medicationCodeableConcept"/>
+      <short value="Coded Medication"/>
+      <min value="0"/>
       <type>
-        <code value="CodeableConcept" />
+        <code value="CodeableConcept"/>
       </type>
     </element>
     <element id="MedicationAdministration.medication[x]:medicationCodeableConcept.coding">
-      <path value="MedicationAdministration.medication[x].coding" />
+      <path value="MedicationAdministration.medication[x].coding"/>
       <slicing>
         <discriminator>
-          <type value="value" />
-          <path value="system" />
+          <type value="value"/>
+          <path value="system"/>
         </discriminator>
-        <rules value="open" />
+        <rules value="open"/>
       </slicing>
-      <short value="Medication Codes" />
+      <short value="Medication Codes"/>
     </element>
     <element id="MedicationAdministration.medication[x]:medicationCodeableConcept.coding:pbs">
-      <path value="MedicationAdministration.medication[x].coding" />
-      <sliceName value="pbs" />
-      <short value="PBS Item Code" />
-      <definition value="PBS code from http://pbs.gov.au/code/item. Use of PBS as a code to refer to a type of medication, this excludes implication of context based on the PBS code. Where context is to be implied or stated PBS code needs to be associated with recording a prescription (MedicationRequest) or dispense record(MedicationDispense)" />
+      <path value="MedicationAdministration.medication[x].coding"/>
+      <sliceName value="pbs"/>
+      <short value="PBS Item Code"/>
+      <definition
+        value="PBS code from http://pbs.gov.au/code/item. Use of PBS as a code to refer to a type of medication, this excludes implication of context based on the PBS code. Where context is to be implied or stated PBS code needs to be associated with recording a prescription (MedicationRequest) or dispense record(MedicationDispense)"/>
       <binding>
-        <strength value="preferred" />
-        <valueSet value="http://hl7.org.au/fhir/ValueSet/pbs-item" />
+        <strength value="preferred"/>
+        <valueSet value="http://hl7.org.au/fhir/ValueSet/pbs-item"/>
       </binding>
     </element>
     <element id="MedicationAdministration.medication[x]:medicationCodeableConcept.coding:pbs.system">
@@ -77,48 +87,52 @@
       <fixedUri value="http://pbs.gov.au/code/item"/>
     </element>
     <element id="MedicationAdministration.medication[x]:medicationCodeableConcept.coding:gtin">
-      <path value="MedicationAdministration.medication[x].coding" />
-      <sliceName value="gtin" />
-      <short value="Medication Package Global Trade Item Number (GTIN)" />
-      <definition value="GTIN value from http://www.gs1.org/gtin." />
+      <path value="MedicationAdministration.medication[x].coding"/>
+      <sliceName value="gtin"/>
+      <short value="Medication Package Global Trade Item Number (GTIN)"/>
+      <definition value="GTIN value from http://www.gs1.org/gtin."/>
       <binding>
-        <strength value="preferred" />
-        <valueSet value="http://hl7.org.au/fhir/ValueSet/gtin" />
+        <strength value="preferred"/>
+        <valueSet value="http://hl7.org.au/fhir/ValueSet/gtin"/>
       </binding>
     </element>
-    <element id="MedicationAdministration.medication[x]:medicationCodeableConcept.coding:gtin.system">
+    <element
+      id="MedicationAdministration.medication[x]:medicationCodeableConcept.coding:gtin.system">
       <path value="MedicationAdministration.medication[x].coding.system"/>
       <min value="1"/>
       <fixedUri value="http://www.gs1.org/gtin"/>
     </element>
     <element id="MedicationAdministration.medication[x]:medicationCodeableConcept.coding:amt">
-      <path value="MedicationAdministration.medication[x].coding" />
-      <sliceName value="amt" />
-      <short value="AMT Medicines" />
+      <path value="MedicationAdministration.medication[x].coding"/>
+      <sliceName value="amt"/>
+      <short value="AMT Medicines"/>
       <binding>
-        <strength value="preferred" />
-        <valueSet value="https://healthterminologies.gov.au/fhir/ValueSet/australian-medication-1" />
+        <strength value="preferred"/>
+        <valueSet value="https://healthterminologies.gov.au/fhir/ValueSet/australian-medication-1"/>
       </binding>
     </element>
-    <element id="MedicationAdministration.medication[x]:medicationCodeableConcept.coding:amt.extension">
-      <path value="MedicationAdministration.medication[x].coding.extension" />
+    <element
+      id="MedicationAdministration.medication[x]:medicationCodeableConcept.coding:amt.extension">
+      <path value="MedicationAdministration.medication[x].coding.extension"/>
       <slicing>
         <discriminator>
-          <type value="value" />
-          <path value="url" />
+          <type value="value"/>
+          <path value="url"/>
         </discriminator>
-        <rules value="open" />
+        <rules value="open"/>
       </slicing>
     </element>
-    <element id="MedicationAdministration.medication[x]:medicationCodeableConcept.coding:amt.extension:medicationClass">
-      <path value="MedicationAdministration.medication[x].coding.extension" />
-      <sliceName value="medicationClass" />
-      <short value="Class of Medication Coding" />
-      <definition value="General category of coding to allow usage of codes to be distinguished from the same CodeSystem" />
-      <max value="1" />
+    <element
+      id="MedicationAdministration.medication[x]:medicationCodeableConcept.coding:amt.extension:medicationClass">
+      <path value="MedicationAdministration.medication[x].coding.extension"/>
+      <sliceName value="medicationClass"/>
+      <short value="Class of Medication Coding"/>
+      <definition
+        value="General category of coding to allow usage of codes to be distinguished from the same CodeSystem"/>
+      <max value="1"/>
       <type>
-        <code value="Extension" />
-        <profile value="http://hl7.org.au/fhir/StructureDefinition/medication-type" />
+        <code value="Extension"/>
+        <profile value="http://hl7.org.au/fhir/StructureDefinition/medication-type"/>
       </type>
     </element>
     <element id="MedicationAdministration.medication[x]:medicationCodeableConcept.coding:amt.system">
@@ -126,29 +140,31 @@
       <min value="1"/>
       <fixedUri value="http://snomed.info/sct"/>
     </element>
-    <element id="MedicationAdministration.medication[x]:medicationCodeableConcept.coding:mimsPackage">
-      <path value="MedicationAdministration.medication[x].coding" />
-      <sliceName value="mimsPackage" />
-      <short value="MIMS Package" />
-      <max value="1" />
+    <element
+      id="MedicationAdministration.medication[x]:medicationCodeableConcept.coding:mimsPackage">
+      <path value="MedicationAdministration.medication[x].coding"/>
+      <sliceName value="mimsPackage"/>
+      <short value="MIMS Package"/>
+      <max value="1"/>
       <binding>
-        <strength value="preferred" />
-        <valueSet value="http://hl7.org.au/fhir/ValueSet/mims" />
+        <strength value="preferred"/>
+        <valueSet value="http://hl7.org.au/fhir/ValueSet/mims"/>
       </binding>
     </element>
-    <element id="MedicationAdministration.medication[x]:medicationCodeableConcept.coding:mimsPackage.system">
+    <element
+      id="MedicationAdministration.medication[x]:medicationCodeableConcept.coding:mimsPackage.system">
       <path value="MedicationAdministration.medication[x].coding.system"/>
       <min value="1"/>
       <fixedUri value="http://www.mims.com.au/codes"/>
     </element>
     <element id="MedicationAdministration.medication[x]:medicationReference">
-      <path value="MedicationAdministration.medication[x]" />
-      <sliceName value="medicationReference" />
-      <short value="Medication Reference" />
-      <min value="0" />
+      <path value="MedicationAdministration.medication[x]"/>
+      <sliceName value="medicationReference"/>
+      <short value="Medication Reference"/>
+      <min value="0"/>
       <type>
-        <code value="Reference" />
-        <targetProfile value="http://hl7.org.au/fhir/StructureDefinition/au-medication" />
+        <code value="Reference"/>
+        <targetProfile value="http://hl7.org.au/fhir/StructureDefinition/au-medication"/>
       </type>
     </element>
   </differential>

--- a/resources/au-medicationdispense.xml
+++ b/resources/au-medicationdispense.xml
@@ -6,18 +6,25 @@
   <name value="AUBaseMedicationDispense"/>
   <title value="AU Base Medication Dispense"/>
   <status value="draft"/>
-  <date value="2019-10-22" />
+  <date value="2020-01-22"/>
   <publisher value="Health Level Seven Australia (Medications WG)"/>
   <contact>
     <telecom>
       <system value="url"/>
-      <value value="http://hl7.org.au/fhir"/>
+      <value value="http://hl7.com.au"/>
       <use value="work"/>
     </telecom>
   </contact>
-  <description value="This profile defines a medication dispense structure including core localisation concepts for use as a dispense record in an Australian context."/>
+  <description
+    value="This profile defines a medication dispense structure including core localisation concepts for use as a dispense record in an Australian context."/>
+  <jurisdiction>
+    <coding>
+      <system value="urn:iso:std:iso:3166"/>
+      <code value="AU"/>
+    </coding>
+  </jurisdiction>
   <copyright value="HL7 Australia© 2018+; Licensed Under Creative Commons No Rights Reserved."/>
-  <fhirVersion value="4.0.0" />
+  <fhirVersion value="4.0.1"/>
   <kind value="resource"/>
   <abstract value="false"/>
   <type value="MedicationDispense"/>
@@ -26,7 +33,8 @@
   <differential>
     <element id="MedicationDispense">
       <path value="MedicationDispense"/>
-      <short value="A dispense record for a medication for a patient in an Australian healthcare context"/>
+      <short
+        value="A dispense record for a medication for a patient in an Australian healthcare context"/>
       <definition value="Dispensing of a medication to patient in an Australian healthcare contex"/>
     </element>
     <element id="MedicationDispense.extension">
@@ -60,20 +68,22 @@
       </type>
     </element>
     <element id="MedicationDispense.extension:brandName">
-      <path value="MedicationDispense.extension" />
-      <sliceName value="brandName" />
-      <short value="Medication Brand Name" />
-      <definition value="The brand medication text name for an associated medication, this may be supplied if a coded brand name is not available for medicationCodeableConcept but the brand name is needed." />
+      <path value="MedicationDispense.extension"/>
+      <sliceName value="brandName"/>
+      <short value="Medication Brand Name"/>
+      <definition
+        value="The brand medication text name for an associated medication, this may be supplied if a coded brand name is not available for medicationCodeableConcept but the brand name is needed."/>
       <type>
         <code value="Extension"/>
         <profile value="http://hl7.org.au/fhir/StructureDefinition/medication-brand-name"/>
       </type>
     </element>
     <element id="MedicationDispense.extension:genericName">
-      <path value="MedicationDispense.extension" />
-      <sliceName value="genericName" />
-      <short value="Medication Generic Drug Name" />
-      <definition value="The generic medication text name for an associated medication, this may not be the same as the medicationCodeableConcept medication (prescribed, dispensed or stated) but may be used to provide an additional or equivalent drug name that is a generic medication concept. " />
+      <path value="MedicationDispense.extension"/>
+      <sliceName value="genericName"/>
+      <short value="Medication Generic Drug Name"/>
+      <definition
+        value="The generic medication text name for an associated medication, this may not be the same as the medicationCodeableConcept medication (prescribed, dispensed or stated) but may be used to provide an additional or equivalent drug name that is a generic medication concept. "/>
       <type>
         <code value="Extension"/>
         <profile value="http://hl7.org.au/fhir/StructureDefinition/medication-generic-name"/>
@@ -97,15 +107,17 @@
       <path value="MedicationDispense.identifier"/>
       <sliceName value="localDispenseIdentifier"/>
       <short value="Local Dispense Identifier"/>
-      <definition value="Identifier assigned by the dispensing system this allows linking of this dispensing record to a local system identfier."/>
+      <definition
+        value="Identifier assigned by the dispensing system this allows linking of this dispensing record to a local system identfier."
+      />
     </element>
     <element id="MedicationDispense.identifier:localDispenseIdentifier.type">
       <path value="MedicationDispense.identifier.type"/>
       <short value="Coded identifier type for local dispense identifier"/>
       <min value="1"/>
       <binding>
-        <strength value="required" />
-        <description value="Local identifier type" />
+        <strength value="required"/>
+        <description value="Local identifier type"/>
         <valueSet value="http://hl7.org.au/fhir/ValueSet/au-hl7v2-0203"/>
       </binding>
     </element>
@@ -168,7 +180,7 @@
       <path value="MedicationDispense.medication[x]"/>
       <sliceName value="medicationCodeableConcept"/>
       <short value="Coded Dispensed Medication"/>
-      <min value="0" />
+      <min value="0"/>
       <type>
         <code value="CodeableConcept"/>
       </type>
@@ -187,7 +199,8 @@
       <path value="MedicationDispense.medication[x].coding"/>
       <sliceName value="pbs"/>
       <short value="PBS Item Code"/>
-      <definition value="PBS code from http://pbs.gov.au/code/item. Use of PBS as a code to refer to a type of medication, this excludes implication of context based on the PBS code. Where context is to be implied or stated PBS code needs to be associated with recording a prescription (MedicationRequest) or dispense record(MedicationDispense)"/>
+      <definition
+        value="PBS code from http://pbs.gov.au/code/item. Use of PBS as a code to refer to a type of medication, this excludes implication of context based on the PBS code. Where context is to be implied or stated PBS code needs to be associated with recording a prescription (MedicationRequest) or dispense record(MedicationDispense)"/>
       <binding>
         <strength value="preferred"/>
         <valueSet value="http://hl7.org.au/fhir/ValueSet/pbs-item"/>
@@ -232,11 +245,13 @@
         <rules value="open"/>
       </slicing>
     </element>
-    <element id="MedicationDispense.medication[x]:medicationCodeableConcept.coding:amt.extension:medicationClass">
+    <element
+      id="MedicationDispense.medication[x]:medicationCodeableConcept.coding:amt.extension:medicationClass">
       <path value="MedicationDispense.medication[x].coding.extension"/>
       <sliceName value="medicationClass"/>
       <short value="Class of Medication Coding"/>
-      <definition value="General category of coding to allow usage of codes to be distinguished from the same CodeSystem"/>
+      <definition
+        value="General category of coding to allow usage of codes to be distinguished from the same CodeSystem"/>
       <max value="1"/>
       <type>
         <code value="Extension"/>
@@ -258,7 +273,8 @@
         <valueSet value="http://hl7.org.au/fhir/ValueSet/mims"/>
       </binding>
     </element>
-    <element id="MedicationDispense.medication[x]:medicationCodeableConcept.coding:mimsPackage.system">
+    <element
+      id="MedicationDispense.medication[x]:medicationCodeableConcept.coding:mimsPackage.system">
       <path value="MedicationDispense.medication[x].coding.system"/>
       <min value="1"/>
       <fixedUri value="http://www.mims.com.au/codes"/>
@@ -269,13 +285,15 @@
       </extension>
       <path value="MedicationDispense.medication[x].text"/>
       <short value="Medication primary text"/>
-      <definition value="A human language representation of the concept as seen/selected/uttered by the user who entered the data and/or which represents the intended meaning of the user.&#xD;&#xA;&#xD;&#xA;This may be a brand or generic name as suitable for the intent of the entry."/>
+      <definition
+        value="A human language representation of the concept as seen/selected/uttered by the user who entered the data and/or which represents the intended meaning of the user.&#xD;&#xA;&#xD;&#xA;This may be a brand or generic name as suitable for the intent of the entry."
+      />
     </element>
     <element id="MedicationDispense.medication[x]:medicationReference">
       <path value="MedicationDispense.medication[x]"/>
       <sliceName value="medicationReference"/>
       <short value="Dispensed Medication"/>
-      <min value="0" />
+      <min value="0"/>
       <type>
         <code value="Reference"/>
         <targetProfile value="http://hl7.org.au/fhir/StructureDefinition/au-medication"/>
@@ -301,9 +319,10 @@
     <element id="MedicationDispense.substitution.reason">
       <path value="MedicationDispense.substitution.reason"/>
       <max value="1"/>
-       <binding>
+      <binding>
         <strength value="preferred"/>
-        <valueSet value="https://healthterminologies.gov.au/fhir/ValueSet/medicine-substitution-reason-1"/>
+        <valueSet
+          value="https://healthterminologies.gov.au/fhir/ValueSet/medicine-substitution-reason-1"/>
       </binding>
     </element>
 

--- a/resources/au-medicationrequest.xml
+++ b/resources/au-medicationrequest.xml
@@ -1,260 +1,278 @@
 <?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
-  <id value="au-medicationrequest" />
-  <url value="http://hl7.org.au/fhir/StructureDefinition/au-medicationrequest" />
+  <id value="au-medicationrequest"/>
+  <url value="http://hl7.org.au/fhir/StructureDefinition/au-medicationrequest"/>
   <version value="2.1.0"/>
-  <name value="AUBaseMedicationRequest" />
-  <title value="AU Base Medication Request" />
-  <status value="draft" />
-  <date value="2019-10-22" />
-  <publisher value="Health Level Seven Australia (Medications WG)" />
+  <name value="AUBaseMedicationRequest"/>
+  <title value="AU Base Medication Request"/>
+  <status value="draft"/>
+  <date value="2020-01-22"/>
+  <publisher value="Health Level Seven Australia (Medications WG)"/>
   <contact>
     <telecom>
-      <system value="url" />
-      <value value="http://hl7.com.au" />
-      <use value="work" />
+      <system value="url"/>
+      <value value="http://hl7.com.au"/>
+      <use value="work"/>
     </telecom>
   </contact>
-  <description value="This profile defines a medication request structure including core localisation concepts for use as a prescription in an Australian context." />
+  <description
+    value="This profile defines a medication request structure including core localisation concepts for use as a prescription in an Australian context."/>
+  <jurisdiction>
+    <coding>
+      <system value="urn:iso:std:iso:3166"/>
+      <code value="AU"/>
+    </coding>
+  </jurisdiction>
   <copyright value="HL7 Australia© 2018+; Licensed Under Creative Commons No Rights Reserved."/>
-  <fhirVersion value="4.0.0" />
-  <kind value="resource" />
-  <abstract value="false" />
-  <type value="MedicationRequest" />
-  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/MedicationRequest" />
-  <derivation value="constraint" />
+  <fhirVersion value="4.0.1"/>
+  <kind value="resource"/>
+  <abstract value="false"/>
+  <type value="MedicationRequest"/>
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/MedicationRequest"/>
+  <derivation value="constraint"/>
   <differential>
     <element id="MedicationRequest">
-      <path value="MedicationRequest" />
-      <short value="A prescription for a medication for a patient in an Australian healthcare context" />
-      <definition value="Prescription of medication" />
+      <path value="MedicationRequest"/>
+      <short
+        value="A prescription for a medication for a patient in an Australian healthcare context"/>
+      <definition value="Prescription of medication"/>
     </element>
     <element id="MedicationRequest.extension">
-      <path value="MedicationRequest.extension" />
+      <path value="MedicationRequest.extension"/>
       <slicing>
         <discriminator>
-          <type value="value" />
-          <path value="url" />
+          <type value="value"/>
+          <path value="url"/>
         </discriminator>
-        <rules value="open" />
+        <rules value="open"/>
       </slicing>
     </element>
     <element id="MedicationRequest.extension:subsidisedConcurrentSupply">
-      <path value="MedicationRequest.extension" />
-      <sliceName value="subsidisedConcurrentSupply" />
-      <short value="Subsidised Concurrent Supply of Medication" />
-      <max value="1" />
+      <path value="MedicationRequest.extension"/>
+      <sliceName value="subsidisedConcurrentSupply"/>
+      <short value="Subsidised Concurrent Supply of Medication"/>
+      <max value="1"/>
       <type>
-        <code value="Extension" />
-        <profile value="http://hl7.org.au/fhir/StructureDefinition/subsidised-concurrent-supply" />
+        <code value="Extension"/>
+        <profile value="http://hl7.org.au/fhir/StructureDefinition/subsidised-concurrent-supply"/>
       </type>
     </element>
     <element id="MedicationRequest.extension:minimumIntervalBetweenRepeats">
-      <path value="MedicationRequest.extension" />
-      <sliceName value="minimumIntervalBetweenRepeats" />
-      <short value="Minimum Interval Between Repeats" />
+      <path value="MedicationRequest.extension"/>
+      <sliceName value="minimumIntervalBetweenRepeats"/>
+      <short value="Minimum Interval Between Repeats"/>
       <type>
-        <code value="Extension" />
-        <profile value="http://hl7.org.au/fhir/StructureDefinition/minimum-interval-between-repeats" />
+        <code value="Extension"/>
+        <profile value="http://hl7.org.au/fhir/StructureDefinition/minimum-interval-between-repeats"
+        />
       </type>
     </element>
     <element id="MedicationRequest.extension:brandName">
-      <path value="MedicationRequest.extension" />
-      <sliceName value="brandName" />
-      <short value="Medication Brand Name" />
-      <definition value="The brand medication text name for an associated medication, this may be supplied if a coded brand name is not available for medicationCodeableConcept but the brand name is needed." />
+      <path value="MedicationRequest.extension"/>
+      <sliceName value="brandName"/>
+      <short value="Medication Brand Name"/>
+      <definition
+        value="The brand medication text name for an associated medication, this may be supplied if a coded brand name is not available for medicationCodeableConcept but the brand name is needed."/>
       <type>
-        <code value="Extension" />
-        <profile value="http://hl7.org.au/fhir/StructureDefinition/medication-brand-name" />
+        <code value="Extension"/>
+        <profile value="http://hl7.org.au/fhir/StructureDefinition/medication-brand-name"/>
       </type>
     </element>
     <element id="MedicationRequest.extension:genericName">
-      <path value="MedicationRequest.extension" />
-      <sliceName value="genericName" />
-      <short value="Medication Generic Drug Name" />
-      <definition value="The generic medication text name for an associated medication, this may not be the same as the medicationCodeableConcept medication (prescribed, dispensed or stated) but may be used to provide an additional or equivalent drug name that is a generic medication concept. " />
+      <path value="MedicationRequest.extension"/>
+      <sliceName value="genericName"/>
+      <short value="Medication Generic Drug Name"/>
+      <definition
+        value="The generic medication text name for an associated medication, this may not be the same as the medicationCodeableConcept medication (prescribed, dispensed or stated) but may be used to provide an additional or equivalent drug name that is a generic medication concept. "/>
       <type>
-        <code value="Extension" />
-        <profile value="http://hl7.org.au/fhir/StructureDefinition/medication-generic-name" />
+        <code value="Extension"/>
+        <profile value="http://hl7.org.au/fhir/StructureDefinition/medication-generic-name"/>
       </type>
     </element>
     <element id="MedicationRequest.identifier">
-      <path value="MedicationRequest.identifier" />
+      <path value="MedicationRequest.identifier"/>
       <slicing>
         <discriminator>
-          <type value="value" />
-          <path value="system" />
+          <type value="value"/>
+          <path value="system"/>
         </discriminator>
         <discriminator>
-          <type value="value" />
-          <path value="type" />
+          <type value="value"/>
+          <path value="type"/>
         </discriminator>
-        <rules value="open" />
+        <rules value="open"/>
       </slicing>
     </element>
     <element id="MedicationRequest.identifier:etpVendorIdentifier">
-      <path value="MedicationRequest.identifier" />
-      <sliceName value="etpVendorIdentifier" />
-      <short value="Electronic Transfer of Prescription Supplier Identifier" />
-      <definition value="Identifier assigned by ETP vendor e.g. ERx, Medisecure etc. This is the assgigned numeric value typically represented as a barcode on a prescription instance." />
+      <path value="MedicationRequest.identifier"/>
+      <sliceName value="etpVendorIdentifier"/>
+      <short value="Electronic Transfer of Prescription Supplier Identifier"/>
+      <definition
+        value="Identifier assigned by ETP vendor e.g. ERx, Medisecure etc. This is the assgigned numeric value typically represented as a barcode on a prescription instance."
+      />
     </element>
     <element id="MedicationRequest.identifier:etpVendorIdentifier.type">
-      <path value="MedicationRequest.identifier.type" />
-      <min value="1" />
+      <path value="MedicationRequest.identifier.type"/>
+      <min value="1"/>
       <binding>
-        <strength value="required" />
-        <description value="Local Identifier Type" />
-        <valueSet value="http://hl7.org.au/fhir/ValueSet/au-hl7v2-0203" />
+        <strength value="required"/>
+        <description value="Local Identifier Type"/>
+        <valueSet value="http://hl7.org.au/fhir/ValueSet/au-hl7v2-0203"/>
       </binding>
     </element>
     <element id="MedicationRequest.identifier:etpVendorIdentifier.type.coding">
-      <path value="MedicationRequest.identifier.type.coding" />
-      <min value="1" />
-      <max value="1" />
+      <path value="MedicationRequest.identifier.type.coding"/>
+      <min value="1"/>
+      <max value="1"/>
     </element>
     <element id="MedicationRequest.identifier:etpVendorIdentifier.type.coding.system">
-      <path value="MedicationRequest.identifier.type.coding.system" />
-      <min value="1" />
-      <fixedUri value="http://hl7.org.au/fhir/v2/0203" />
+      <path value="MedicationRequest.identifier.type.coding.system"/>
+      <min value="1"/>
+      <fixedUri value="http://hl7.org.au/fhir/v2/0203"/>
     </element>
     <element id="MedicationRequest.identifier:etpVendorIdentifier.type.coding.code">
-      <path value="MedicationRequest.identifier.type.coding.code" />
-      <min value="1" />
-      <fixedCode value="ETP" />
+      <path value="MedicationRequest.identifier.type.coding.code"/>
+      <min value="1"/>
+      <fixedCode value="ETP"/>
     </element>
     <element id="MedicationRequest.identifier:etpVendorIdentifier.type.text">
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable">
-        <valueBoolean value="true" />
+        <valueBoolean value="true"/>
       </extension>
-      <path value="MedicationRequest.identifier.type.text" />
-      <min value="1" />
-      <fixedString value="ETP Identifier" />
+      <path value="MedicationRequest.identifier.type.text"/>
+      <min value="1"/>
+      <fixedString value="ETP Identifier"/>
     </element>
     <element id="MedicationRequest.identifier:etpVendorIdentifier.system">
-      <path value="MedicationRequest.identifier.system" />
-      <short value="ETP vendor identifier system URL" />
-      <definition value="URL assigned by the ETP (electronic transfer of prescription) vendor allocating the identifier." />
-      <min value="1" />
+      <path value="MedicationRequest.identifier.system"/>
+      <short value="ETP vendor identifier system URL"/>
+      <definition
+        value="URL assigned by the ETP (electronic transfer of prescription) vendor allocating the identifier."/>
+      <min value="1"/>
     </element>
     <element id="MedicationRequest.identifier:etpVendorIdentifier.value">
-      <path value="MedicationRequest.identifier.value" />
-      <short value="ETP vendor identifier" />
-      <definition value="ETP Vendor allocated identifier for the request this dispense record is fulfilling." />
-      <min value="1" />
+      <path value="MedicationRequest.identifier.value"/>
+      <short value="ETP vendor identifier"/>
+      <definition
+        value="ETP Vendor allocated identifier for the request this dispense record is fulfilling."/>
+      <min value="1"/>
     </element>
     <element id="MedicationRequest.identifier:etpVendorIdentifier.assigner">
-      <path value="MedicationRequest.identifier.assigner" />
-      <short value="ETP vendor" />
-      <definition value="ETP Vendor assigning this identifier" />
-      <min value="1" />
+      <path value="MedicationRequest.identifier.assigner"/>
+      <short value="ETP vendor"/>
+      <definition value="ETP Vendor assigning this identifier"/>
+      <min value="1"/>
     </element>
     <element id="MedicationRequest.identifier:etpVendorIdentifier.assigner.display">
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable">
-        <valueBoolean value="true" />
+        <valueBoolean value="true"/>
       </extension>
-      <path value="MedicationRequest.identifier.assigner.display" />
-      <short value="ETP vendor name" />
-      <definition value="Name of the ETP vendor assigning this identifier." />
-      <min value="1" />
+      <path value="MedicationRequest.identifier.assigner.display"/>
+      <short value="ETP vendor name"/>
+      <definition value="Name of the ETP vendor assigning this identifier."/>
+      <min value="1"/>
     </element>
     <element id="MedicationRequest.identifier:localScriptNumber">
-      <path value="MedicationRequest.identifier" />
-      <sliceName value="localScriptNumber" />
-      <short value="Local Prescription Number" />
-      <definition value="Identifier assigined by the prescribing system allows linking of a prescription record to local system identifier." />
+      <path value="MedicationRequest.identifier"/>
+      <sliceName value="localScriptNumber"/>
+      <short value="Local Prescription Number"/>
+      <definition
+        value="Identifier assigined by the prescribing system allows linking of a prescription record to local system identifier."
+      />
     </element>
     <element id="MedicationRequest.identifier:localScriptNumber.type">
-      <path value="MedicationRequest.identifier.type" />
-      <short value="Coded identifier type for local prescription number" />
-      <min value="1" />
+      <path value="MedicationRequest.identifier.type"/>
+      <short value="Coded identifier type for local prescription number"/>
+      <min value="1"/>
       <binding>
-        <strength value="required" />
-        <description value="Local Identifier Type" />
-        <valueSet value="http://hl7.org.au/fhir/ValueSet/au-hl7v2-0203" />
+        <strength value="required"/>
+        <description value="Local Identifier Type"/>
+        <valueSet value="http://hl7.org.au/fhir/ValueSet/au-hl7v2-0203"/>
       </binding>
     </element>
     <element id="MedicationRequest.identifier:localScriptNumber.type.coding">
-      <path value="MedicationRequest.identifier.type.coding" />
-      <min value="1" />
-      <max value="1" />
+      <path value="MedicationRequest.identifier.type.coding"/>
+      <min value="1"/>
+      <max value="1"/>
     </element>
     <element id="MedicationRequest.identifier:localScriptNumber.type.coding.system">
-      <path value="MedicationRequest.identifier.type.coding.system" />
-      <min value="1" />
-      <fixedUri value="http://hl7.org.au/fhir/v2/0203" />
+      <path value="MedicationRequest.identifier.type.coding.system"/>
+      <min value="1"/>
+      <fixedUri value="http://hl7.org.au/fhir/v2/0203"/>
     </element>
     <element id="MedicationRequest.identifier:localScriptNumber.type.coding.code">
-      <path value="MedicationRequest.identifier.type.coding.code" />
-      <min value="1" />
-      <fixedCode value="LPN" />
+      <path value="MedicationRequest.identifier.type.coding.code"/>
+      <min value="1"/>
+      <fixedCode value="LPN"/>
     </element>
     <element id="MedicationRequest.identifier:localScriptNumber.type.text">
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable">
-        <valueBoolean value="true" />
+        <valueBoolean value="true"/>
       </extension>
-      <path value="MedicationRequest.identifier.type.text" />
-      <min value="1" />
-      <fixedString value="Local Prescription Number" />
+      <path value="MedicationRequest.identifier.type.text"/>
+      <min value="1"/>
+      <fixedString value="Local Prescription Number"/>
     </element>
     <element id="MedicationRequest.identifier:localScriptNumber.system">
-      <path value="MedicationRequest.identifier.system" />
-      <short value="Namespace for local prescription number" />
-      <definition value="URL namespace assigned by the local prescription system." />
-      <min value="1" />
+      <path value="MedicationRequest.identifier.system"/>
+      <short value="Namespace for local prescription number"/>
+      <definition value="URL namespace assigned by the local prescription system."/>
+      <min value="1"/>
     </element>
     <element id="MedicationRequest.identifier:localScriptNumber.value">
-      <path value="MedicationRequest.identifier.value" />
-      <short value="Prescription number" />
-      <min value="1" />
+      <path value="MedicationRequest.identifier.value"/>
+      <short value="Prescription number"/>
+      <min value="1"/>
     </element>
     <element id="MedicationRequest.identifier:localScriptNumber.assigner">
-      <path value="MedicationRequest.identifier.assigner" />
-      <min value="1" />
+      <path value="MedicationRequest.identifier.assigner"/>
+      <min value="1"/>
     </element>
     <element id="MedicationRequest.identifier:localScriptNumber.assigner.display">
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable">
-        <valueBoolean value="true" />
+        <valueBoolean value="true"/>
       </extension>
-      <path value="MedicationRequest.identifier.assigner.display" />
-      <min value="1" />
+      <path value="MedicationRequest.identifier.assigner.display"/>
+      <min value="1"/>
     </element>
     <element id="MedicationRequest.medication[x]">
-      <path value="MedicationRequest.medication[x]" />
+      <path value="MedicationRequest.medication[x]"/>
       <slicing>
         <discriminator>
-          <type value="type" />
-          <path value="$this" />
+          <type value="type"/>
+          <path value="$this"/>
         </discriminator>
-        <rules value="closed" />
+        <rules value="closed"/>
       </slicing>
     </element>
     <element id="MedicationRequest.medication[x]:medicationCodeableConcept">
-      <path value="MedicationRequest.medication[x]" />
-      <sliceName value="medicationCodeableConcept" />
-      <short value="Coded Prescribed Medication" />
-      <min value="0" />
+      <path value="MedicationRequest.medication[x]"/>
+      <sliceName value="medicationCodeableConcept"/>
+      <short value="Coded Prescribed Medication"/>
+      <min value="0"/>
       <type>
-        <code value="CodeableConcept" />
+        <code value="CodeableConcept"/>
       </type>
     </element>
     <element id="MedicationRequest.medication[x]:medicationCodeableConcept.coding">
-      <path value="MedicationRequest.medication[x].coding" />
+      <path value="MedicationRequest.medication[x].coding"/>
       <slicing>
         <discriminator>
-          <type value="value" />
-          <path value="system" />
+          <type value="value"/>
+          <path value="system"/>
         </discriminator>
-        <rules value="open" />
+        <rules value="open"/>
       </slicing>
     </element>
     <element id="MedicationRequest.medication[x]:medicationCodeableConcept.coding:pbs">
-      <path value="MedicationRequest.medication[x].coding" />
-      <sliceName value="pbs" />
-      <short value="PBS Item Code" />
-      <definition value="PBS code from http://pbs.gov.au/code/item. Use of PBS as a code to refer to a type of medication, this excludes implication of context based on the PBS code. Where context is to be implied or stated PBS code needs to be associated with recording a prescription (MedicationRequest) or dispense record(MedicationDispense)" />
+      <path value="MedicationRequest.medication[x].coding"/>
+      <sliceName value="pbs"/>
+      <short value="PBS Item Code"/>
+      <definition
+        value="PBS code from http://pbs.gov.au/code/item. Use of PBS as a code to refer to a type of medication, this excludes implication of context based on the PBS code. Where context is to be implied or stated PBS code needs to be associated with recording a prescription (MedicationRequest) or dispense record(MedicationDispense)"/>
       <binding>
-        <strength value="preferred" />
-        <valueSet value="http://hl7.org.au/fhir/ValueSet/pbs-item" />
+        <strength value="preferred"/>
+        <valueSet value="http://hl7.org.au/fhir/ValueSet/pbs-item"/>
       </binding>
     </element>
     <element id="MedicationRequest.medication[x]:medicationCodeableConcept.coding:pbs.system">
@@ -263,13 +281,13 @@
       <fixedUri value="http://pbs.gov.au/code/item"/>
     </element>
     <element id="MedicationRequest.medication[x]:medicationCodeableConcept.coding:gtin">
-      <path value="MedicationRequest.medication[x].coding" />
-      <sliceName value="gtin" />
-      <short value="Medication Package Global Trade Item Number (GTIN)" />
-      <definition value="GTIN value from http://www.gs1.org/gtin." />
+      <path value="MedicationRequest.medication[x].coding"/>
+      <sliceName value="gtin"/>
+      <short value="Medication Package Global Trade Item Number (GTIN)"/>
+      <definition value="GTIN value from http://www.gs1.org/gtin."/>
       <binding>
-        <strength value="preferred" />
-        <valueSet value="http://hl7.org.au/fhir/ValueSet/gtin" />
+        <strength value="preferred"/>
+        <valueSet value="http://hl7.org.au/fhir/ValueSet/gtin"/>
       </binding>
     </element>
     <element id="MedicationRequest.medication[x]:medicationCodeableConcept.coding:gtin.system">
@@ -278,33 +296,35 @@
       <fixedUri value="http://www.gs1.org/gtin"/>
     </element>
     <element id="MedicationRequest.medication[x]:medicationCodeableConcept.coding:amt">
-      <path value="MedicationRequest.medication[x].coding" />
-      <sliceName value="amt" />
-      <short value="AMT Medicines" />
+      <path value="MedicationRequest.medication[x].coding"/>
+      <sliceName value="amt"/>
+      <short value="AMT Medicines"/>
       <binding>
-        <strength value="preferred" />
-        <valueSet value="https://healthterminologies.gov.au/fhir/ValueSet/australian-medication-1" />
+        <strength value="preferred"/>
+        <valueSet value="https://healthterminologies.gov.au/fhir/ValueSet/australian-medication-1"/>
       </binding>
     </element>
     <element id="MedicationRequest.medication[x]:medicationCodeableConcept.coding:amt.extension">
-      <path value="MedicationRequest.medication[x].coding.extension" />
+      <path value="MedicationRequest.medication[x].coding.extension"/>
       <slicing>
         <discriminator>
-          <type value="value" />
-          <path value="url" />
+          <type value="value"/>
+          <path value="url"/>
         </discriminator>
-        <rules value="open" />
+        <rules value="open"/>
       </slicing>
     </element>
-    <element id="MedicationRequest.medication[x]:medicationCodeableConcept.coding:amt.extension:medicationClass">
-      <path value="MedicationRequest.medication[x].coding.extension" />
-      <sliceName value="medicationClass" />
-      <short value="Class of Medication Coding" />
-      <definition value="General category of coding to allow usage of codes to be distinguished from the same CodeSystem" />
-      <max value="1" />
+    <element
+      id="MedicationRequest.medication[x]:medicationCodeableConcept.coding:amt.extension:medicationClass">
+      <path value="MedicationRequest.medication[x].coding.extension"/>
+      <sliceName value="medicationClass"/>
+      <short value="Class of Medication Coding"/>
+      <definition
+        value="General category of coding to allow usage of codes to be distinguished from the same CodeSystem"/>
+      <max value="1"/>
       <type>
-        <code value="Extension" />
-        <profile value="http://hl7.org.au/fhir/StructureDefinition/medication-type" />
+        <code value="Extension"/>
+        <profile value="http://hl7.org.au/fhir/StructureDefinition/medication-type"/>
       </type>
     </element>
     <element id="MedicationRequest.medication[x]:medicationCodeableConcept.coding:amt.system">
@@ -313,108 +333,112 @@
       <fixedUri value="http://snomed.info/sct"/>
     </element>
     <element id="MedicationRequest.medication[x]:medicationCodeableConcept.coding:mimsPackage">
-      <path value="MedicationRequest.medication[x].coding" />
-      <sliceName value="mimsPackage" />
-      <short value="MIMS Package" />
-      <max value="1" />
+      <path value="MedicationRequest.medication[x].coding"/>
+      <sliceName value="mimsPackage"/>
+      <short value="MIMS Package"/>
+      <max value="1"/>
       <binding>
-        <strength value="preferred" />
-        <valueSet value="http://hl7.org.au/fhir/ValueSet/mims" />
+        <strength value="preferred"/>
+        <valueSet value="http://hl7.org.au/fhir/ValueSet/mims"/>
       </binding>
     </element>
-    <element id="MedicationRequest.medication[x]:medicationCodeableConcept.coding:mimsPackage.system">
+    <element
+      id="MedicationRequest.medication[x]:medicationCodeableConcept.coding:mimsPackage.system">
       <path value="MedicationRequest.medication[x].coding.system"/>
       <min value="1"/>
       <fixedUri value="http://www.mims.com.au/codes"/>
     </element>
     <element id="MedicationRequest.medication[x]:medicationCodeableConcept.text">
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable">
-        <valueBoolean value="true" />
+        <valueBoolean value="true"/>
       </extension>
-      <path value="MedicationRequest.medication[x].text" />
-      <short value="Medication primary text" />
-      <definition value="A human language representation of the concept as seen/selected/uttered by the user who entered the data and/or which represents the intended meaning of the user.&#xD;&#xA;&#xD;&#xA;This may be a brand or generic name as suitable for the intent of the entry." />
+      <path value="MedicationRequest.medication[x].text"/>
+      <short value="Medication primary text"/>
+      <definition
+        value="A human language representation of the concept as seen/selected/uttered by the user who entered the data and/or which represents the intended meaning of the user.&#xD;&#xA;&#xD;&#xA;This may be a brand or generic name as suitable for the intent of the entry."
+      />
     </element>
     <element id="MedicationRequest.medication[x]:medicationReference">
-      <path value="MedicationRequest.medication[x]" />
-      <sliceName value="medicationReference" />
-      <short value="Prescribed Medication" />
-       <min value="0" />
+      <path value="MedicationRequest.medication[x]"/>
+      <sliceName value="medicationReference"/>
+      <short value="Prescribed Medication"/>
+      <min value="0"/>
       <type>
-        <code value="Reference" />
-        <targetProfile value="http://hl7.org.au/fhir/StructureDefinition/au-medication" />
+        <code value="Reference"/>
+        <targetProfile value="http://hl7.org.au/fhir/StructureDefinition/au-medication"/>
       </type>
     </element>
     <element id="MedicationRequest.supportingInformation">
-      <path value="MedicationRequest.supportingInformation" />
+      <path value="MedicationRequest.supportingInformation"/>
       <slicing>
         <discriminator>
-          <type value="profile" />
-          <path value="resolve()" />
+          <type value="profile"/>
+          <path value="resolve()"/>
         </discriminator>
-        <ordered value="false" />
-        <rules value="open" />
+        <ordered value="false"/>
+        <rules value="open"/>
       </slicing>
     </element>
     <element id="MedicationRequest.supportingInformation:bodyHeight">
-      <path value="MedicationRequest.supportingInformation" />
-      <sliceName value="bodyHeight" />
-      <short value="Observation of Body Height" />
-      <max value="1" />
+      <path value="MedicationRequest.supportingInformation"/>
+      <sliceName value="bodyHeight"/>
+      <short value="Observation of Body Height"/>
+      <max value="1"/>
       <type>
-        <code value="Reference" />
-        <targetProfile value="http://hl7.org/fhir/StructureDefinition/bodyheight" />
+        <code value="Reference"/>
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/bodyheight"/>
       </type>
     </element>
     <element id="MedicationRequest.supportingInformation:bodyWeight">
-      <path value="MedicationRequest.supportingInformation" />
-      <sliceName value="bodyWeight" />
-      <short value="Observation of Body Weight" />
-      <max value="1" />
+      <path value="MedicationRequest.supportingInformation"/>
+      <sliceName value="bodyWeight"/>
+      <short value="Observation of Body Weight"/>
+      <max value="1"/>
       <type>
-        <code value="Reference" />
-        <targetProfile value="http://hl7.org/fhir/StructureDefinition/bodyweight" />
+        <code value="Reference"/>
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/bodyweight"/>
       </type>
     </element>
     <element id="MedicationRequest.authoredOn">
-      <path value="MedicationRequest.authoredOn" />
-      <short value="Created date" />
+      <path value="MedicationRequest.authoredOn"/>
+      <short value="Created date"/>
     </element>
     <element id="MedicationRequest.reasonCode">
-      <path value="MedicationRequest.reasonCode" />
+      <path value="MedicationRequest.reasonCode"/>
       <binding>
-        <strength value="preferred" />
-        <valueSet value="https://healthterminologies.gov.au/fhir/ValueSet/reason-for-request-1" />
+        <strength value="preferred"/>
+        <valueSet value="https://healthterminologies.gov.au/fhir/ValueSet/reason-for-request-1"/>
       </binding>
     </element>
     <element id="MedicationRequest.dosageInstruction">
-      <path value="MedicationRequest.dosageInstruction" />
+      <path value="MedicationRequest.dosageInstruction"/>
       <type>
-        <code value="Dosage" />
-        <profile value="http://hl7.org.au/fhir/StructureDefinition/au-dosage" />
+        <code value="Dosage"/>
+        <profile value="http://hl7.org.au/fhir/StructureDefinition/au-dosage"/>
       </type>
     </element>
     <element id="MedicationRequest.dispenseRequest">
-      <path value="MedicationRequest.dispenseRequest" />
-      <short value="Requested dispensing" />
+      <path value="MedicationRequest.dispenseRequest"/>
+      <short value="Requested dispensing"/>
     </element>
     <element id="MedicationRequest.dispenseRequest.numberOfRepeatsAllowed">
-      <path value="MedicationRequest.dispenseRequest.numberOfRepeatsAllowed" />
-      <short value="Maximum repeats authorised" />
+      <path value="MedicationRequest.dispenseRequest.numberOfRepeatsAllowed"/>
+      <short value="Maximum repeats authorised"/>
     </element>
     <element id="MedicationRequest.substitution">
-      <path value="MedicationRequest.substitution" />
-      <short value="Brand substitution details" />
+      <path value="MedicationRequest.substitution"/>
+      <short value="Brand substitution details"/>
     </element>
     <element id="MedicationRequest.substitution.allowedBoolean">
-      <path value="MedicationRequest.substitution.allowed[x]" />
-      <short value="Brand substitution flag" />
+      <path value="MedicationRequest.substitution.allowed[x]"/>
+      <short value="Brand substitution flag"/>
     </element>
-  	<element id="MedicationRequest.substitution.reason">
-      <path value="MedicationRequest.substitution.reason" />
-       <binding>
-        <strength value="preferred" />
-        <valueSet value="https://healthterminologies.gov.au/fhir/ValueSet/medicine-substitution-reason-1" />
+    <element id="MedicationRequest.substitution.reason">
+      <path value="MedicationRequest.substitution.reason"/>
+      <binding>
+        <strength value="preferred"/>
+        <valueSet
+          value="https://healthterminologies.gov.au/fhir/ValueSet/medicine-substitution-reason-1"/>
       </binding>
     </element>
 

--- a/resources/au-medicationstatement.xml
+++ b/resources/au-medicationstatement.xml
@@ -1,113 +1,125 @@
 <?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
-  <id value="au-medicationstatement" />
-  <url value="http://hl7.org.au/fhir/StructureDefinition/au-medicationstatement" />
+  <id value="au-medicationstatement"/>
+  <url value="http://hl7.org.au/fhir/StructureDefinition/au-medicationstatement"/>
   <version value="2.1.0"/>
-  <name value="AUBaseMedicationStatement" />
-  <title value="AU Base Medication Statement" />
-  <status value="draft" />
-  <date value="2019-07-29" />
-  <publisher value="Health Level Seven Australia (Medications WG)" />
+  <name value="AUBaseMedicationStatement"/>
+  <title value="AU Base Medication Statement"/>
+  <status value="draft"/>
+  <date value="2020-07-29"/>
+  <publisher value="Health Level Seven Australia (Medications WG)"/>
   <contact>
     <telecom>
-      <system value="url" />
-      <value value="http://hl7.com.au" />
-      <use value="work" />
+      <system value="url"/>
+      <value value="http://hl7.com.au"/>
+      <use value="work"/>
     </telecom>
   </contact>
-  <description value="This profile defines a medication statement structure including core localisation concepts for use in an Australian context." />
+  <description
+    value="This profile defines a medication statement structure including core localisation concepts for use in an Australian context."/>
+  <jurisdiction>
+    <coding>
+      <system value="urn:iso:std:iso:3166"/>
+      <code value="AU"/>
+    </coding>
+  </jurisdiction>
   <copyright value="HL7 Australia© 2018+; Licensed Under Creative Commons No Rights Reserved."/>
-  <fhirVersion value="4.0.0" />
-  <kind value="resource" />
-  <abstract value="false" />
-  <type value="MedicationStatement" />
-  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/MedicationStatement" />
-  <derivation value="constraint" />
+  <fhirVersion value="4.0.1"/>
+  <kind value="resource"/>
+  <abstract value="false"/>
+  <type value="MedicationStatement"/>
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/MedicationStatement"/>
+  <derivation value="constraint"/>
   <differential>
     <element id="MedicationStatement">
-      <path value="MedicationStatement" />
-      <short value="A record of medication being taken by a patient in an Australian healthcare context" />
+      <path value="MedicationStatement"/>
+      <short
+        value="A record of medication being taken by a patient in an Australian healthcare context"
+      />
     </element>
     <element id="MedicationStatement.extension">
-      <path value="MedicationStatement.extension" />
+      <path value="MedicationStatement.extension"/>
       <slicing>
         <discriminator>
-          <type value="value" />
-          <path value="url" />
+          <type value="value"/>
+          <path value="url"/>
         </discriminator>
-        <rules value="open" />
+        <rules value="open"/>
       </slicing>
     </element>
     <element id="MedicationStatement.extension:longTerm">
-      <path value="MedicationStatement.extension" />
-      <sliceName value="longTerm" />
-      <short value="Medication Long Term Indicator" />
+      <path value="MedicationStatement.extension"/>
+      <sliceName value="longTerm"/>
+      <short value="Medication Long Term Indicator"/>
       <type>
-        <code value="Extension" />
-        <profile value="http://hl7.org.au/fhir/StructureDefinition/medication-long-term" />
+        <code value="Extension"/>
+        <profile value="http://hl7.org.au/fhir/StructureDefinition/medication-long-term"/>
       </type>
     </element>
     <element id="MedicationStatement.extension:brandName">
-      <path value="MedicationStatement.extension" />
-      <sliceName value="brandName" />
-      <short value="Medication Brand Name" />
-      <definition value="The brand medication text name for an associated medication, this may be supplied if a coded brand name is not available for medicationCodeableConcept but the brand name is needed." />
+      <path value="MedicationStatement.extension"/>
+      <sliceName value="brandName"/>
+      <short value="Medication Brand Name"/>
+      <definition
+        value="The brand medication text name for an associated medication, this may be supplied if a coded brand name is not available for medicationCodeableConcept but the brand name is needed."/>
       <type>
-        <code value="Extension" />
-        <profile value="http://hl7.org.au/fhir/StructureDefinition/medication-brand-name" />
+        <code value="Extension"/>
+        <profile value="http://hl7.org.au/fhir/StructureDefinition/medication-brand-name"/>
       </type>
     </element>
     <element id="MedicationStatement.extension:genericName">
-      <path value="MedicationStatement.extension" />
-      <sliceName value="genericName" />
-      <short value="Medication Generic Drug Name" />
-      <definition value="The generic medication text name for an associated medication, this may not be the same as the medicationCodeableConcept medication (prescribed, dispensed or stated) but may be used to provide an additional or equivalent drug name that is a generic medication concept. " />
+      <path value="MedicationStatement.extension"/>
+      <sliceName value="genericName"/>
+      <short value="Medication Generic Drug Name"/>
+      <definition
+        value="The generic medication text name for an associated medication, this may not be the same as the medicationCodeableConcept medication (prescribed, dispensed or stated) but may be used to provide an additional or equivalent drug name that is a generic medication concept. "/>
       <type>
-        <code value="Extension" />
-        <profile value="http://hl7.org.au/fhir/StructureDefinition/medication-generic-name" />
+        <code value="Extension"/>
+        <profile value="http://hl7.org.au/fhir/StructureDefinition/medication-generic-name"/>
       </type>
     </element>
     <element id="MedicationStatement.medication[x]">
-      <path value="MedicationStatement.medication[x]" />
+      <path value="MedicationStatement.medication[x]"/>
       <slicing>
         <discriminator>
-          <type value="type" />
-          <path value="$this" />
+          <type value="type"/>
+          <path value="$this"/>
         </discriminator>
-        <rules value="closed" />
+        <rules value="closed"/>
       </slicing>
-      <short value="Medication Detail" />
+      <short value="Medication Detail"/>
     </element>
     <element id="MedicationStatement.medication[x]:medicationCodeableConcept">
-      <path value="MedicationStatement.medication[x]" />
-      <sliceName value="medicationCodeableConcept" />
-      <short value="Coded Medication" />
+      <path value="MedicationStatement.medication[x]"/>
+      <sliceName value="medicationCodeableConcept"/>
+      <short value="Coded Medication"/>
       <min value="0"/>
       <type>
-        <code value="CodeableConcept" />
+        <code value="CodeableConcept"/>
       </type>
     </element>
     <element id="MedicationStatement.medication[x]:medicationCodeableConcept.coding">
-      <path value="MedicationStatement.medication[x].coding" />
+      <path value="MedicationStatement.medication[x].coding"/>
       <slicing>
         <discriminator>
-          <type value="value" />
-          <path value="system" />
+          <type value="value"/>
+          <path value="system"/>
         </discriminator>
-        <rules value="open" />
+        <rules value="open"/>
       </slicing>
-      <short value="Medication Codes" />
+      <short value="Medication Codes"/>
     </element>
     <element id="MedicationStatement.medication[x]:medicationCodeableConcept.coding:pbs">
-      <path value="MedicationStatement.medication[x].coding" />
-      <sliceName value="pbs" />
-      <short value="PBS Item Code" />
-      <definition value="PBS code from http://pbs.gov.au/code/item. Use of PBS as a code to refer to a type of medication, this excludes implication of context based on the PBS code. Where context is to be implied or stated PBS code needs to be associated with recording a prescription (MedicationRequest) or dispense record(MedicationDispense)" />
+      <path value="MedicationStatement.medication[x].coding"/>
+      <sliceName value="pbs"/>
+      <short value="PBS Item Code"/>
+      <definition
+        value="PBS code from http://pbs.gov.au/code/item. Use of PBS as a code to refer to a type of medication, this excludes implication of context based on the PBS code. Where context is to be implied or stated PBS code needs to be associated with recording a prescription (MedicationRequest) or dispense record(MedicationDispense)"/>
       <binding>
-        <strength value="preferred" />
-        <valueSet value="http://hl7.org.au/fhir/ValueSet/pbs-item" />
+        <strength value="preferred"/>
+        <valueSet value="http://hl7.org.au/fhir/ValueSet/pbs-item"/>
       </binding>
-      
+
     </element>
     <element id="MedicationStatement.medication[x]:medicationCodeableConcept.coding:pbs.system">
       <path value="MedicationStatement.medication[x].coding.system"/>
@@ -115,13 +127,13 @@
       <fixedUri value="http://pbs.gov.au/code/item"/>
     </element>
     <element id="MedicationStatement.medication[x]:medicationCodeableConcept.coding:gtin">
-      <path value="MedicationStatement.medication[x].coding" />
-      <sliceName value="gtin" />
-      <short value="Medication Package Global Trade Item Number (GTIN)" />
-      <definition value="GTIN value from http://www.gs1.org/gtin." />
+      <path value="MedicationStatement.medication[x].coding"/>
+      <sliceName value="gtin"/>
+      <short value="Medication Package Global Trade Item Number (GTIN)"/>
+      <definition value="GTIN value from http://www.gs1.org/gtin."/>
       <binding>
-        <strength value="preferred" />
-        <valueSet value="http://hl7.org.au/fhir/ValueSet/gtin" />
+        <strength value="preferred"/>
+        <valueSet value="http://hl7.org.au/fhir/ValueSet/gtin"/>
       </binding>
     </element>
     <element id="MedicationStatement.medication[x]:medicationCodeableConcept.coding:gtin.system">
@@ -130,33 +142,35 @@
       <fixedUri value="http://www.gs1.org/gtin"/>
     </element>
     <element id="MedicationStatement.medication[x]:medicationCodeableConcept.coding:amt">
-      <path value="MedicationStatement.medication[x].coding" />
-      <sliceName value="amt" />
-      <short value="AMT Medicines" />
+      <path value="MedicationStatement.medication[x].coding"/>
+      <sliceName value="amt"/>
+      <short value="AMT Medicines"/>
       <binding>
-        <strength value="preferred" />
-        <valueSet value="https://healthterminologies.gov.au/fhir/ValueSet/australian-medication-1" />
+        <strength value="preferred"/>
+        <valueSet value="https://healthterminologies.gov.au/fhir/ValueSet/australian-medication-1"/>
       </binding>
     </element>
     <element id="MedicationStatement.medication[x]:medicationCodeableConcept.coding:amt.extension">
-      <path value="MedicationStatement.medication[x].coding.extension" />
+      <path value="MedicationStatement.medication[x].coding.extension"/>
       <slicing>
         <discriminator>
-          <type value="value" />
-          <path value="url" />
+          <type value="value"/>
+          <path value="url"/>
         </discriminator>
-        <rules value="open" />
+        <rules value="open"/>
       </slicing>
     </element>
-    <element id="MedicationStatement.medication[x]:medicationCodeableConcept.coding:amt.extension:medicationClass">
-      <path value="MedicationStatement.medication[x].coding.extension" />
-      <sliceName value="medicationClass" />
-      <short value="Class of Medication Coding" />
-      <definition value="General category of coding to allow usage of codes to be distinguished from the same CodeSystem" />
-      <max value="1" />
+    <element
+      id="MedicationStatement.medication[x]:medicationCodeableConcept.coding:amt.extension:medicationClass">
+      <path value="MedicationStatement.medication[x].coding.extension"/>
+      <sliceName value="medicationClass"/>
+      <short value="Class of Medication Coding"/>
+      <definition
+        value="General category of coding to allow usage of codes to be distinguished from the same CodeSystem"/>
+      <max value="1"/>
       <type>
-        <code value="Extension" />
-        <profile value="http://hl7.org.au/fhir/StructureDefinition/medication-type" />
+        <code value="Extension"/>
+        <profile value="http://hl7.org.au/fhir/StructureDefinition/medication-type"/>
       </type>
     </element>
     <element id="MedicationStatement.medication[x]:medicationCodeableConcept.coding:amt.system">
@@ -165,42 +179,44 @@
       <fixedUri value="http://snomed.info/sct"/>
     </element>
     <element id="MedicationStatement.medication[x]:medicationCodeableConcept.coding:mimsPackage">
-      <path value="MedicationStatement.medication[x].coding" />
-      <sliceName value="mimsPackage" />
-      <short value="MIMS Package" />
-      <max value="1" />
+      <path value="MedicationStatement.medication[x].coding"/>
+      <sliceName value="mimsPackage"/>
+      <short value="MIMS Package"/>
+      <max value="1"/>
       <binding>
-        <strength value="preferred" />
-        <valueSet value="http://hl7.org.au/fhir/ValueSet/mims" />
+        <strength value="preferred"/>
+        <valueSet value="http://hl7.org.au/fhir/ValueSet/mims"/>
       </binding>
     </element>
-    <element id="MedicationStatement.medication[x]:medicationCodeableConcept.coding:mimsPackage.system">
+    <element
+      id="MedicationStatement.medication[x]:medicationCodeableConcept.coding:mimsPackage.system">
       <path value="MedicationStatement.medication[x].coding.system"/>
       <min value="1"/>
       <fixedUri value="http://www.mims.com.au/codes"/>
     </element>
     <element id="MedicationStatement.medication[x]:medicationReference">
-      <path value="MedicationStatement.medicationReference" />
-      <sliceName value="medicationReference" />
-      <short value="Medication Reference" />
+      <path value="MedicationStatement.medicationReference"/>
+      <sliceName value="medicationReference"/>
+      <short value="Medication Reference"/>
       <min value="0"/>
       <type>
-        <code value="Reference" />
-        <targetProfile value="http://hl7.org.au/fhir/StructureDefinition/au-medication" />
+        <code value="Reference"/>
+        <targetProfile value="http://hl7.org.au/fhir/StructureDefinition/au-medication"/>
       </type>
     </element>
     <element id="MedicationStatement.reasonCode">
-      <path value="MedicationStatement.reasonCode" />
-       <binding>
-        <strength value="preferred" />
-        <valueSet value="https://healthterminologies.gov.au/fhir/ValueSet/medication-reason-taken-1" />
+      <path value="MedicationStatement.reasonCode"/>
+      <binding>
+        <strength value="preferred"/>
+        <valueSet value="https://healthterminologies.gov.au/fhir/ValueSet/medication-reason-taken-1"
+        />
       </binding>
     </element>
     <element id="MedicationStatement.dosage">
-      <path value="MedicationStatement.dosage" />
+      <path value="MedicationStatement.dosage"/>
       <type>
-        <code value="Dosage" />
-        <profile value="http://hl7.org.au/fhir/StructureDefinition/au-dosage" />
+        <code value="Dosage"/>
+        <profile value="http://hl7.org.au/fhir/StructureDefinition/au-dosage"/>
       </type>
     </element>
   </differential>

--- a/resources/au-medlist.xml
+++ b/resources/au-medlist.xml
@@ -1,101 +1,109 @@
 <?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
-  <id value="au-medlist" />
-  <url value="http://hl7.org.au/fhir/StructureDefinition/au-medlist" />
+  <id value="au-medlist"/>
+  <url value="http://hl7.org.au/fhir/StructureDefinition/au-medlist"/>
   <version value="2.1.0"/>
-  <name value="AUMedicineList" />
-  <title value="AU Medicine List" />
-  <status value="draft" />
-  <date value="2018-11-30" />
-  <publisher value="Health Level Seven Australia (Medications WG)" />
+  <name value="AUMedicineList"/>
+  <title value="AU Medicine List"/>
+  <status value="draft"/>
+  <date value="2020-01-30"/>
+  <publisher value="Health Level Seven Australia (Medications WG)"/>
   <contact>
     <telecom>
-      <system value="url" />
-      <value value="http://hl7.com.au" />
-      <use value="work" />
+      <system value="url"/>
+      <value value="http://hl7.com.au"/>
+      <use value="work"/>
     </telecom>
   </contact>
-  <description value="This profile defines a list structure including core localisation concepts for use as a medicines list in an Australian context. This profile is intended to offer a common structure and expectations to record, exchange, and fetch a list of medications associated with a patient in an Australian healthcare context." />
+  <description
+    value="This profile defines a list structure including core localisation concepts for use as a medicines list in an Australian context. This profile is intended to offer a common structure and expectations to record, exchange, and fetch a list of medications associated with a patient in an Australian healthcare context."/>
+  <jurisdiction>
+    <coding>
+      <system value="urn:iso:std:iso:3166"/>
+      <code value="AU"/>
+    </coding>
+  </jurisdiction>
   <copyright value="HL7 Australia© 2018+; Licensed Under Creative Commons No Rights Reserved."/>
-  <fhirVersion value="4.0.0" />
-  <kind value="resource" />
-  <abstract value="false" />
-  <type value="List" />
-  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/List" />
-  <derivation value="constraint" />
+  <fhirVersion value="4.0.1"/>
+  <kind value="resource"/>
+  <abstract value="false"/>
+  <type value="List"/>
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/List"/>
+  <derivation value="constraint"/>
   <differential>
     <element id="List">
-      <path value="List" />
-      <short value="A list of medications in an Australian healthcare context" />
+      <path value="List"/>
+      <short value="A list of medications in an Australian healthcare context"/>
     </element>
     <element id="List.extension">
-      <path value="List.extension" />
+      <path value="List.extension"/>
       <slicing>
         <discriminator>
-          <type value="value" />
-          <path value="url" />
+          <type value="value"/>
+          <path value="url"/>
         </discriminator>
-        <rules value="open" />
+        <rules value="open"/>
       </slicing>
     </element>
     <element id="List.extension:sourceRelatedPerson">
-      <path value="List.extension" />
-      <sliceName value="sourceRelatedPerson" />
-      <short value="Related person that defined the list contents (aka Author)" />
-      <definition value="The entity (related person) responsible for deciding what the contents of the list were. Where the list was created by a human, this is the same as the author of the list." />
-      <min value="0" />
-      <max value="1" />
+      <path value="List.extension"/>
+      <sliceName value="sourceRelatedPerson"/>
+      <short value="Related person that defined the list contents (aka Author)"/>
+      <definition
+        value="The entity (related person) responsible for deciding what the contents of the list were. Where the list was created by a human, this is the same as the author of the list."/>
+      <min value="0"/>
+      <max value="1"/>
       <type>
-        <code value="Extension" />
-        <profile value="http://hl7.org.au/fhir/StructureDefinition/author-related-person" />
+        <code value="Extension"/>
+        <profile value="http://hl7.org.au/fhir/StructureDefinition/author-related-person"/>
       </type>
     </element>
     <element id="List.entry">
-      <path value="List.entry" />
-      <short value="Medicine list entry" />
-      <definition value="List of medicine type entries" />
+      <path value="List.entry"/>
+      <short value="Medicine list entry"/>
+      <definition value="List of medicine type entries"/>
     </element>
     <element id="List.entry.extension">
-      <path value="List.entry.extension" />
+      <path value="List.entry.extension"/>
       <slicing>
         <discriminator>
-          <type value="value" />
-          <path value="url" />
+          <type value="value"/>
+          <path value="url"/>
         </discriminator>
-        <rules value="open" />
+        <rules value="open"/>
       </slicing>
     </element>
     <element id="List.entry.extension:changeDescription">
       <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
-        <valueCode value="draft" />
+        <valueCode value="draft"/>
       </extension>
-      <path value="List.entry.extension" />
-      <sliceName value="changeDescription" />
-      <short value="Description of the change to the item" />
-      <max value="1" />
+      <path value="List.entry.extension"/>
+      <sliceName value="changeDescription"/>
+      <short value="Description of the change to the item"/>
+      <max value="1"/>
       <type>
-        <code value="Extension" />
-        <profile value="http://hl7.org.au/fhir/StructureDefinition/change-description" />
+        <code value="Extension"/>
+        <profile value="http://hl7.org.au/fhir/StructureDefinition/change-description"/>
       </type>
     </element>
     <element id="List.entry.flag">
-      <path value="List.entry.flag" />
-      <short value="Medicine item change" />
+      <path value="List.entry.flag"/>
+      <short value="Medicine item change"/>
       <binding>
-        <strength value="preferred" />
-        <valueSet value="http://hl7.org.au/fhir/ValueSet/medicine-item-change" />
+        <strength value="preferred"/>
+        <valueSet value="http://hl7.org.au/fhir/ValueSet/medicine-item-change"/>
       </binding>
     </element>
     <element id="List.entry.item">
-      <path value="List.entry.item" />
+      <path value="List.entry.item"/>
       <type>
-        <code value="Reference" />
-        <targetProfile value="http://hl7.org/fhir/StructureDefinition/MedicationStatement" />
-        <targetProfile value="http://hl7.org/fhir/StructureDefinition/MedicationRequest" />
-        <targetProfile value="http://hl7.org/fhir/StructureDefinition/MedicationDispense" />
-        <targetProfile value="http://hl7.org/fhir/StructureDefinition/MedicationAdministration" />
-        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Immunization" />
-        <targetProfile value="http://hl7.org.au/fhir/StructureDefinition/au-norelevantfinding" />
+        <code value="Reference"/>
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/MedicationStatement"/>
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/MedicationRequest"/>
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/MedicationDispense"/>
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/MedicationAdministration"/>
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Immunization"/>
+        <targetProfile value="http://hl7.org.au/fhir/StructureDefinition/au-norelevantfinding"/>
       </type>
     </element>
   </differential>

--- a/resources/au-norelevantfinding.xml
+++ b/resources/au-norelevantfinding.xml
@@ -1,82 +1,91 @@
 <?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
-  <id value="au-norelevantfinding" />
-  <url value="http://hl7.org.au/fhir/StructureDefinition/au-norelevantfinding" />
+  <id value="au-norelevantfinding"/>
+  <url value="http://hl7.org.au/fhir/StructureDefinition/au-norelevantfinding"/>
   <version value="2.1.0"/>
-  <name value="AUAssertionNoRelevantFinding" />
-  <title value="AU Assertion of No Relevant Finding" />
-  <status value="draft" />
-  <date value="2019-07-29" />
-  <publisher value="Health Level Seven Australia (Orders and Observations WG)" />
+  <name value="AUAssertionNoRelevantFinding"/>
+  <title value="AU Assertion of No Relevant Finding"/>
+  <status value="draft"/>
+  <date value="2020-07-29"/>
+  <publisher value="Health Level Seven Australia (Orders and Observations WG)"/>
   <contact>
     <telecom>
-      <system value="url" />
-      <value value="http://hl7.org.au" />
-      <use value="work" />
+      <system value="url"/>
+      <value value="http://hl7.com.au"/>
+      <use value="work"/>
     </telecom>
   </contact>
-  <description value="This profile provides an observation information structure for asserting a clinical judgement that there are no items of specific interest, e.g. allergies, no medications, for a patient." />
-  <copyright value="HL7 Australia© 2018+; Licensed Under Creative Commons No Rights Reserved." />
-  <fhirVersion value="4.0.0" />
-  <kind value="resource" />
-  <abstract value="false" />
-  <type value="Observation" />
-  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Observation" />
-  <derivation value="constraint" />
+  <description
+    value="This profile provides an observation information structure for asserting a clinical judgement that there are no items of specific interest, e.g. allergies, no medications, for a patient."/>
+  <jurisdiction>
+    <coding>
+      <system value="urn:iso:std:iso:3166"/>
+      <code value="AU"/>
+    </coding>
+  </jurisdiction>
+  <copyright value="HL7 Australia© 2018+; Licensed Under Creative Commons No Rights Reserved."/>
+  <fhirVersion value="4.0.1"/>
+  <kind value="resource"/>
+  <abstract value="false"/>
+  <type value="Observation"/>
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Observation"/>
+  <derivation value="constraint"/>
   <differential>
     <element id="Observation">
-      <path value="Observation" />
-      <short value="Statement of clinical judgement that there are no items of specific interest" />
-      <definition value="Statement of clinical judgement that there are no items of specific interest after a reasonable investigation." />
+      <path value="Observation"/>
+      <short value="Statement of clinical judgement that there are no items of specific interest"/>
+      <definition
+        value="Statement of clinical judgement that there are no items of specific interest after a reasonable investigation."
+      />
     </element>
     <element id="Observation.code">
-      <path value="Observation.code" />
+      <path value="Observation.code"/>
       <patternCodeableConcept>
         <coding>
-          <system value="http://terminology.hl7.org/CodeSystem/v3-ActCode" />
-          <code value="ASSERTION" />
+          <system value="http://terminology.hl7.org/CodeSystem/v3-ActCode"/>
+          <code value="ASSERTION"/>
         </coding>
       </patternCodeableConcept>
     </element>
     <element id="Observation.subject">
-      <path value="Observation.subject" />
-      <min value="1" />
+      <path value="Observation.subject"/>
+      <min value="1"/>
       <type>
-        <code value="Reference" />
-        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Patient" />
-        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Group" />
+        <code value="Reference"/>
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Patient"/>
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Group"/>
       </type>
     </element>
     <element id="Observation.performer">
-      <path value="Observation.performer" />
-      <short value="Asserter of the statement" />
+      <path value="Observation.performer"/>
+      <short value="Asserter of the statement"/>
     </element>
     <element id="Observation.value[x]">
-      <path value="Observation.value[x]" />
+      <path value="Observation.value[x]"/>
       <slicing>
         <discriminator>
-          <type value="type" />
-          <path value="$this" />
+          <type value="type"/>
+          <path value="$this"/>
         </discriminator>
         <rules value="open"/>
       </slicing>
     </element>
     <element id="Observation.value[x]:valueCodeableConcept">
-      <path value="Observation.value[x]" />
-      <sliceName value="valueCodeableConcept" />
-      <short value="Coded value of the observation" />
-      <min value="1" />
+      <path value="Observation.value[x]"/>
+      <sliceName value="valueCodeableConcept"/>
+      <short value="Coded value of the observation"/>
+      <min value="1"/>
       <type>
-        <code value="CodeableConcept" />
+        <code value="CodeableConcept"/>
       </type>
       <binding>
-        <strength value="extensible" />
-        <valueSet value="https://healthterminologies.gov.au/fhir/ValueSet/assertion-of-absence-1" />
+        <strength value="extensible"/>
+        <valueSet value="https://healthterminologies.gov.au/fhir/ValueSet/assertion-of-absence-1"/>
       </binding>
     </element>
     <element id="Observation.dataAbsentReason">
-      <path value="Observation.dataAbsentReason" />
-      <max value="0" />
+      <path value="Observation.dataAbsentReason"/>
+      <max value="0"/>
     </element>
   </differential>
 </StructureDefinition>

--- a/resources/codesystem-gtin.xml
+++ b/resources/codesystem-gtin.xml
@@ -17,10 +17,14 @@
 	<title value="GTIN (External)"/>
 	<status value="draft"/>
 	<experimental value="true"/>
-	<date value="2018-09-24"/>
+	<date value="2020-08-24"/>
 	<publisher value="Health Level Seven Australia (Patient Administration)"/>
 	<contact>
-		<name value="hl7.org.au"/>
+		<telecom>
+			<system value="url" />
+			<value value="http://hl7.com.au" />
+			<use value="work" />
+		</telecom>
 	</contact>
 	<description value="GTIN"/>
 	<copyright value="HL7 Australia© 2018+; Licensed Under Creative Commons No Rights Reserved."/>

--- a/resources/codesystem-medication-type.xml
+++ b/resources/codesystem-medication-type.xml
@@ -17,10 +17,14 @@
 	<title value="Medication Type"/>
 	<status value="draft"/>
 	<experimental value="true"/>
-	<date value="2018-09-24"/>
+	<date value="2020-08-24"/>
 	<publisher value="Health Level Seven Australia (Patient Administration)"/>
 	<contact>
-		<name value="hl7.org.au"/>
+		<telecom>
+			<system value="url" />
+			<value value="http://hl7.com.au" />
+			<use value="work" />
+		</telecom>
 	</contact>
 	<description value="Medication Type"/>
 	<copyright value="HL7 Australia© 2018+; Licensed Under Creative Commons No Rights Reserved."/>

--- a/resources/codesystem-mims.xml
+++ b/resources/codesystem-mims.xml
@@ -19,10 +19,14 @@
 	<title value="MIMS (External)"/>
 	<status value="draft"/>
 	<experimental value="true"/>
-	<date value="2019-07-23"/>
+	<date value="2020-07-23"/>
 	<publisher value="Health Level Seven Australia (Patient Administration)"/>
 	<contact>
-		<name value="hl7.org.au"/>
+		<telecom>
+			<system value="url" />
+			<value value="http://hl7.com.au" />
+			<use value="work" />
+		</telecom>
 	</contact>
 	<description value="The intended use of Monthly Index of Medical Specialties (MIMS) Data is to fully specify the product as a combination of product code, form code, and pack code. For example, when providing a MIMS Code within a Clinical Document Architecture (CDA) document, the MIMS code will be a minimum of 5 digits (in most cases, will be 8 digits)."/>
 	<copyright value="HL7 Australia© 2018+; Licensed Under Creative Commons No Rights Reserved."/>

--- a/resources/codesystem-pbs-item.xml
+++ b/resources/codesystem-pbs-item.xml
@@ -16,10 +16,14 @@
 	<title value="PBS Item Codes (External)"/>
 	<status value="draft"/>
 	<experimental value="true"/>
-	<date value="2018-09-24"/>
+	<date value="2020-08-24"/>
 	<publisher value="Health Level Seven Australia (Patient Administration)"/>
 	<contact>
-		<name value="hl7.org.au"/>
+		<telecom>
+			<system value="url"/>
+			<value value="http://hl7.com.au"/>
+			<use value="work"/>
+		</telecom>
 	</contact>
 	<description value="PBS item codes"/>
 	<copyright value="HL7 Australia© 2018+; Licensed Under Creative Commons No Rights Reserved."/>

--- a/resources/structuredefinition-change-description.xml
+++ b/resources/structuredefinition-change-description.xml
@@ -1,51 +1,58 @@
 <?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
-  <id value="change-description" />
-  <url value="http://hl7.org.au/fhir/StructureDefinition/change-description" />
+  <id value="change-description"/>
+  <url value="http://hl7.org.au/fhir/StructureDefinition/change-description"/>
   <version value="2.1.0"/>
-  <name value="ChangeDescription" />
-  <title value="Change Description" />
-  <status value="draft" />
-  <date value="2018-11-30" />
-  <publisher value="Health Level Seven Australia (Medications WG)" />
+  <name value="ChangeDescription"/>
+  <title value="Change Description"/>
+  <status value="draft"/>
+  <date value="2020-01-30"/>
+  <publisher value="Health Level Seven Australia (Medications WG)"/>
   <contact>
     <telecom>
-      <system value="url" />
-      <value value="http://hl7.com.au" />
-      <use value="work" />
+      <system value="url"/>
+      <value value="http://hl7.com.au"/>
+      <use value="work"/>
     </telecom>
   </contact>
-  <description value="This extension applies to the List resource and provides a narrative description of the change to an item in a list entry. The narrative description may include the reason for the change to an item." />
+  <description
+    value="This extension applies to the List resource and provides a narrative description of the change to an item in a list entry. The narrative description may include the reason for the change to an item."/>
+  <jurisdiction>
+    <coding>
+      <system value="urn:iso:std:iso:3166"/>
+      <code value="AU"/>
+    </coding>
+  </jurisdiction>
   <copyright value="HL7 Australia© 2018+; Licensed Under Creative Commons No Rights Reserved."/>
-  <fhirVersion value="4.0.0" />
-  <kind value="complex-type" />
-  <abstract value="false" />
+  <fhirVersion value="4.0.1"/>
+  <kind value="complex-type"/>
+  <abstract value="false"/>
   <context>
-    <type value="element" />
-    <expression value="List.entry" />
+    <type value="element"/>
+    <expression value="List.entry"/>
   </context>
-  <type value="Extension" />
-  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Extension" />
-  <derivation value="constraint" />
+  <type value="Extension"/>
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Extension"/>
+  <derivation value="constraint"/>
   <differential>
     <element id="Extension">
-     <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
-        <valueCode value="draft"/> 
-      </extension> 
-      <path value="Extension" />
-      <short value="Change description" />
-      <definition value="Description of a change including the reason for change." />
+      <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
+        <valueCode value="draft"/>
+      </extension>
+      <path value="Extension"/>
+      <short value="Change description"/>
+      <definition value="Description of a change including the reason for change."/>
     </element>
     <element id="Extension.url">
-      <path value="Extension.url" />
-      <fixedUri value="http://hl7.org.au/fhir/StructureDefinition/change-description" />
+      <path value="Extension.url"/>
+      <fixedUri value="http://hl7.org.au/fhir/StructureDefinition/change-description"/>
     </element>
     <element id="Extension.value[x]:valueString">
-      <path value="Extension.valueString" />
-      <sliceName value="valueString" />
-      <min value="1" />
+      <path value="Extension.valueString"/>
+      <sliceName value="valueString"/>
+      <min value="1"/>
       <type>
-        <code value="string" />
+        <code value="string"/>
       </type>
     </element>
   </differential>

--- a/resources/structuredefinition-dispense-number.xml
+++ b/resources/structuredefinition-dispense-number.xml
@@ -1,51 +1,60 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
-  <id value="dispense-number" />
-  <url value="http://hl7.org.au/fhir/StructureDefinition/dispense-number" />
+  <id value="dispense-number"/>
+  <url value="http://hl7.org.au/fhir/StructureDefinition/dispense-number"/>
   <version value="2.1.0"/>
-  <name value="DispenseNumber" />
-  <title value="Number of this Dispense" />
-  <status value="draft" />
-  <date value="2019-10-22" />
-  <publisher value="Health Level Seven Australia (Medications WG)" />
+  <name value="DispenseNumber"/>
+  <title value="Number of this Dispense"/>
+  <status value="draft"/>
+  <date value="2020-01-22"/>
+  <publisher value="Health Level Seven Australia (Medications WG)"/>
   <contact>
     <telecom>
-      <system value="url" />
-      <value value="http://hl7.org.au" />
-      <use value="work" />
+      <system value="url"/>
+      <value value="http://hl7.com.au"/>
+      <use value="work"/>
     </telecom>
   </contact>
-  <description value="This extension applies to the MedicationDispense resource and the value indicates the dispense number or sequence number that has been reached for a therapeutic good prescribed with repeats. It has the value 1 when there are no repeats. The value increments by one each time a dispense act is successfully completed." />
+  <description
+    value="This extension applies to the MedicationDispense resource and the value indicates the dispense number or sequence number that has been reached for a therapeutic good prescribed with repeats. It has the value 1 when there are no repeats. The value increments by one each time a dispense act is successfully completed."/>
+  <jurisdiction>
+    <coding>
+      <system value="urn:iso:std:iso:3166"/>
+      <code value="AU"/>
+    </coding>
+  </jurisdiction>
   <copyright value="HL7 Australia© 2018+; Licensed Under Creative Commons No Rights Reserved."/>
-  <fhirVersion value="4.0.0" />
-  <kind value="complex-type" />
-  <abstract value="false" />
+  <fhirVersion value="4.0.1"/>
+  <kind value="complex-type"/>
+  <abstract value="false"/>
   <context>
     <type value="element"/>
-    <expression value="MedicationDispense" />
+    <expression value="MedicationDispense"/>
   </context>
-  <type value="Extension" />
-  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Extension" />
-  <derivation value="constraint" />
+  <type value="Extension"/>
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Extension"/>
+  <derivation value="constraint"/>
   <differential>
     <element id="Extension">
-      <path value="Extension" />
-      <short value="Number of this dispense" />
-      <definition value="This extension applies to the MedicationDispense resource and the value indicates the dispense number or sequence number that has been reached for a therapeutic good prescribed with repeats. " />
-      <comment value="It has the value 1 when there are no repeats. The value increments by one each time a dispense act is successfully completed. " />
-      <max value="1" />
+      <path value="Extension"/>
+      <short value="Number of this dispense"/>
+      <definition
+        value="This extension applies to the MedicationDispense resource and the value indicates the dispense number or sequence number that has been reached for a therapeutic good prescribed with repeats. "/>
+      <comment
+        value="It has the value 1 when there are no repeats. The value increments by one each time a dispense act is successfully completed. "/>
+      <max value="1"/>
     </element>
     <element id="Extension.url">
-      <path value="Extension.url" />
-      <fixedUri value="http://hl7.org.au/fhir/StructureDefinition/dispense-number" />
+      <path value="Extension.url"/>
+      <fixedUri value="http://hl7.org.au/fhir/StructureDefinition/dispense-number"/>
     </element>
     <element id="Extension.value[x]:valueInteger">
-      <path value="Extension.valueInteger" />
-      <sliceName value="valueInteger" />
-      <short value="Dispense Number" />
-      <min value="1" />
+      <path value="Extension.valueInteger"/>
+      <sliceName value="valueInteger"/>
+      <short value="Dispense Number"/>
+      <min value="1"/>
       <type>
-        <code value="integer" />
+        <code value="integer"/>
       </type>
     </element>
   </differential>

--- a/resources/structuredefinition-medication-brand-name.xml
+++ b/resources/structuredefinition-medication-brand-name.xml
@@ -1,62 +1,70 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
-  <id value="medication-brand-name" />
-  <url value="http://hl7.org.au/fhir/StructureDefinition/medication-brand-name" />
+  <id value="medication-brand-name"/>
+  <url value="http://hl7.org.au/fhir/StructureDefinition/medication-brand-name"/>
   <version value="2.1.0"/>
-  <name value="MedicationBrandName" />
-  <title value="Medication Brand Name" />
-  <status value="active" />
-  <date value="2018-10-03" />
-  <publisher value="Health Level Seven Australia (Medications WG)" />
+  <name value="MedicationBrandName"/>
+  <title value="Medication Brand Name"/>
+  <status value="active"/>
+  <date value="2020-01-03"/>
+  <publisher value="Health Level Seven Australia (Medications WG)"/>
   <contact>
     <telecom>
-      <system value="url" />
-      <value value="http://hl7.org.au" />
-      <use value="work" />
+      <system value="url"/>
+      <value value="http://hl7.com.au"/>
+      <use value="work"/>
     </telecom>
   </contact>
-  <description value="This extension applies to the Medication, MedicationRequest, MedicationDispense amd MedicationStatement resources and provides text brand name of a medication." />
+  <description
+    value="This extension applies to the Medication, MedicationRequest, MedicationDispense amd MedicationStatement resources and provides text brand name of a medication."/>
+  <jurisdiction>
+    <coding>
+      <system value="urn:iso:std:iso:3166"/>
+      <code value="AU"/>
+    </coding>
+  </jurisdiction>
   <copyright value="HL7 Australia© 2018+; Licensed Under Creative Commons No Rights Reserved."/>
-  <fhirVersion value="4.0.0" />
-  <kind value="complex-type" />
-  <abstract value="false" />
+  <fhirVersion value="4.0.1"/>
+  <kind value="complex-type"/>
+  <abstract value="false"/>
   <context>
     <type value="element"/>
-    <expression value="Medication" />
+    <expression value="Medication"/>
   </context>
   <context>
     <type value="element"/>
-    <expression value="MedicationRequest" />
+    <expression value="MedicationRequest"/>
   </context>
   <context>
     <type value="element"/>
-    <expression value="MedicationDispense" />
-   </context>
+    <expression value="MedicationDispense"/>
+  </context>
   <context>
     <type value="element"/>
     <expression value="MedicationStatement"/>
   </context>
-  <type value="Extension" />
-  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Extension" />
-  <derivation value="constraint" />
+  <type value="Extension"/>
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Extension"/>
+  <derivation value="constraint"/>
   <differential>
     <element id="Extension">
-      <path value="Extension" />
-      <short value="Medication brand name" />
-      <definition value="The brand medication text name for an associated medication, this may be supplied if a coded brand name is not available."/>
-      <max value="1" />
+      <path value="Extension"/>
+      <short value="Medication brand name"/>
+      <definition
+        value="The brand medication text name for an associated medication, this may be supplied if a coded brand name is not available."/>
+      <max value="1"/>
     </element>
     <element id="Extension.url">
-      <path value="Extension.url" />
-      <fixedUri value="http://hl7.org.au/fhir/StructureDefinition/medication-brand-name" />
+      <path value="Extension.url"/>
+      <fixedUri value="http://hl7.org.au/fhir/StructureDefinition/medication-brand-name"/>
     </element>
     <element id="Extension.value[x]:valueString">
-      <path value="Extension.valueString" />
-      <sliceName value="valueString" />
-      <short value="Text Brand or Product name" />
-      <min value="1" />
+      <path value="Extension.valueString"/>
+      <sliceName value="valueString"/>
+      <short value="Text Brand or Product name"/>
+      <min value="1"/>
       <type>
-        <code value="string" />
+        <code value="string"/>
       </type>
     </element>
   </differential>

--- a/resources/structuredefinition-medication-generic-name.xml
+++ b/resources/structuredefinition-medication-generic-name.xml
@@ -1,62 +1,70 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
-  <id value="medication-generic-name" />
-  <url value="http://hl7.org.au/fhir/StructureDefinition/medication-generic-name" />
+  <id value="medication-generic-name"/>
+  <url value="http://hl7.org.au/fhir/StructureDefinition/medication-generic-name"/>
   <version value="2.1.0"/>
-  <name value="MedicationGenericName" />
-  <title value="Medication Generic Drug Name" />
-  <status value="active" />
-  <date value="2018-10-03" />
-  <publisher value="Health Level Seven Australia (Medications WG)" />
+  <name value="MedicationGenericName"/>
+  <title value="Medication Generic Drug Name"/>
+  <status value="active"/>
+  <date value="2020-01-03"/>
+  <publisher value="Health Level Seven Australia (Medications WG)"/>
   <contact>
     <telecom>
-      <system value="url" />
-      <value value="http://hl7.org.au" />
-      <use value="work" />
+      <system value="url"/>
+      <value value="http://hl7.com.au"/>
+      <use value="work"/>
     </telecom>
-  </contact>  
-  <description value="This extension applies to the Medication, MedicationRequest, MedicationDispense and MedicationStatement resources and provides generic name of a medication." />
+  </contact>
+  <description
+    value="This extension applies to the Medication, MedicationRequest, MedicationDispense and MedicationStatement resources and provides generic name of a medication."/>
+  <jurisdiction>
+    <coding>
+      <system value="urn:iso:std:iso:3166"/>
+      <code value="AU"/>
+    </coding>
+  </jurisdiction>
   <copyright value="HL7 Australia© 2018+; Licensed Under Creative Commons No Rights Reserved."/>
-  <fhirVersion value="4.0.0" />
-  <kind value="complex-type" />
-  <abstract value="false" />
+  <fhirVersion value="4.0.1"/>
+  <kind value="complex-type"/>
+  <abstract value="false"/>
   <context>
     <type value="element"/>
-    <expression value="Medication" />
+    <expression value="Medication"/>
   </context>
   <context>
     <type value="element"/>
-    <expression value="MedicationRequest" />
+    <expression value="MedicationRequest"/>
   </context>
   <context>
     <type value="element"/>
-    <expression value="MedicationDispense" />
-   </context>
+    <expression value="MedicationDispense"/>
+  </context>
   <context>
     <type value="element"/>
     <expression value="MedicationStatement"/>
   </context>
-  <type value="Extension" />
-  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Extension" />
-  <derivation value="constraint" />
+  <type value="Extension"/>
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Extension"/>
+  <derivation value="constraint"/>
   <differential>
     <element id="Extension">
-      <path value="Extension" />
-      <short value="Medication generic drug name" />
-      <definition value="The generic medication text name for an associated medication, this may not be the same as the subject medication (prescribed, dispensed or stated) but may be used to provide an additional or equivalent drug name that is a generic medication concept."/>
-      <max value="1" />
+      <path value="Extension"/>
+      <short value="Medication generic drug name"/>
+      <definition
+        value="The generic medication text name for an associated medication, this may not be the same as the subject medication (prescribed, dispensed or stated) but may be used to provide an additional or equivalent drug name that is a generic medication concept."/>
+      <max value="1"/>
     </element>
     <element id="Extension.url">
-      <path value="Extension.url" />
-      <fixedUri value="http://hl7.org.au/fhir/StructureDefinition/medication-generic-name" />
+      <path value="Extension.url"/>
+      <fixedUri value="http://hl7.org.au/fhir/StructureDefinition/medication-generic-name"/>
     </element>
     <element id="Extension.value[x]:valueString">
-      <path value="Extension.valueString" />
-      <sliceName value="valueString" />
-      <short value="Text Generic Drug Name" />
-      <min value="1" />
+      <path value="Extension.valueString"/>
+      <sliceName value="valueString"/>
+      <short value="Text Generic Drug Name"/>
+      <min value="1"/>
       <type>
-        <code value="string" />
+        <code value="string"/>
       </type>
     </element>
   </differential>

--- a/resources/structuredefinition-medication-long-term.xml
+++ b/resources/structuredefinition-medication-long-term.xml
@@ -1,50 +1,57 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
-  <id value="medication-long-term" />
-  <url value="http://hl7.org.au/fhir/StructureDefinition/medication-long-term" />
+  <id value="medication-long-term"/>
+  <url value="http://hl7.org.au/fhir/StructureDefinition/medication-long-term"/>
   <version value="2.1.0"/>
-  <name value="MedicationLongTerm" />
-  <title value="Long Term" />
-  <status value="active" />
-  <date value="2018-10-03" />
-  <publisher value="Health Level Seven Australia (Medications WG)" />
+  <name value="MedicationLongTerm"/>
+  <title value="Long Term"/>
+  <status value="active"/>
+  <date value="2020-01-03"/>
+  <publisher value="Health Level Seven Australia (Medications WG)"/>
   <contact>
     <telecom>
-      <system value="url" />
-      <value value="http://hl7.com.au" />
-      <use value="work" />
+      <system value="url"/>
+      <value value="http://hl7.com.au"/>
+      <use value="work"/>
     </telecom>
   </contact>
-  <description value="This extension applies to the MedicationStatement resource and provides an indicator of long term medication use." />
+  <description
+    value="This extension applies to the MedicationStatement resource and provides an indicator of long term medication use."/>
+  <jurisdiction>
+    <coding>
+      <system value="urn:iso:std:iso:3166"/>
+      <code value="AU"/>
+    </coding>
+  </jurisdiction>
   <copyright value="HL7 Australia© 2018+; Licensed Under Creative Commons No Rights Reserved."/>
-  <fhirVersion value="4.0.0" />
-  <kind value="complex-type" />
-  <abstract value="false" />
+  <fhirVersion value="4.0.1"/>
+  <kind value="complex-type"/>
+  <abstract value="false"/>
   <context>
     <type value="element"/>
     <expression value="MedicationStatement"/>
   </context>
-  <type value="Extension" />
-  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Extension" />
-  <derivation value="constraint" />
+  <type value="Extension"/>
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Extension"/>
+  <derivation value="constraint"/>
   <differential>
     <element id="Extension">
-      <path value="Extension" />
-      <short value="Medication long term" />
-      <definition value="Medication long-term indicator" />
-      <min value="0" />
-      <max value="1" />
+      <path value="Extension"/>
+      <short value="Medication long term"/>
+      <definition value="Medication long-term indicator"/>
+      <min value="0"/>
+      <max value="1"/>
     </element>
     <element id="Extension.url">
-      <path value="Extension.url" />
-      <fixedUri value="http://hl7.org.au/fhir/StructureDefinition/medication-long-term" />
+      <path value="Extension.url"/>
+      <fixedUri value="http://hl7.org.au/fhir/StructureDefinition/medication-long-term"/>
     </element>
     <element id="Extension.value[x]:valueBoolean">
-      <path value="Extension.valueBoolean" />
-      <sliceName value="valueBoolean" />
-      <min value="1" />
+      <path value="Extension.valueBoolean"/>
+      <sliceName value="valueBoolean"/>
+      <min value="1"/>
       <type>
-        <code value="boolean" />
+        <code value="boolean"/>
       </type>
     </element>
   </differential>

--- a/resources/structuredefinition-medication-type.xml
+++ b/resources/structuredefinition-medication-type.xml
@@ -1,86 +1,93 @@
 <?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
-  <id value="medication-type" />
-  <url value="http://hl7.org.au/fhir/StructureDefinition/medication-type" />
+  <id value="medication-type"/>
+  <url value="http://hl7.org.au/fhir/StructureDefinition/medication-type"/>
   <version value="2.1.0"/>
-  <name value="MedicationType" />
-  <title value="Medication Type" />
-  <status value="draft" />
-  <date value="2018-10-03" />
-  <publisher value="Health Level Seven Australia (Medications WG)" />
+  <name value="MedicationType"/>
+  <title value="Medication Type"/>
+  <status value="draft"/>
+  <date value="2020-01-03"/>
+  <publisher value="Health Level Seven Australia (Medications WG)"/>
   <contact>
     <telecom>
-      <system value="url" />
-      <value value="http://hl7.org.au" />
-      <use value="work" />
+      <system value="url"/>
+      <value value="http://hl7.com.au"/>
+      <use value="work"/>
     </telecom>
   </contact>
-  <description value="This extension applies to the Coding datatype and provides a value to indicate a classification of the type of medication the parent coding. This is useful     when there are multiple codings from the same CodingSystem at different levels/classifications." />
+  <description
+    value="This extension applies to the Coding datatype and provides a value to indicate a classification of the type of medication the parent coding. This is useful     when there are multiple codings from the same CodingSystem at different levels/classifications."/>
+  <jurisdiction>
+    <coding>
+      <system value="urn:iso:std:iso:3166"/>
+      <code value="AU"/>
+    </coding>
+  </jurisdiction>
   <copyright value="HL7 Australia© 2018+; Licensed Under Creative Commons No Rights Reserved."/>
-  <fhirVersion value="4.0.0" />
-  <kind value="complex-type" />
-  <abstract value="false" />
+  <fhirVersion value="4.0.1"/>
+  <kind value="complex-type"/>
+  <abstract value="false"/>
   <context>
-    <type value="element" />
-    <expression value="Medication.code.coding" />
+    <type value="element"/>
+    <expression value="Medication.code.coding"/>
   </context>
   <context>
-    <type value="element" />
-    <expression value="MedicationRequest.medicationCodeableConcept.coding" />
+    <type value="element"/>
+    <expression value="MedicationRequest.medicationCodeableConcept.coding"/>
   </context>
   <context>
-    <type value="element" />
-    <expression value="MedicationDispense.medicationCodeableConcept.coding" />
+    <type value="element"/>
+    <expression value="MedicationDispense.medicationCodeableConcept.coding"/>
   </context>
   <context>
-    <type value="element" />
-    <expression value="MedicationStatement.medicationCodeableConcept.coding" />
+    <type value="element"/>
+    <expression value="MedicationStatement.medicationCodeableConcept.coding"/>
   </context>
   <context>
-    <type value="element" />
-    <expression value="MedicationAdministration.medicationCodeableConcept.coding" />
+    <type value="element"/>
+    <expression value="MedicationAdministration.medicationCodeableConcept.coding"/>
   </context>
   <context>
-    <type value="element" />
-    <expression value="ValueSet.expansion.contains" />
+    <type value="element"/>
+    <expression value="ValueSet.expansion.contains"/>
   </context>
   <context>
-    <type value="element" />
-    <expression value="ValueSet.expansion.contains.contains" />
+    <type value="element"/>
+    <expression value="ValueSet.expansion.contains.contains"/>
   </context>
   <context>
-    <type value="element" />
-    <expression value="CodeSystem.concept" />
+    <type value="element"/>
+    <expression value="CodeSystem.concept"/>
   </context>
   <context>
-    <type value="element" />
-    <expression value="CodeSystem.concept.concept" />
+    <type value="element"/>
+    <expression value="CodeSystem.concept.concept"/>
   </context>
-  <type value="Extension" />
-  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Extension" />
-  <derivation value="constraint" />
+  <type value="Extension"/>
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Extension"/>
+  <derivation value="constraint"/>
   <differential>
     <element id="Extension">
-      <path value="Extension" />
-      <short value="Medication Type" />
-      <definition value="A classifying type code to assist identifying a coding usage" />
+      <path value="Extension"/>
+      <short value="Medication Type"/>
+      <definition value="A classifying type code to assist identifying a coding usage"/>
     </element>
     <element id="Extension.url">
-      <path value="Extension.url" />
-      <fixedUri value="http://hl7.org.au/fhir/StructureDefinition/medication-type" />
+      <path value="Extension.url"/>
+      <fixedUri value="http://hl7.org.au/fhir/StructureDefinition/medication-type"/>
     </element>
     <element id="Extension.value[x]:valueCoding">
-      <path value="Extension.valueCoding" />
-      <sliceName value="valueCoding" />
-      <min value="1" />
+      <path value="Extension.valueCoding"/>
+      <sliceName value="valueCoding"/>
+      <min value="1"/>
       <type>
-        <code value="Coding" />
+        <code value="Coding"/>
       </type>
       <binding>
-        <strength value="required" />
-        <description value="Medication Type" />
-        <valueSet value="http://hl7.org.au/fhir/ValueSet/medication-type" />
+        <strength value="required"/>
+        <description value="Medication Type"/>
+        <valueSet value="http://hl7.org.au/fhir/ValueSet/medication-type"/>
       </binding>
-    </element> 
+    </element>
   </differential>
 </StructureDefinition>

--- a/resources/structuredefinition-minimum-interval-between-repeats.xml
+++ b/resources/structuredefinition-minimum-interval-between-repeats.xml
@@ -6,18 +6,24 @@
   <name value="MinimumIntervalBetweenRepeats" />
   <title value="Minimum Interval Between Repeats" />
   <status value="draft" />
-  <date value="2018-10-03" />
+  <date value="2020-01-03" />
   <publisher value="Health Level Seven Australia (Medications WG)" />
   <contact>
     <telecom>
       <system value="url" />
-      <value value="http://hl7.org.au" />
+      <value value="http://hl7.com.au" />
       <use value="work" />
     </telecom>
   </contact>  
   <description value="This extension applies to MedicationRequest resource and allows the definition of a duration indicating the minimum allowed time period between dispensing repeats." />
+  <jurisdiction>
+    <coding>
+      <system value="urn:iso:std:iso:3166"/>
+      <code value="AU"/>
+    </coding>
+  </jurisdiction>
   <copyright value="HL7 Australia© 2018+; Licensed Under Creative Commons No Rights Reserved."/>
-  <fhirVersion value="4.0.0" />
+  <fhirVersion value="4.0.1" />
   <kind value="complex-type" />
   <abstract value="false" />
   <context>

--- a/resources/structuredefinition-subsidised-concurrent-supply.xml
+++ b/resources/structuredefinition-subsidised-concurrent-supply.xml
@@ -1,58 +1,64 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
-  <id value="subsidised-concurrent-supply" />
-  <url value="http://hl7.org.au/fhir/StructureDefinition/subsidised-concurrent-supply" />
+  <id value="subsidised-concurrent-supply"/>
+  <url value="http://hl7.org.au/fhir/StructureDefinition/subsidised-concurrent-supply"/>
   <version value="2.1.0"/>
-  <name value="GroundsForConcurrentSupplyOfMedication" />
-  <title value="Grounds for Concurrent Supply of Medication" />
-  <status value="draft" />
-  <date value="2019-10-22" />
-  <publisher value="Health Level Seven Australia (Medications WG)" />
+  <name value="GroundsForConcurrentSupplyOfMedication"/>
+  <title value="Grounds for Concurrent Supply of Medication"/>
+  <status value="draft"/>
+  <date value="2020-01-22"/>
+  <publisher value="Health Level Seven Australia (Medications WG)"/>
   <contact>
     <telecom>
-      <system value="url" />
-      <value value="http://hl7.org.au" />
+      <system value="url"/>
+      <value value="http://hl7.com.au"/>
       <use value="work"/>
     </telecom>
   </contact>
-  <description value="This extension applies to MedicationRequest or MedicationDispense resources and the value indicates the reason a pharmacist
-    may or has supplied multiple repeats of a medication prescription at one time." />
+  <description
+    value="This extension applies to MedicationRequest or MedicationDispense resources and the value indicates the reason a pharmacist may or has supplied multiple repeats of a medication prescription at one time."/>
+  <jurisdiction>
+    <coding>
+      <system value="urn:iso:std:iso:3166"/>
+      <code value="AU"/>
+    </coding>
+  </jurisdiction>
   <copyright value="HL7 Australia© 2018+; Licensed Under Creative Commons No Rights Reserved."/>
-  <fhirVersion value="4.0.0" />
-  <kind value="complex-type" />
-  <abstract value="false" />
+  <fhirVersion value="4.0.1"/>
+  <kind value="complex-type"/>
+  <abstract value="false"/>
   <context>
     <type value="element"/>
     <expression value="MedicationRequest"/>
-  </context>  
+  </context>
   <context>
     <type value="element"/>
     <expression value="MedicationDispense"/>
   </context>
-  <type value="Extension" />
-  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Extension" />
-  <derivation value="constraint" />
+  <type value="Extension"/>
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Extension"/>
+  <derivation value="constraint"/>
   <differential>
     <element id="Extension">
-      <path value="Extension" />
-      <short value="Grounds for concurrent supply of medication" />
-      <definition value="Coded Grounds for Concurrent Supply of Medication" />
+      <path value="Extension"/>
+      <short value="Grounds for concurrent supply of medication"/>
+      <definition value="Coded Grounds for Concurrent Supply of Medication"/>
     </element>
     <element id="Extension.url">
-      <path value="Extension.url" />
-      <fixedUri value="http://hl7.org.au/fhir/StructureDefinition/subsidised-concurrent-supply" />
+      <path value="Extension.url"/>
+      <fixedUri value="http://hl7.org.au/fhir/StructureDefinition/subsidised-concurrent-supply"/>
     </element>
     <element id="Extension.value[x]:valueCoding">
-      <path value="Extension.valueCoding" />
-      <sliceName value="valueCoding" />
-      <min value="1" />
+      <path value="Extension.valueCoding"/>
+      <sliceName value="valueCoding"/>
+      <min value="1"/>
       <type>
-        <code value="Coding" />
+        <code value="Coding"/>
       </type>
       <binding>
-        <strength value="required" />
-        <description value="grounds for concurrent supply types" />
-        <valueSet value="http://hl7.org.au/fhir/ValueSet/grounds-for-concurrent-supply" />
+        <strength value="required"/>
+        <description value="grounds for concurrent supply types"/>
+        <valueSet value="http://hl7.org.au/fhir/ValueSet/grounds-for-concurrent-supply"/>
       </binding>
     </element>
   </differential>

--- a/resources/valueset-amt-mp-codes.xml
+++ b/resources/valueset-amt-mp-codes.xml
@@ -1,35 +1,41 @@
-<ValueSet xmlns="http://hl7.org/fhir" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hl7.org/fhir ../fhir-all-xsd/valueset.xsd">
+<ValueSet xmlns="http://hl7.org/fhir" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<id value="amt-mp-codes"/>
 	<url value="http://hl7.org.au/fhir/ValueSet/amt-mp-codes"/>
-    <identifier> 
-	   <system value="urn:ietf:rfc:3986"/> 
-       <value value="urn:oid:2.16.840.1.113883.2.3.4.2.2.16"/> 
-    </identifier>
+	<identifier>
+		<system value="urn:ietf:rfc:3986"/>
+		<value value="urn:oid:2.16.840.1.113883.2.3.4.2.2.16"/>
+	</identifier>
 	<version value="2.1.0"/>
 	<name value="AMTMedicinalProduct"/>
 	<title value="AMT Medicinal Product"/>
 	<status value="active"/>
 	<experimental value="false"/>
-	<date value="2019-05-01"/>
+	<date value="2020-05-01"/>
 	<publisher value="Health Level Seven Australia"/>
 	<contact>
 		<telecom>
-		  <system value="url" />
-		  <value value="http://hl7.com.au" />
-		  <use value="work" />
+			<system value="url"/>
+			<value value="http://hl7.com.au"/>
+			<use value="work"/>
 		</telecom>
 	</contact>
 	<description value="Medicines set for AMT Medicinal Product (MP) refset"/>
+	<jurisdiction>
+		<coding>
+			<system value="urn:iso:std:iso:3166"/>
+			<code value="AU"/>
+		</coding>
+	</jurisdiction>
 	<copyright value="HL7 Australia© 2018+; Licensed Under Creative Commons No Rights Reserved."/>
 	<compose>
-		<include> 
-		  <system value="http://snomed.info/sct"/> 
-		  <version value="http://snomed.info/sct/32506021000036107"/>
-		  <filter> 
-			<property value="concept"/> 
-			<op value="in"/> 
-			<value value="929360061000036106"/> 
-		  </filter> 
-		</include> 
+		<include>
+			<system value="http://snomed.info/sct"/>
+			<version value="http://snomed.info/sct/32506021000036107"/>
+			<filter>
+				<property value="concept"/>
+				<op value="in"/>
+				<value value="929360061000036106"/>
+			</filter>
+		</include>
 	</compose>
 </ValueSet>

--- a/resources/valueset-grounds-for-concurrent-supply.xml
+++ b/resources/valueset-grounds-for-concurrent-supply.xml
@@ -1,29 +1,37 @@
-<ValueSet xmlns="http://hl7.org/fhir" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hl7.org/fhir ../fhir-all-xsd/valueset.xsd">
+<ValueSet xmlns="http://hl7.org/fhir" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<id value="grounds-for-concurrent-supply"/>
 	<url value="http://hl7.org.au/fhir/ValueSet/grounds-for-concurrent-supply"/>
-	<identifier> 
-		<system value="urn:ietf:rfc:3986"/> 
-       <value value="urn:oid:2.16.840.1.113883.2.3.4.2.2.3"/> 
-    </identifier>
+	<identifier>
+		<system value="urn:ietf:rfc:3986"/>
+		<value value="urn:oid:2.16.840.1.113883.2.3.4.2.2.3"/>
+	</identifier>
 	<version value="2.1.0"/>
 	<name value="GroundsforConcurrentSupply"/>
 	<title value="Grounds for Concurrent Supply"/>
 	<status value="active"/>
 	<experimental value="false"/>
-	<date value="2019-05-01"/>
+	<date value="2020-05-01"/>
 	<publisher value="Health Level Seven Australia"/>
 	<contact>
 		<telecom>
-		  <system value="url" />
-		  <value value="http://hl7.com.au" />
-		  <use value="work" />
+			<system value="url"/>
+			<value value="http://hl7.com.au"/>
+			<use value="work"/>
 		</telecom>
 	</contact>
 	<description value="Record of grounds for concurrent supply of medication"/>
+	<jurisdiction>
+		<coding>
+			<system value="urn:iso:std:iso:3166"/>
+			<code value="AU"/>
+		</coding>
+	</jurisdiction>
 	<copyright value="HL7 Australia© 2018+; Licensed Under Creative Commons No Rights Reserved."/>
 	<compose>
 		<include>
-			<system value="https://healthterminologies.gov.au/fhir/CodeSystem/concurrent-supply-grounds-1"/>
+			<system
+				value="https://healthterminologies.gov.au/fhir/CodeSystem/concurrent-supply-grounds-1"
+			/>
 		</include>
 	</compose>
 </ValueSet>

--- a/resources/valueset-gtin.xml
+++ b/resources/valueset-gtin.xml
@@ -1,4 +1,4 @@
-<ValueSet xmlns="http://hl7.org/fhir" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hl7.org/fhir ../fhir-all-xsd/valueset.xsd">
+<ValueSet xmlns="http://hl7.org/fhir" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<id value="gtin"/>
 	<url value="http://hl7.org.au/fhir/ValueSet/gtin"/>
 	<identifier> 
@@ -10,7 +10,7 @@
 	<title value="GTIN for Medicines"/>
 	<status value="active"/>
 	<experimental value="false"/>
-	<date value="2019-05-01"/>
+	<date value="2020-05-01"/>
 	<publisher value="Health Level Seven Australia"/>
 	<contact>
 		<telecom>
@@ -20,6 +20,12 @@
 		</telecom>
 	</contact>
 	<description value="GTIN for medicines"/>
+	<jurisdiction>
+		<coding>
+			<system value="urn:iso:std:iso:3166"/>
+			<code value="AU"/>
+		</coding>
+	</jurisdiction>
 	<copyright value="HL7 Australia© 2018+; Licensed Under Creative Commons No Rights Reserved."/>
 	<compose>
     <include> 

--- a/resources/valueset-mims.xml
+++ b/resources/valueset-mims.xml
@@ -1,29 +1,35 @@
-<ValueSet xmlns="http://hl7.org/fhir" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hl7.org/fhir ../fhir-all-xsd/valueset.xsd">
+<ValueSet xmlns="http://hl7.org/fhir" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<id value="mims"/>
 	<url value="http://hl7.org.au/fhir/ValueSet/mims"/>
-	<identifier> 
-	   <system value="urn:ietf:rfc:3986"/> 
-       <value value="urn:oid:2.16.840.1.113883.2.3.4.2.2.7"/> 
-    </identifier>
+	<identifier>
+		<system value="urn:ietf:rfc:3986"/>
+		<value value="urn:oid:2.16.840.1.113883.2.3.4.2.2.7"/>
+	</identifier>
 	<version value="2.1.0"/>
 	<name value="MIMSTerminology"/>
 	<title value="MIMS Terminology"/>
 	<status value="active"/>
 	<experimental value="false"/>
-	<date value="2019-05-01"/>
+	<date value="2020-05-01"/>
 	<publisher value="Health Level Seven Australia"/>
 	<contact>
 		<telecom>
-		  <system value="url" />
-		  <value value="http://hl7.com.au" />
-		  <use value="work" />
+			<system value="url"/>
+			<value value="http://hl7.com.au"/>
+			<use value="work"/>
 		</telecom>
 	</contact>
 	<description value="MIMS Australian medicines coding"/>
+	<jurisdiction>
+		<coding>
+			<system value="urn:iso:std:iso:3166"/>
+			<code value="AU"/>
+		</coding>
+	</jurisdiction>
 	<copyright value="HL7 Australia© 2018+; Licensed Under Creative Commons No Rights Reserved."/>
 	<compose>
-    <include> 
-      <system value="http://www.mims.com.au/codes"/> 
-    </include> 
+		<include>
+			<system value="http://www.mims.com.au/codes"/>
+		</include>
 	</compose>
 </ValueSet>

--- a/resources/valueset-pbs-item.xml
+++ b/resources/valueset-pbs-item.xml
@@ -1,4 +1,4 @@
-<ValueSet xmlns="http://hl7.org/fhir" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hl7.org/fhir ../fhir-all-xsd/valueset.xsd">
+<ValueSet xmlns="http://hl7.org/fhir" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<id value="pbs-item"/>
 	<url value="http://hl7.org.au/fhir/ValueSet/pbs-item"/>
 	<identifier> 
@@ -10,7 +10,7 @@
 	<title value="PBS Medicines Item Codes"/>
 	<status value="active"/>
 	<experimental value="false"/>
-	<date value="2019-05-01"/>
+	<date value="2020-05-01"/>
 	<publisher value="Health Level Seven Australia"/>
 	<contact>
 		<telecom>
@@ -20,6 +20,12 @@
 		</telecom>
 	</contact>
 	<description value="PBS medicines coding"/>
+	<jurisdiction>
+		<coding>
+			<system value="urn:iso:std:iso:3166"/>
+			<code value="AU"/>
+		</coding>
+	</jurisdiction>
 	<copyright value="HL7 Australia© 2018+; Licensed Under Creative Commons No Rights Reserved."/>
 	<compose>
 		<include> 


### PR DESCRIPTION
Includes fixes to add jurisdiction declaration and update date and contact details; mostly related to Medications profiles & related terminology.
Fixes #484.