### PR TITLE
Updated terminology bindings for AU Base Healthcare Service and AU Base Practitioner Role

### DIFF
--- a/resources/au-healthcareservice.xml
+++ b/resources/au-healthcareservice.xml
@@ -51,7 +51,7 @@
       <binding>
         <strength value="preferred" />
         <description value="A type of service that a healthcare service may provide." />
-        <valueSet value="http://hl7.org.au/fhir/ValueSet/snomed-healthcareservice-services" />
+        <valueSet value="https://healthterminologies.gov.au/fhir/ValueSet/service-type-1" />
       </binding>
     </element>
     <element id="HealthcareService.specialty">
@@ -60,7 +60,7 @@
       <binding>
         <strength value="preferred" />
         <description value="A specialty role that a healthcare service may provide." />
-        <valueSet value="http://hl7.org.au/fhir/ValueSet/snomed-healthcareservice-specialties" />
+        <valueSet value="https://healthterminologies.gov.au/fhir/ValueSet/clinical-specialty-1" />
       </binding>
     </element>
     <element id="HealthcareService.serviceProvisionCode">

--- a/resources/au-practitionerrole.xml
+++ b/resources/au-practitionerrole.xml
@@ -59,7 +59,7 @@
       <short value="Practitioner specialties" />
       <binding>
         <strength value="preferred" />
-        <valueSet value="http://hl7.org.au/fhir/ValueSet/snomed-practitioner-specialties" />
+        <valueSet value="https://healthterminologies.gov.au/fhir/ValueSet/clinical-specialty-1" />
       </binding>
     </element>
   </differential>


### PR DESCRIPTION
Updated terminology bindings in HL7 AU Base Healthcare Service and Practitioner Role.
Terminology bindings changed from HL7 bindings to NCTS bindings.
- Binding on PractitionerRole.specialty changed to https://healthterminologies.gov.au/fhir/ValueSet/clinical-specialty-1 ValueSet
- Binding on HealthcareService.type changed to https://healthterminologies.gov.au/fhir/ValueSet/service-type-1  ValueSet
- Binding on HealthcareService.specialty changed to https://healthterminologies.gov.au/fhir/ValueSet/clinical-specialty-1 ValueSet