### PR TITLE
Updated MedicationType extension and MedicationStatement examples

### DIFF
--- a/examples/medicationstatement-MedicationStatementexample0.xml
+++ b/examples/medicationstatement-MedicationStatementexample0.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <MedicationStatement xmlns="http://hl7.org/fhir">
-    <id value="MedicationStatementexample0"/>    
-   
+    <id value="MedicationStatementexample0"/>
+
     <status value="active"/>
-    
+
     <medicationCodeableConcept>
         <coding>
             <extension url="http://hl7.org.au/fhir/StructureDefinition/medication-type">
@@ -15,30 +15,30 @@
             </extension>
             <system value="http://snomed.info/sct"/>
             <code value="6166011000036106"/>
-            <display value="Roferon-A 9 million units/0.5 mL injection solution, 0.5 mL syringe"/>
+            <display value="Roferon-A 9 million units (33.333 microgram)/0.5 mL injection, 0.5 mL syringe"/>
         </coding>
     </medicationCodeableConcept>
-    
-    <effectivePeriod>        
-        <start value="2018-06-25"/> 
-    </effectivePeriod>        
-    
-    <dateAsserted value = "2018-07-25"/>
-    
-    <informationSource>
-        <reference value="Practitioner/example0"/>
-        <display value="Doctor Mayo"/>
-    </informationSource>
-    
     <subject>
         <reference value="Patient/example0"/>
         <display value="Franklin"/>
     </subject>
-    
-    <taken value="y"/>   
-     
-    <dosage>        
-        
+    <effectivePeriod>
+        <start value="2018-06-25"/>
+    </effectivePeriod>
+
+    <dateAsserted value="2018-07-25"/>
+
+    <informationSource>
+        <reference value="Practitioner/example0"/>
+        <display value="Doctor Mayo"/>
+    </informationSource>
+
+
+
+    <!--<taken value="y"/>-->
+
+    <dosage>
+
         <timing>
             <repeat>
                 <frequency value="3"/>
@@ -48,7 +48,7 @@
                 <dayOfWeek value="wed"/>
                 <dayOfWeek value="sat"/>
             </repeat>
-        </timing>             
-       
+        </timing>
+
     </dosage>
 </MedicationStatement>

--- a/examples/medicationstatement-MedicationStatementexample0.xml
+++ b/examples/medicationstatement-MedicationStatementexample0.xml
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <MedicationStatement xmlns="http://hl7.org/fhir">
     <id value="MedicationStatementexample0"/>
-
     <status value="active"/>
-
     <medicationCodeableConcept>
         <coding>
             <extension url="http://hl7.org.au/fhir/StructureDefinition/medication-type">
@@ -15,7 +13,9 @@
             </extension>
             <system value="http://snomed.info/sct"/>
             <code value="6166011000036106"/>
-            <display value="Roferon-A 9 million units (33.333 microgram)/0.5 mL injection, 0.5 mL syringe"/>
+            <display
+                value="Roferon-A 9 million units (33.333 microgram)/0.5 mL injection, 0.5 mL syringe"
+            />
         </coding>
     </medicationCodeableConcept>
     <subject>
@@ -25,20 +25,12 @@
     <effectivePeriod>
         <start value="2018-06-25"/>
     </effectivePeriod>
-
     <dateAsserted value="2018-07-25"/>
-
     <informationSource>
         <reference value="Practitioner/example0"/>
         <display value="Doctor Mayo"/>
     </informationSource>
-
-
-
-    <!--<taken value="y"/>-->
-
     <dosage>
-
         <timing>
             <repeat>
                 <frequency value="3"/>
@@ -49,6 +41,5 @@
                 <dayOfWeek value="sat"/>
             </repeat>
         </timing>
-
     </dosage>
 </MedicationStatement>

--- a/examples/medicationstatement-MedicationStatementexample1.xml
+++ b/examples/medicationstatement-MedicationStatementexample1.xml
@@ -22,18 +22,20 @@
             <display value="Zoloft"/>
         </coding>
     </medicationCodeableConcept>
-    
-    <dateAsserted value = "2018-07-25"/>
-
     <subject>
         <reference value="Patient/example0"/>
         <display value="Franklin"/>
     </subject>
+    <dateAsserted value="2018-07-25"/>
 
-    <taken value="y"/>   
-    
+
+
+    <!--<taken value="y"/>-->
+
     <note>
-        <text value="The patient is not sure when exactly started taking the medication but is certain it's been over a year"/>        
+        <text
+            value="The patient is not sure when exactly started taking the medication but is certain it's been over a year"
+        />
     </note>
 
 </MedicationStatement>

--- a/examples/medicationstatement-MedicationStatementexample1.xml
+++ b/examples/medicationstatement-MedicationStatementexample1.xml
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <MedicationStatement xmlns="http://hl7.org/fhir">
     <id value="MedicationStatementexample1"/>
-
     <extension url="http://hl7.org.au/fhir/StructureDefinition/medication-long-term">
         <valueBoolean value="true"/>
     </extension>
-
     <status value="active"/>
-
     <medicationCodeableConcept>
         <coding>
             <extension url="http://hl7.org.au/fhir/StructureDefinition/medication-type">
@@ -27,15 +24,9 @@
         <display value="Franklin"/>
     </subject>
     <dateAsserted value="2018-07-25"/>
-
-
-
-    <!--<taken value="y"/>-->
-
     <note>
         <text
             value="The patient is not sure when exactly started taking the medication but is certain it's been over a year"
         />
     </note>
-
 </MedicationStatement>

--- a/examples/medicationstatement-MedicationStatementexample2.xml
+++ b/examples/medicationstatement-MedicationStatementexample2.xml
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <MedicationStatement xmlns="http://hl7.org/fhir">
     <id value="MedicationStatementexample2"/>
-
     <status value="completed"/>
-
     <medicationCodeableConcept>
         <coding>
             <extension url="http://hl7.org.au/fhir/StructureDefinition/medication-type">
@@ -15,7 +13,7 @@
             </extension>
             <system value="http://snomed.info/sct"/>
             <code value="5232011000036102"/>
-            <display value="Diflucan 200 mg/100 mL injection solution, 100 mL vial"/>
+            <display value="Diflucan 200 mg/100 mL injection, 100 mL vial"/>
         </coding>
     </medicationCodeableConcept>
     <subject>
@@ -26,19 +24,12 @@
         <start value="2018-06-25"/>
         <end value="2018-07-05"/>
     </effectivePeriod>
-
     <dateAsserted value="2018-07-10"/>
-
     <informationSource>
         <reference value="Practitioner/example0"/>
         <display value="Doctor Mayo"/>
     </informationSource>
-
-    
-
-    <!--<taken value="y"/>-->
-
-    <dosage>
+       <dosage>
         <timing>
             <repeat>
                 <duration value="30"/>
@@ -51,19 +42,19 @@
             </repeat>
         </timing>
         <route>
-            <coding> 
-                <system value="http://snomed.info/sct"/> 
-                <code value="47625008"/> 
-                <display value="Intravenous route"/> 
-            </coding> 
+            <coding>
+                <system value="http://snomed.info/sct"/>
+                <code value="47625008"/>
+                <display value="Intravenous route"/>
+            </coding>
         </route>
-       <doseAndRate>
-        <doseQuantity>
-            <value value="200"/>
-            <unit value="mg"/>
-            <system value="http://unitsofmeasure.org"/>
-            <code value="mg"/>
-        </doseQuantity>
-       </doseAndRate>
+        <doseAndRate>
+            <doseQuantity>
+                <value value="200"/>
+                <unit value="mg"/>
+                <system value="http://unitsofmeasure.org"/>
+                <code value="mg"/>
+            </doseQuantity>
+        </doseAndRate>
     </dosage>
 </MedicationStatement>

--- a/examples/medicationstatement-MedicationStatementexample2.xml
+++ b/examples/medicationstatement-MedicationStatementexample2.xml
@@ -18,7 +18,10 @@
             <display value="Diflucan 200 mg/100 mL injection solution, 100 mL vial"/>
         </coding>
     </medicationCodeableConcept>
-
+    <subject>
+        <reference value="Patient/example0"/>
+        <display value="Franklin"/>
+    </subject>
     <effectivePeriod>
         <start value="2018-06-25"/>
         <end value="2018-07-05"/>
@@ -31,12 +34,9 @@
         <display value="Doctor Mayo"/>
     </informationSource>
 
-    <subject>
-        <reference value="Patient/example0"/>
-        <display value="Franklin"/>
-    </subject>
+    
 
-    <taken value="y"/>
+    <!--<taken value="y"/>-->
 
     <dosage>
         <timing>
@@ -57,12 +57,13 @@
                 <display value="Intravenous route"/> 
             </coding> 
         </route>
+       <doseAndRate>
         <doseQuantity>
             <value value="200"/>
             <unit value="mg"/>
             <system value="http://unitsofmeasure.org"/>
             <code value="mg"/>
         </doseQuantity>
-
+       </doseAndRate>
     </dosage>
 </MedicationStatement>

--- a/resources/structuredefinition-medication-type.xml
+++ b/resources/structuredefinition-medication-type.xml
@@ -28,24 +28,28 @@
   <kind value="complex-type"/>
   <abstract value="false"/>
   <context>
-    <type value="element"/>
-    <expression value="Medication.code.coding"/>
+    <type value="fhirpath"/>
+    <expression value="Medication.code.ofType(CodeableConcept).coding"/>
   </context>
   <context>
-    <type value="element"/>
-    <expression value="MedicationRequest.medicationCodeableConcept.coding"/>
+    <type value="fhirpath"/>
+    <expression value="Medication.ingredient.item.ofType(CodeableConcept).coding"/>
   </context>
   <context>
-    <type value="element"/>
-    <expression value="MedicationDispense.medicationCodeableConcept.coding"/>
+    <type value="fhirpath"/>
+    <expression value="MedicationRequest.medication.ofType(CodeableConcept).coding"/>
   </context>
   <context>
-    <type value="element"/>
-    <expression value="MedicationStatement.medicationCodeableConcept.coding"/>
+    <type value="fhirpath"/>
+    <expression value="MedicationDispense.medication.ofType(CodeableConcept).coding"/>
   </context>
   <context>
-    <type value="element"/>
-    <expression value="MedicationAdministration.medicationCodeableConcept.coding"/>
+    <type value="fhirpath"/>
+    <expression value="MedicationStatement.medication.ofType(CodeableConcept).coding"/>
+  </context>
+  <context>
+    <type value="fhirpath"/>
+    <expression value="MedicationAdministration.medication.ofType(CodeableConcept).coding"/>
   </context>
   <context>
     <type value="element"/>
@@ -76,8 +80,17 @@
       <path value="Extension.url"/>
       <fixedUri value="http://hl7.org.au/fhir/StructureDefinition/medication-type"/>
     </element>
+    <element id="Extension.value[x]">
+      <path value="Extension.value[x]"/>
+      <slicing>
+        <discriminator>
+          <type value="type"/>
+          <path value="$this"/>
+        </discriminator>
+      </slicing>
+    </element>
     <element id="Extension.value[x]:valueCoding">
-      <path value="Extension.valueCoding"/>
+      <path value="Extension.value[x]"/>
       <sliceName value="valueCoding"/>
       <min value="1"/>
       <type>


### PR DESCRIPTION
Fixes #479.
Related to #482, #481

Changes to MedicationType extension StructureDefinition context declaration to be of type fhirPath.

Changes to MedicationStatement examples 
- medicationstatement-MedicationStatementexample0.xml
- medicationstatement-MedicationStatementexample1.xml
- medicationstatement-MedicationStatementexample2.xml
to fix the QA errors related to unknown elements and elements out of order. 

