### PR TITLE
AU Medicines List examples QA fixes

### DIFF
--- a/examples/list-0ebc46a8-4ea8-11e9-8647-d663bd873d93.xml
+++ b/examples/list-0ebc46a8-4ea8-11e9-8647-d663bd873d93.xml
@@ -64,8 +64,8 @@
                     <tr>
                         <th>Consultation summary</th>
                         <td>Patient presented with weakness over the last couple of days. No other
-                            symptoms. Revised patient's medications. Advised patient to
-                            see the usual GPs clinic for further consultation and review. </td>
+                            symptoms. Revised patient's medications. Advised patient to see the
+                            usual GPs clinic for further consultation and review. </td>
                     </tr>
                 </tbody>
             </table>
@@ -147,10 +147,10 @@
             <medicationCodeableConcept>
                 <text value="Multi-vitamins"/>
             </medicationCodeableConcept>
-            <dateAsserted value="2019-03-15"/>
             <subject>
                 <reference value="#cfd14b34-4eaa-11e9-8647-d663bd873d93"/>
             </subject>
+            <dateAsserted value="2019-03-15"/>
             <dosage>
                 <text value="1 tablet daily"/>
             </dosage>
@@ -163,10 +163,10 @@
             <medicationCodeableConcept>
                 <text value="Spiriva (tiotropium bromide 18mg per inhalation) inhalant"/>
             </medicationCodeableConcept>
-            <dateAsserted value="2019-03-15"/>
             <subject>
                 <reference value="#cfd14b34-4eaa-11e9-8647-d663bd873d93"/>
             </subject>
+            <dateAsserted value="2019-03-15"/>
             <reasonCode>
                 <text value="COPD"/>
             </reasonCode>
@@ -390,7 +390,7 @@
             </type>
             <priority>
                 <coding>
-                    <system value="http://hl7.org/fhir/v3/ActPriority"/>
+                    <system value="http://terminology.hl7.org/CodeSystem/v3-ActPriority"/>
                     <code value="R"/>
                 </coding>
             </priority>

--- a/examples/list-e0a6c4a6-4e97-11e9-8647-d663bd873d93.xml
+++ b/examples/list-e0a6c4a6-4e97-11e9-8647-d663bd873d93.xml
@@ -1,12 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <List xmlns="http://hl7.org/fhir">
     <id value="e0a6c4a6-4e97-11e9-8647-d663bd873d93"/>
-
-    <extension url="http://hl7.org.au/fhir/StructureDefinition/author-role">
-        <valueReference>
-            <reference value="PractitionerRole/example3"/>
-        </valueReference>
-    </extension>
     <identifier>
         <system value="https://tools.ietf.org/html/rfc4122"/>
         <value value="fbee41d4-4e98-11e9-8647-d663bd873d93"/>
@@ -25,6 +19,9 @@
         <reference value="Patient/example0"/>
     </subject>
     <date value="2019-02-08"/>
+    <source>
+        <reference value="PractitionerRole/example3"/>
+    </source>
     <entry>
         <flag>
             <coding>


### PR DESCRIPTION
Fixes https://github.com/hl7au/au-fhir-base/issues/483.

Made following changes:

- In list-0ebc46a8-4ea8-11e9-8647-d663bd873d93.xml
corrected order of subject element in contained MedicationStatement examples
corrected Encounter.priority code system value to R4; previously example included STU3 value

- In list-e0a6c4a6-4e97-11e9-8647-d663bd873d93.xml
removed the author-role extension fragment and included source element instead. The extension was needed in STU3 where source did not allow for PractitionerRole which is not the case anymore.