### PR TITLE
Medication Type QA fix

### DIFF
--- a/resources/structuredefinition-medication-type.xml
+++ b/resources/structuredefinition-medication-type.xml
@@ -80,17 +80,8 @@
       <path value="Extension.url"/>
       <fixedUri value="http://hl7.org.au/fhir/StructureDefinition/medication-type"/>
     </element>
-    <element id="Extension.value[x]">
-      <path value="Extension.value[x]"/>
-      <slicing>
-        <discriminator>
-          <type value="type"/>
-          <path value="$this"/>
-        </discriminator>
-      </slicing>
-    </element>
     <element id="Extension.value[x]:valueCoding">
-      <path value="Extension.value[x]"/>
+      <path value="Extension.valueCoding"/>
       <sliceName value="valueCoding"/>
       <min value="1"/>
       <type>


### PR DESCRIPTION
Removed the slicing definition from the extension StructureDefinition to fix the qa error:
Profile http://hl7.org/fhir/StructureDefinition/ElementDefinition, Element 'StructureDefinition.differential.element[2].slicing.rules': minimum required = 1, but only found 0