### PR TITLE
ig.json typo fix

### DIFF
--- a/ig.json
+++ b/ig.json
@@ -218,7 +218,7 @@
         },
         "StructureDefinition/au-australianregistredbodynumber": {
             "base": "StructureDefinition-au-australianregistredbodynumber.html",
-            "defns": "StructureDefinition-au-australianregistredbodynumberr-definitions.html"
+            "defns": "StructureDefinition-au-australianregistredbodynumber-definitions.html"
         },
        "StructureDefinition/au-insurernumber": {
             "base": "StructureDefinition-au-insurernumber.html",


### PR DESCRIPTION
Misspelled profile name causing problems with the profile (AU Australian Registered Body Number) and build errors on QA report.

Fixes #517