### PR TITLE
Correct errors in PractitionerRole examples

### DIFF
--- a/examples/practitionerrole-example0.xml
+++ b/examples/practitionerrole-example0.xml
@@ -11,15 +11,16 @@
 			</p>
 			<p><b>id</b>: example0</p>
 			<p><b>meta</b>: </p>
-			<p><b>identifier</b>: Medicare Provider Number: 2426621B</p>
+			<p><b>identifier</b>: Medicare Provider Number: 1234561A</p>
 			<p><b>active</b>: true</p>
 			<p><b>practitioner</b>: <a href="Practitioner-example0.html">Generated Summary: id: example0; HPI-I: 8003619900015717, Prescriber Number: 453221, AHPRA Registration Number: MED0000932945,
-					Care Agency Employee Identifier: 9003600003999997; active; Helen Mayo ; helen.mayo@downunderhospital.com.au(WORK); <span title="Codes: {urn:ietf:bcp:47 asf}">Auslan</span></a></p>
+					Care Agency Employee Identifier: 9003600003999997; active; Helen Mayo ; helen.mayo@downunderhospital.example.com(WORK); <span title="Codes: {urn:ietf:bcp:47 asf}">Auslan</span></a></p>
 			<p><b>organization</b>: <a href="Organization-example0.html">Generated Summary: id: example0; HPI-O: 8003621566684455; active; name: Downunder Hospital;
 					helen.mayo@downunderhospital.example.com(WORK)</a></p>
-			<p><b>specialty</b>: <span title="Codes: {http://snomed.info/sct 17561000}">Cardiologist</span></p>
-			<p><b>location</b>: <a href="Location-example0.html">Generated Summary: id: example0; status: active; name: Downunder Hospital Blacktown; ph: 025553555(WORK)</a></p>
-			<p><b>telecom</b>: ph: 025557777(WORK), ph: 025558888(After Hours)</p>
+			<p><b>code</b>: <span title="Codes: {http://snomed.info/sct 17561000}">Cardiologist</span></p>
+			<p><b>specialty</b>: <span title="Codes: {http://snomed.info/sct 394579002}">Cardiology</span></p>
+			<p><b>location</b>: <a href="Location-example0.html">Generated Summary: id: example0; status: active; name: Downunder Hospital Blacktown; ph: 0255503555(WORK)</a></p>
+			<p><b>telecom</b>: ph: 0255507777(WORK), ph: 0255508888(After Hours)</p>
 		</div>
 	</text>
 	<identifier>
@@ -31,7 +32,7 @@
 			<text value="Medicare Provider Number"/>
 		</type>
 		<system value="http://ns.electronichealth.net.au/id/medicare-provider-number"/>
-		<value value="2426621B"/>
+		<value value="1234561A"/>
 	</identifier>
 	<active value="true"/>
 	<practitioner>
@@ -40,11 +41,18 @@
 	<organization>
 		<reference value="Organization/example0"/>
 	</organization>
-	<specialty>
+	<code>
 		<coding>
 			<system value="http://snomed.info/sct"/>
 			<code value="17561000"/>
 			<display value="Cardiologist"/>
+		</coding>
+	</code>
+	<specialty>
+		<coding>
+			<system value="http://snomed.info/sct"/>
+			<code value="394579002"/>
+			<display value="Cardiology"/>
 		</coding>
 	</specialty>
 	<location>
@@ -52,7 +60,7 @@
 	</location>
 	<telecom>
 		<system value="phone"/>
-		<value value="025557777"/>
+		<value value="0255507777"/>
 		<use value="work"/>
 	</telecom>
 	<telecom>
@@ -66,6 +74,6 @@
 			</valueCodeableConcept>
 		</extension>
 		<system value="phone"/>
-		<value value="025558888"/>
+		<value value="0255508888"/>
 	</telecom>
 </PractitionerRole>

--- a/examples/practitionerrole-example1.xml
+++ b/examples/practitionerrole-example1.xml
@@ -8,7 +8,7 @@
 			<coding>
 				<system value="http://terminology.hl7.org.au/CodeSystem/v2-0203"/>
 				<code value="NPIO"/>
-				<display value="National Provider at Organisation Identifier"/>
+				<display value="National provider at organisation identifier"/>
 			</coding>
 			<text value="NPIO"/>
 		</type>
@@ -21,13 +21,13 @@
 	<organization>
 		<reference value="Organization/example1"/>
 	</organization>
-	<specialty>
+	<code>
 		<coding>
 			<system value="http://snomed.info/sct"/>
 			<code value="66862007"/>
 			<display value="Radiologist"/>
 		</coding>
-	</specialty>
+	</code>
 	<location>
 		<reference value="Location/example1"/>
 	</location>
@@ -36,7 +36,7 @@
 	</healthcareService> 
 	<telecom>
 		<system value="email"/>
-		<value value="helen.mayo@downunderhospital.com.au"/>
+		<value value="helen.mayo@downunderhospital.example.com"/>
 		<use value="work"/>
 	</telecom>
 	<availabilityExceptions value="Availability on public holidays may vary, please contact the hospital directly to confirm."/>

--- a/examples/practitionerrole-example2.xml
+++ b/examples/practitionerrole-example2.xml
@@ -12,7 +12,7 @@
 			</coding>	
 			<text value="Employee Number"/>
 		</type>
-		<system value="http://ns.electronichealth.net.au/id/abn-scoped/service-provider-individual/1.0/84425496912"/>
+		<system value="http://ns.electronichealth.net.au/id/abn-scoped/service-provider-individual/1.0/51824753556"/>
 		<value value="peterwinslow44"/>	
         <assigner>
         	<display value="Albion Hospital"/>
@@ -27,8 +27,8 @@
 	<specialty>
 		<coding>
 			<system value="http://snomed.info/sct"/>
-			<code value="85733003"/>
-			<display value="General pathologist"/>
+			<code value="394915009"/>
+			<display value="General pathology (specialty)"/>
 		</coding>
 	</specialty>
 	<location>
@@ -39,7 +39,7 @@
 	</healthcareService> 
 	<telecom>
 		<system value="email"/>
-		<value value="peter.winslow@amail.com.au"/>
+		<value value="peter.winslow@amail.example.com"/>
 		<use value="work"/>
 	</telecom>
 	<availableTime> 

--- a/examples/practitionerrole-example3.xml
+++ b/examples/practitionerrole-example3.xml
@@ -12,7 +12,7 @@
 			<text value="Medicare Provider Number"/>
 		</type>
 		<system value="http://ns.electronichealth.net.au/id/medicare-provider-number"/>
-		<value value="5544887B"/>
+		<value value="1234561A"/>
 	</identifier>
 	<practitioner>
 		<reference value="Practitioner/example3"/>
@@ -23,8 +23,8 @@
 	<specialty>
 		<coding>
 			<system value="http://snomed.info/sct"/>
-			<code value="309394004"/>
-			<display value="General practitioner principal"/>
+			<code value="394814009"/>
+			<display value="General practice (specialty)"/>
 		</coding>
 	</specialty>
 	<location>
@@ -35,7 +35,7 @@
 	</healthcareService> 
 	<telecom>
 		<system value="email"/>
-		<value value="francis.fernando@alphamail.com.au"/>
+		<value value="francis.fernando@alphamail.example.com"/>
 		<use value="work"/>
 	</telecom>
 	<availableTime> 

--- a/examples/practitionerrole-example4.xml
+++ b/examples/practitionerrole-example4.xml
@@ -58,19 +58,19 @@
   <organization>
     <reference value="Organization/example0"/>
   </organization>
-  <specialty>
+  <code>
     <coding>
       <system value="http://snomed.info/sct"/>
       <code value="17561000"/>
       <display value="Cardiologist"/>
     </coding>
-  </specialty>
+  </code>
   <location>
     <reference value="Location/example0"/>
   </location>
   <telecom>
     <system value="phone"/>
-    <value value="025553333"/>
+    <value value="0255503333"/>
     <use value="work"/>
   </telecom>
   <endpoint>


### PR DESCRIPTION
Use preferred values for code and specialty, use example values for telecom and identifier.