### PR TITLE
removing redundant min max tags from au-patient

### DIFF
--- a/resources/au-patient.xml
+++ b/resources/au-patient.xml
@@ -107,8 +107,6 @@
     <element id="Patient.extension:ethnicity">
       <path value="Patient.extension" />
       <sliceName value="ethnicity" />
-      <min value="0" />
-      <max value="*" />
       <type>
         <code value="Extension" />
         <profile value="http://hl7.org.au/fhir/StructureDefinition/ethnicity" />


### PR DESCRIPTION
Hi,
The two tags (min and max) in the au-patient have been removed as they were causing qa errors.
They seem to be redundant.

Please review and accept as required.

Thanks,
Vikas