### PR TITLE
AU Base Allergy Intolerance - fixed broken example link

### DIFF
--- a/examples/allergyintolerance-example1.xml
+++ b/examples/allergyintolerance-example1.xml
@@ -33,7 +33,7 @@
     <code value="a"/>
   </onsetAge>
 
-  <assertedDate value="2018-03-07"/>
+  <recordedDate value="2018-03-07"/>
 
   <asserter>
     <reference value="Patient/example2"/>

--- a/examples/allergyintolerance-example1.xml
+++ b/examples/allergyintolerance-example1.xml
@@ -5,9 +5,21 @@
     <profile value="http://hl7.org.au/fhir/StructureDefinition/au-allergyintolerance"/>
   </meta>
 
-  <clinicalStatus value="active"/>
-
-  <verificationStatus value="unconfirmed"/>
+  <clinicalStatus>
+    <coding>
+      <system value="http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical"/>
+      <code value="active"/>
+      <display value="Active"/>
+    </coding>
+  </clinicalStatus>
+  
+  <verificationStatus>
+    <coding>
+      <system value="http://terminology.hl7.org/CodeSystem/allergyintolerance-verification"/>
+      <code value="unconfirmed"/>
+      <display value="Unconfirmed"/>
+    </coding>
+  </verificationStatus>
 
   <type value="allergy"/>
 

--- a/resources/ig.xml
+++ b/resources/ig.xml
@@ -865,6 +865,14 @@
     </resource>
     <resource>
       <reference>
+        <reference value="AllergyIntolerance/allergyintolerance-example1"/>
+      </reference>
+      <name value="AllergyIntolerance example - self-reported allergy to eggs"/>
+      <exampleBoolean value="true"/>
+      <groupingId value="p1"/>
+    </resource>
+    <resource>
+      <reference>
         <reference value="Location/example1"/>
       </reference>
       <name value="Location of a Practitioner as a Radiologist"/>


### PR DESCRIPTION
The link to the example was broken due to the file not being listed in the ig.xml. But when it was, there were then 6 errors that needing fixing.

### Changes
1. Added allergyintolerance-example1 example into ig.xml
1. Example: allergyintolerance-example1
    - corrected element name (changed 'assertedDate' to 'recordedDate')
    - corrected structure of clinicalStatus and verificationStatus

Fixes #564 