### PR TITLE
Minor updates to AU AllergyIntolerance profile

### DIFF
--- a/pages/_includes/au-allergyintolerance-intro.md
+++ b/pages/_includes/au-allergyintolerance-intro.md
@@ -2,9 +2,6 @@
 
 This profile defines an allergy intolerance structure including core localisation concepts for use in an Australian context.
 
-Note: The value set [Indicator of Hypersensitivity or Intolerance to Substance](https://healthterminologies.gov.au/fhir/ValueSet/indicator-hypersensitivity-intolerance-to-substance-1) is part of a staged approach to offering meaningful localised coding. There is significant redesign occurring in SNOMED CT content relating to allergies, adverse reactions and intolerances. Once the redesign is realised, projected to be 2019, a more focused value set reducing the clinical finding noise will be proposed.
-
-
 **Examples**
 
 [Ibuprofen allergy, with a manifestation of urticaria](AllergyIntolerance-allergyintolerance-example0.html)

--- a/resources/au-allergyintolerance.xml
+++ b/resources/au-allergyintolerance.xml
@@ -44,7 +44,6 @@
     </element>
     <element id="AllergyIntolerance.reaction">
       <path value="AllergyIntolerance.reaction" />
-      <short value="Reaction details" />
     </element>
     <element id="AllergyIntolerance.reaction.substance">
       <path value="AllergyIntolerance.reaction.substance" />

--- a/resources/au-allergyintolerance.xml
+++ b/resources/au-allergyintolerance.xml
@@ -39,7 +39,7 @@
       <binding>
         <strength value="preferred" />
         <description value="Preferred SNOMED-CT coding for type of the substance/product, allergy or intolerance condition, or negation/exclusion codes for reporting no known allergies." />
-        <valueSet value="https://healthterminologies.gov.au/fhir/ValueSet/indicator-hypersensitivity-intolerance-to-substance-1" />
+        <valueSet value="https://healthterminologies.gov.au/fhir/ValueSet/indicator-hypersensitivity-intolerance-to-substance-2" />
       </binding>
     </element>
     <element id="AllergyIntolerance.reaction">


### PR DESCRIPTION
1)  The terminology binding on AllergyIntollerance.code was updated from https://healthterminologies.gov.au/fhir/ValueSet/indicator-hypersensitivity-intolerance-to-substance-1 to https://healthterminologies.gov.au/fhir/ValueSet/indicator-hypersensitivity-intolerance-to-substance-2 with the deletion of text int he intro.md referring to the impending update.
2) The short for AllergyIntollerance.reaction was deleted as the existing short of "Reaction details" was only present to circumvent a previous IG Publisher problem which has since been resolved.