### PR TITLE
AU Sex Assigned At Birth changes

### DIFF
--- a/pages/_includes/au-sexassignedatbirth-intro.md
+++ b/pages/_includes/au-sexassignedatbirth-intro.md
@@ -1,10 +1,7 @@
-**AU Base Sex Assigned At Birth Profile** *[[FMM Level 0](guidance.html)]*
+**AU Sex Assigned At Birth** *[[FMM Level 0](guidance.html)]*
 
-This profile is provided as a common representation of sex assigned at birth.
+This profile is provided as a common representation of the sex assigned to a person at birth, usually based on physical properties that are visually apparent at birth.
 
-#### Usage Notes
-* Is used to record sex assigned at birth at a point in time.
+This profile is not appropriate for recording patient's gender (administrativeGender).
 
-**Examples**
 
-TODO

--- a/resources/au-sexassignedatbirth.xml
+++ b/resources/au-sexassignedatbirth.xml
@@ -2,9 +2,11 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="au-sexassignedatbirth" />
   <url value="http://hl7.org.au/fhir/StructureDefinition/au-sexassignedatbirth" />
+  <version value="1.0.0" />
   <name value="AUSexAssignedAtBirth" />
   <title value="AU Sex Assigned At Birth" />
   <status value="draft" />
+  <description value="This profile is provided as a common representation of the sex assigned to a person at birth, usually based on physical properties that are visually apparent at birth." />
   <jurisdiction>
     <coding>
       <system value="urn:iso:std:iso:3166" />
@@ -18,32 +20,35 @@
   <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Observation" />
   <derivation value="constraint" />
   <differential>
-    <element id="Observation.status">
-      <path value="Observation.status" />
-      <fixedCode value="final" />
+    <element id="Observation">
+      <path value="Observation" />
+      <short value="Sex assigned at birth" />
+      <definition value="The sex assigned to a person at birth, usually based on physical properties that are visually apparent at birth." />
     </element>
     <element id="Observation.code.coding">
       <path value="Observation.code.coding" />
       <slicing>
         <discriminator>
-          <type value="value" />
-          <path value="code" />
-        </discriminator>
-        <discriminator>
-          <type value="value" />
-          <path value="system" />
+          <type value="pattern" />
+          <path value="$this" />
         </discriminator>
         <rules value="open" />
       </slicing>
       <min value="1" />
+    </element>
+    <element id="Observation.code.coding:snomedSexAtBirth">
+      <path value="Observation.code.coding" />
+      <sliceName value="snomedSexAtBirth" />
+      <min value="1" />
+      <max value="1" />
       <patternCoding>
         <system value="http://snomed.info/sct" />
-        <code value="268476009" />
+        <code value="1515311000168102" />
       </patternCoding>
     </element>
-    <element id="Observation.code.coding:sexatbirthLOINCCode">
+    <element id="Observation.code.coding:loincSexAtBirth">
       <path value="Observation.code.coding" />
-      <sliceName value="sexatbirthLOINCCode" />
+      <sliceName value="loincSexAtBirth" />
       <max value="1" />
       <patternCoding>
         <system value="http://loinc.org" />
@@ -60,7 +65,6 @@
     </element>
     <element id="Observation.effective[x]">
       <path value="Observation.effective[x]" />
-      <min value="1" />
       <type>
         <code value="dateTime" />
       </type>
@@ -70,6 +74,10 @@
       <type>
         <code value="CodeableConcept" />
       </type>
+      <binding>
+        <strength value="extensible" />
+        <valueSet value="https://healthterminologies.gov.au/fhir/ValueSet/biological-sex-1" />
+      </binding>
     </element>
   </differential>
 </StructureDefinition>


### PR DESCRIPTION
Hello, please accept this PR with proposed changes to the existing draft profile:

* Changed SNOMED code from 268476009 to 1515311000168102 |Biological sex at birth| and defined a mandatory SNOMED slice as the current design is failing validation. I was unable to confirm though that this is the intent of the original design (that an instance is always expected to include a SNOMED code and could optionally include LOINC code 76689-9).
* Removed constraints on the status fixed value of 'final' and effective[x] minimum cardinality as the AU profile should leave these open and available to be constrained by specific implementation requirements
* Added terminology binding to value[x]; it is bound to  [Biological Sex](https://www.healthterminologies.gov.au/integration/R4/fhir/ValueSet/biological-sex-)1 value set with the strength of extensible
* Added descriptions and definition
* Added version number
* Various chnages in intro.md to improve the profile description, update page title to match the StructureDefinition.title and remove content placeholders

Related to #321.