### PR TITLE
au-relatedperson ::   Edits to short descriptions, definitions and example

### DIFF
--- a/examples/relatedperson-example3.xml
+++ b/examples/relatedperson-example3.xml
@@ -21,7 +21,21 @@
   </identifier>
   <active value="true"/>
   <patient>
-    <reference value="Patient/example4"/>
+      <identifier>
+        <type>
+          <coding>
+            <system value="http://terminology.hl7.org/CodeSystem/v2-0203"/>
+            <code value="MR"/>
+          </coding>
+        </type>
+        <system value="http://downunderhospital.example.com/identifiers/patient"/>
+        <value value="765567765FRD"/>
+        <assigner>
+          <reference value="Organization/example0"/>
+          <display value="Downunder Hospital"/>
+        </assigner>
+      </identifier>
+    <display value="Alejandro Hernández MRN: 765567765FRD"/>
   </patient>
   <relationship>
     <coding>

--- a/resources/au-relatedperson.xml
+++ b/resources/au-relatedperson.xml
@@ -54,7 +54,7 @@
     <element id="RelatedPerson.relationship">
       <path value="RelatedPerson.relationship" />
       <short value="The nature of the relationship to the patient"/>
-      <definition value="The nature of the relationship that the related person has with the patient. e.g. The RelatedPerson is the mother of the Patient"/>
+      <definition value="The nature of the relationship that the related person has with the patient. e.g. The RelatedPerson is the mother of the Patient."/>
       <binding>
         <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
           <valueString value="PatientRelationshipType" />

--- a/resources/au-relatedperson.xml
+++ b/resources/au-relatedperson.xml
@@ -74,6 +74,7 @@
     </element>
     <element id="RelatedPerson.communication.language">
       <path value="RelatedPerson.communication.language" />
+      <definition value="A language which can be used to communicate with about the patient's health. The ISO-639-1 alpha 2 code in lower case for the language, optionally followed by a hyphen and the ISO-3166-1 alpha 2 code for the region in upper case; e.g. &quot;en&quot; for English, or &quot;en-US&quot; for American English versus &quot;en-EN&quot; for England English." />
       <binding>
         <strength value="extensible" />
         <valueSet value="https://healthterminologies.gov.au/fhir/ValueSet/common-languages-australia-2" />

--- a/resources/au-relatedperson.xml
+++ b/resources/au-relatedperson.xml
@@ -53,6 +53,8 @@
     </element>
     <element id="RelatedPerson.relationship">
       <path value="RelatedPerson.relationship" />
+      <short value="The nature of the relationship to the patient"/>
+      <definition value="The nature of the relationship that the related person has with the patient. e.g. The RelatedPerson is the mother of the Patient"/>
       <binding>
         <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
           <valueString value="PatientRelationshipType" />


### PR DESCRIPTION
Hello Brett, 

Please review and accept the pull request regarding the following changes to au-relatedperson and its example-3.

- Adding identifier and display for RelatedPerson.patient element of "RelatedPerson-example3" example to show the Implementers that not only reference can be used to mention the patient but also identifier and display can be used

- Edited the definition RelatedPerson.communication.language to have "A language which can be used to communicate with about the patient's health." it will look like below :
"A language which can be used to communicate with about the patient's health. The ISO-639-1 alpha 2 code in lower case for the language, optionally followed by a hyphen and the ISO-3166-1 alpha 2 code for the region in upper case; e.g. "en" for English, or "en-US" for American English versus "en-EN" for England English."

- Added "short" and "definition" values for RelatedPerson.relationship

Kind Regards, 
Uday
