### PR TITLE
Fixed multiple medication examples with R4 codesystem URL.

### DIFF
--- a/examples/bundle-9309d080-4e97-11e9-8647-d663bd873d93.xml
+++ b/examples/bundle-9309d080-4e97-11e9-8647-d663bd873d93.xml
@@ -635,7 +635,7 @@
           <coding>
             <extension url="http://hl7.org.au/fhir/StructureDefinition/medication-type">
               <valueCoding>
-                <system value="http://hl7.org.au/fhir/CodeSystem/medication-type"/>
+                <system value="http://terminology.hl7.org.au/CodeSystem/medication-type"/>
                 <code value="UPDSF"/>
                 <display value="Unbranded product with strengths and form"/>
               </valueCoding>
@@ -647,7 +647,7 @@
           <coding>
             <extension url="http://hl7.org.au/fhir/StructureDefinition/medication-type">
               <valueCoding>
-                <system value="http://hl7.org.au/fhir/CodeSystem/medication-type"/>
+                <system value="http://terminology.hl7.org.au/CodeSystem/medication-type"/>
                 <code value="BPD"/>
                 <display value="Branded product with no strengths or form"/>
               </valueCoding>
@@ -658,7 +658,7 @@
           <coding>
             <extension url="http://hl7.org.au/fhir/StructureDefinition/medication-type">
               <valueCoding>
-                <system value="http://hl7.org.au/fhir/CodeSystem/medication-type"/>
+                <system value="http://terminology.hl7.org.au/CodeSystem/medication-type"/>
                 <code value="BPD"/>
                 <display value="Branded product with no strengths or form"/>
               </valueCoding>
@@ -669,7 +669,7 @@
           <coding>
             <extension url="http://hl7.org.au/fhir/StructureDefinition/medication-type">
               <valueCoding>
-                <system value="http://hl7.org.au/fhir/CodeSystem/medication-type"/>
+                <system value="http://terminology.hl7.org.au/CodeSystem/medication-type"/>
                 <code value="BPD"/>
                 <display value="Branded product with no strengths or form"/>
               </valueCoding>
@@ -785,7 +785,7 @@
           <coding>
             <extension url="http://hl7.org.au/fhir/StructureDefinition/medication-type">
               <valueCoding>
-                <system value="http://hl7.org.au/fhir/CodeSystem/medication-type"/>
+                <system value="http://terminology.hl7.org.au/CodeSystem/medication-type"/>
                 <code value="UPDSF"/>
                 <display value="Unbranded product with strengths and form"/>
               </valueCoding>
@@ -797,7 +797,7 @@
           <coding>
             <extension url="http://hl7.org.au/fhir/StructureDefinition/medication-type">
               <valueCoding>
-                <system value="http://hl7.org.au/fhir/CodeSystem/medication-type"/>
+                <system value="http://terminology.hl7.org.au/CodeSystem/medication-type"/>
                 <code value="BPD"/>
                 <display value="Branded product with no strengths or form"/>
               </valueCoding>
@@ -911,7 +911,7 @@
           <coding>
             <extension url="http://hl7.org.au/fhir/StructureDefinition/medication-type">
               <valueCoding>
-                <system value="http://hl7.org.au/fhir/CodeSystem/medication-type"/>
+                <system value="http://terminology.hl7.org.au/CodeSystem/medication-type"/>
                 <code value="UPDSF"/>
                 <display value="Unbranded product with strengths and form"/>
               </valueCoding>
@@ -923,7 +923,7 @@
           <coding>
             <extension url="http://hl7.org.au/fhir/StructureDefinition/medication-type">
               <valueCoding>
-                <system value="http://hl7.org.au/fhir/CodeSystem/medication-type"/>
+                <system value="http://terminology.hl7.org.au/CodeSystem/medication-type"/>
                 <code value="BPD"/>
                 <display value="Branded product with no strengths or form"/>
               </valueCoding>
@@ -1038,7 +1038,7 @@
           <coding>
             <extension url="http://hl7.org.au/fhir/StructureDefinition/medication-type">
               <valueCoding>
-                <system value="http://hl7.org.au/fhir/CodeSystem/medication-type"/>
+                <system value="http://terminology.hl7.org.au/CodeSystem/medication-type"/>
                 <code value="UPDSF"/>
                 <display value="Unbranded product with strengths and form"/>
               </valueCoding>
@@ -1050,7 +1050,7 @@
           <coding>
             <extension url="http://hl7.org.au/fhir/StructureDefinition/medication-type">
               <valueCoding>
-                <system value="http://hl7.org.au/fhir/CodeSystem/medication-type"/>
+                <system value="http://terminology.hl7.org.au/CodeSystem/medication-type"/>
                 <code value="BPD"/>
                 <display value="Branded product with no strengths or form"/>
               </valueCoding>
@@ -1163,7 +1163,7 @@
           <coding>
             <extension url="http://hl7.org.au/fhir/StructureDefinition/medication-type">
               <valueCoding>
-                <system value="http://hl7.org.au/fhir/CodeSystem/medication-type"/>
+                <system value="http://terminology.hl7.org.au/CodeSystem/medication-type"/>
                 <code value="UPDSF"/>
                 <display value="Unbranded product with strengths and form"/>
               </valueCoding>
@@ -1175,7 +1175,7 @@
           <coding>
             <extension url="http://hl7.org.au/fhir/StructureDefinition/medication-type">
               <valueCoding>
-                <system value="http://hl7.org.au/fhir/CodeSystem/medication-type"/>
+                <system value="http://terminology.hl7.org.au/CodeSystem/medication-type"/>
                 <code value="BPDSF"/>
                 <display value="Branded product with strengths and form"/>
               </valueCoding>
@@ -1187,7 +1187,7 @@
           <coding>
             <extension url="http://hl7.org.au/fhir/StructureDefinition/medication-type">
               <valueCoding>
-                <system value="http://hl7.org.au/fhir/CodeSystem/medication-type"/>
+                <system value="http://terminology.hl7.org.au/CodeSystem/medication-type"/>
                 <code value="BPD"/>
                 <display value="Branded product with no strengths or form"/>
               </valueCoding>
@@ -1199,7 +1199,7 @@
           <coding>
             <extension url="http://hl7.org.au/fhir/StructureDefinition/medication-type">
               <valueCoding>
-                <system value="http://hl7.org.au/fhir/CodeSystem/medication-type"/>
+                <system value="http://terminology.hl7.org.au/CodeSystem/medication-type"/>
                 <code value="BPD"/>
                 <display value="Branded product with no strengths or form"/>
               </valueCoding>
@@ -1211,7 +1211,7 @@
           <coding>
             <extension url="http://hl7.org.au/fhir/StructureDefinition/medication-type">
               <valueCoding>
-                <system value="http://hl7.org.au/fhir/CodeSystem/medication-type"/>
+                <system value="http://terminology.hl7.org.au/CodeSystem/medication-type"/>
                 <code value="BPD"/>
                 <display value="Branded product with no strengths or form"/>
               </valueCoding>
@@ -1332,7 +1332,7 @@
           <coding>
             <extension url="http://hl7.org.au/fhir/StructureDefinition/medication-type">
               <valueCoding>
-                <system value="http://hl7.org.au/fhir/CodeSystem/medication-type"/>
+                <system value="http://terminology.hl7.org.au/CodeSystem/medication-type"/>
                 <code value="UPG"/>
                 <display value="Unbranded package with no container"/>
               </valueCoding>
@@ -1344,7 +1344,7 @@
           <coding>
             <extension url="http://hl7.org.au/fhir/StructureDefinition/medication-type">
               <valueCoding>
-                <system value="http://hl7.org.au/fhir/CodeSystem/medication-type"/>
+                <system value="http://terminology.hl7.org.au/CodeSystem/medication-type"/>
                 <code value="BPD"/>
                 <display value="Branded product with no strengths or form"/>
               </valueCoding>
@@ -1455,7 +1455,7 @@
           <coding>
             <extension url="http://hl7.org.au/fhir/StructureDefinition/medication-type">
               <valueCoding>
-                <system value="http://hl7.org.au/fhir/CodeSystem/medication-type"/>
+                <system value="http://terminology.hl7.org.au/CodeSystem/medication-type"/>
                 <code value="UPDSF"/>
                 <display value="Unbranded product with strengths and form"/>
               </valueCoding>
@@ -1467,7 +1467,7 @@
           <coding>
             <extension url="http://hl7.org.au/fhir/StructureDefinition/medication-type">
               <valueCoding>
-                <system value="http://hl7.org.au/fhir/CodeSystem/medication-type"/>
+                <system value="http://terminology.hl7.org.au/CodeSystem/medication-type"/>
                 <code value="BPD"/>
                 <display value="Branded product with no strengths or form"/>
               </valueCoding>
@@ -1479,7 +1479,7 @@
           <coding>
             <extension url="http://hl7.org.au/fhir/StructureDefinition/medication-type">
               <valueCoding>
-                <system value="http://hl7.org.au/fhir/CodeSystem/medication-type"/>
+                <system value="http://terminology.hl7.org.au/CodeSystem/medication-type"/>
                 <code value="BPD"/>
                 <display value="Branded product with no strengths or form"/>
               </valueCoding>
@@ -1491,7 +1491,7 @@
           <coding>
             <extension url="http://hl7.org.au/fhir/StructureDefinition/medication-type">
               <valueCoding>
-                <system value="http://hl7.org.au/fhir/CodeSystem/medication-type"/>
+                <system value="http://terminology.hl7.org.au/CodeSystem/medication-type"/>
                 <code value="BPD"/>
                 <display value="Branded product with no strengths or form"/>
               </valueCoding>
@@ -1503,7 +1503,7 @@
           <coding>
             <extension url="http://hl7.org.au/fhir/StructureDefinition/medication-type">
               <valueCoding>
-                <system value="http://hl7.org.au/fhir/CodeSystem/medication-type"/>
+                <system value="http://terminology.hl7.org.au/CodeSystem/medication-type"/>
                 <code value="BPD"/>
                 <display value="Branded product with no strengths or form"/>
               </valueCoding>
@@ -1617,7 +1617,7 @@
           <coding>
             <extension url="http://hl7.org.au/fhir/StructureDefinition/medication-type">
               <valueCoding>
-                <system value="http://hl7.org.au/fhir/CodeSystem/medication-type"/>
+                <system value="http://terminology.hl7.org.au/CodeSystem/medication-type"/>
                 <code value="UPDSF"/>
                 <display value="Unbranded product with strengths and form"/>
               </valueCoding>
@@ -1629,7 +1629,7 @@
           <coding>
             <extension url="http://hl7.org.au/fhir/StructureDefinition/medication-type">
               <valueCoding>
-                <system value="http://hl7.org.au/fhir/CodeSystem/medication-type"/>
+                <system value="http://terminology.hl7.org.au/CodeSystem/medication-type"/>
                 <code value="BPD"/>
                 <display value="Branded product with no strengths or form"/>
               </valueCoding>
@@ -1641,7 +1641,7 @@
           <coding>
             <extension url="http://hl7.org.au/fhir/StructureDefinition/medication-type">
               <valueCoding>
-                <system value="http://hl7.org.au/fhir/CodeSystem/medication-type"/>
+                <system value="http://terminology.hl7.org.au/CodeSystem/medication-type"/>
                 <code value="BPD"/>
                 <display value="Branded product with no strengths or form"/>
               </valueCoding>

--- a/examples/medication-BrandProductwithBatchDetails0.xml
+++ b/examples/medication-BrandProductwithBatchDetails0.xml
@@ -17,7 +17,7 @@
         <coding>
             <extension url="http://hl7.org.au/fhir/StructureDefinition/medication-type">
                 <valueCoding>
-                    <system value="http://hl7.org.au/fhir/CodeSystem/medication-type"/>
+                    <system value="http://terminology.hl7.org.au/CodeSystem/medication-type"/>
                     <code value="BPD"/>
                     <display value="Branded product with no strengths or form"/>
                 </valueCoding>
@@ -39,7 +39,7 @@
             <coding>
                 <extension url="http://hl7.org.au/fhir/StructureDefinition/medication-type">
                     <valueCoding>
-                        <system value="http://hl7.org.au/fhir/CodeSystem/medication-type"/>
+                        <system value="http://terminology.hl7.org.au/CodeSystem/medication-type"/>
                         <code value="UPD"/>
                         <display value="Unbranded product with no strengths or form"/>
                     </valueCoding>

--- a/examples/medication-BrandedPack0.xml
+++ b/examples/medication-BrandedPack0.xml
@@ -8,7 +8,7 @@
     <coding>
       <extension url="http://hl7.org.au/fhir/StructureDefinition/medication-type">
         <valueCoding>
-          <system value="http://hl7.org.au/fhir/CodeSystem/medication-type"/>
+          <system value="http://terminology.hl7.org.au/CodeSystem/medication-type"/>
           <code value="BPG"/>
           <display value="Branded package with no container"/>
         </valueCoding>
@@ -30,7 +30,7 @@
     <coding>
       <extension url="http://hl7.org.au/fhir/StructureDefinition/medication-type">
         <valueCoding>
-          <system value="http://hl7.org.au/fhir/CodeSystem/medication-type"/>
+          <system value="http://terminology.hl7.org.au/CodeSystem/medication-type"/>
           <code value="UPG"/>
           <display value="Unbranded package with no container"/>
         </valueCoding>
@@ -42,7 +42,7 @@
     <coding>
       <extension url="http://hl7.org.au/fhir/StructureDefinition/medication-type">
         <valueCoding>
-          <system value="http://hl7.org.au/fhir/CodeSystem/medication-type"/>
+          <system value="http://terminology.hl7.org.au/CodeSystem/medication-type"/>
           <code value="BPG"/>
           <display value="Branded package with no container"/>
         </valueCoding>

--- a/examples/medication-BrandedPack1.xml
+++ b/examples/medication-BrandedPack1.xml
@@ -11,7 +11,7 @@
 		<coding>
 			<extension url="http://hl7.org.au/fhir/StructureDefinition/medication-type">
 				<valueCoding>
-					<system value="http://hl7.org.au/fhir/CodeSystem/medication-type"/>
+					<system value="http://terminology.hl7.org.au/CodeSystem/medication-type"/>
 					<code value="BPG"/>
 					<display value="Branded package with no container"/>
 				</valueCoding>
@@ -23,7 +23,7 @@
 		<coding>
 			<extension url="http://hl7.org.au/fhir/StructureDefinition/medication-type">
 				<valueCoding>
-					<system value="http://hl7.org.au/fhir/CodeSystem/medication-type"/>
+					<system value="http://terminology.hl7.org.au/CodeSystem/medication-type"/>
 					<code value="UPG"/>
 					<display value="Unbranded package with no container"/>
 				</valueCoding>

--- a/examples/medication-BrandedPackSingleActiveIngredient0.xml
+++ b/examples/medication-BrandedPackSingleActiveIngredient0.xml
@@ -14,7 +14,7 @@
     <coding>
       <extension url="http://hl7.org.au/fhir/StructureDefinition/medication-type">
         <valueCoding>
-          <system value="http://hl7.org.au/fhir/CodeSystem/medication-type"/>
+          <system value="http://terminology.hl7.org.au/CodeSystem/medication-type"/>
           <code value="BPD"/>
           <display value="Branded product with no strengths or form"/>
         </valueCoding>
@@ -36,7 +36,7 @@
       <coding>
         <extension url="http://hl7.org.au/fhir/StructureDefinition/medication-type">
           <valueCoding>
-            <system value="http://hl7.org.au/fhir/CodeSystem/medication-type"/>
+            <system value="http://terminology.hl7.org.au/CodeSystem/medication-type"/>
             <code value="UPD"/>
             <display value="Unbranded product with no strengths or form"/>
           </valueCoding>

--- a/examples/medication-CombinationPackage0.xml
+++ b/examples/medication-CombinationPackage0.xml
@@ -8,7 +8,7 @@
           <coding>
             <extension url="http://hl7.org.au/fhir/StructureDefinition/medication-type">
               <valueCoding>
-                <system value="http://hl7.org.au/fhir/CodeSystem/medication-type"/>
+                <system value="http://terminology.hl7.org.au/CodeSystem/medication-type"/>
                 <code value="BPG"/>
                 <display value="Branded package with no container"/>
               </valueCoding>
@@ -20,7 +20,7 @@
           <coding>
             <extension url="http://hl7.org.au/fhir/StructureDefinition/medication-type">
               <valueCoding>
-                <system value="http://hl7.org.au/fhir/CodeSystem/medication-type"/>
+                <system value="http://terminology.hl7.org.au/CodeSystem/medication-type"/>
                 <code value="UPG"/>
                 <display value="Unbranded package with no container"/>
               </valueCoding>
@@ -32,7 +32,7 @@
           <coding>
             <extension url="http://hl7.org.au/fhir/StructureDefinition/medication-type">
               <valueCoding>
-                <system value="http://hl7.org.au/fhir/CodeSystem/medication-type"/>
+                <system value="http://terminology.hl7.org.au/CodeSystem/medication-type"/>
                 <code value="BPG"/>
                 <display value="Branded package with no container"/>
               </valueCoding>

--- a/examples/medication-FourOrMoreActiveIngredientsProduct0.xml
+++ b/examples/medication-FourOrMoreActiveIngredientsProduct0.xml
@@ -15,7 +15,7 @@
         <coding>
             <extension url="http://hl7.org.au/fhir/StructureDefinition/medication-type">
                 <valueCoding>
-                    <system value="http://hl7.org.au/fhir/CodeSystem/medication-type"/>
+                    <system value="http://terminology.hl7.org.au/CodeSystem/medication-type"/>
                     <code value="BPD"/>
                     <display value="Branded product with no strengths or form"/>
                 </valueCoding>
@@ -37,7 +37,7 @@
             <coding>
                 <extension url="http://hl7.org.au/fhir/StructureDefinition/medication-type">
                     <valueCoding>
-                        <system value="http://hl7.org.au/fhir/CodeSystem/medication-type"/>
+                        <system value="http://terminology.hl7.org.au/CodeSystem/medication-type"/>
                         <code value="UPD"/>
                         <display value="Unbranded product with no strengths or form"/>
                     </valueCoding>
@@ -64,7 +64,7 @@
             <coding>
                 <extension url="http://hl7.org.au/fhir/StructureDefinition/medication-type">
                     <valueCoding>
-                        <system value="http://hl7.org.au/fhir/CodeSystem/medication-type"/>
+                        <system value="http://terminology.hl7.org.au/CodeSystem/medication-type"/>
                         <code value="UPD"/>
                         <display value="Unbranded product with no strengths or form"/>
                     </valueCoding>
@@ -91,7 +91,7 @@
             <coding>
                 <extension url="http://hl7.org.au/fhir/StructureDefinition/medication-type">
                     <valueCoding>
-                        <system value="http://hl7.org.au/fhir/CodeSystem/medication-type"/>
+                        <system value="http://terminology.hl7.org.au/CodeSystem/medication-type"/>
                         <code value="UPD"/>
                         <display value="Unbranded product with no strengths or form"/>
                     </valueCoding>
@@ -118,7 +118,7 @@
             <coding>
                 <extension url="http://hl7.org.au/fhir/StructureDefinition/medication-type">
                     <valueCoding>
-                        <system value="http://hl7.org.au/fhir/CodeSystem/medication-type"/>
+                        <system value="http://terminology.hl7.org.au/CodeSystem/medication-type"/>
                         <code value="UPD"/>
                         <display value="Unbranded product with no strengths or form"/>
                     </valueCoding>

--- a/examples/medication-GenericPack0.xml
+++ b/examples/medication-GenericPack0.xml
@@ -8,7 +8,7 @@
 		<coding>
 			<extension url="http://hl7.org.au/fhir/StructureDefinition/medication-type">
 				<valueCoding>
-					<system value="http://hl7.org.au/fhir/CodeSystem/medication-type"/>
+					<system value="http://terminology.hl7.org.au/CodeSystem/medication-type"/>
 					<code value="UPG"/>
 					<display value="Unbranded package with no container"/>
 				</valueCoding>
@@ -25,7 +25,7 @@
 		<coding>
 			<extension url="http://hl7.org.au/fhir/StructureDefinition/medication-type">
 				<valueCoding>
-					<system value="http://hl7.org.au/fhir/CodeSystem/medication-type"/>
+					<system value="http://terminology.hl7.org.au/CodeSystem/medication-type"/>
 					<code value="UPG"/>
 					<display value="Unbranded package with no container"/>
 				</valueCoding>

--- a/examples/medication-MedicationDoseBased.xml
+++ b/examples/medication-MedicationDoseBased.xml
@@ -18,7 +18,7 @@
             <coding>
 				<extension url="http://hl7.org.au/fhir/StructureDefinition/medication-type">
 				  <valueCoding>
-					<system value="http://hl7.org.au/fhir/CodeSystem/medication-type"/>
+					<system value="http://terminology.hl7.org.au/CodeSystem/medication-type"/>
 					<code value="UPD"/>
 					<display value="Unbranded product with no strengths or form"/>
 				  </valueCoding>

--- a/examples/medication-TwoActiveIngredientsProduct0.xml
+++ b/examples/medication-TwoActiveIngredientsProduct0.xml
@@ -22,7 +22,7 @@
             <coding>
                 <extension url="http://hl7.org.au/fhir/StructureDefinition/medication-type">
                     <valueCoding>
-                        <system value="http://hl7.org.au/fhir/CodeSystem/medication-type"/>
+                        <system value="http://terminology.hl7.org.au/CodeSystem/medication-type"/>
                         <code value="UPD"/>
                         <display value="Unbranded product with no strengths or form"/>
                     </valueCoding>
@@ -49,7 +49,7 @@
             <coding>
                 <extension url="http://hl7.org.au/fhir/StructureDefinition/medication-type">
                     <valueCoding>
-                        <system value="http://hl7.org.au/fhir/CodeSystem/medication-type"/>
+                        <system value="http://terminology.hl7.org.au/CodeSystem/medication-type"/>
                         <code value="UPD"/>
                         <display value="Unbranded product with no strengths or form"/>
                     </valueCoding>

--- a/examples/medication-UnbrandedProduct0.xml
+++ b/examples/medication-UnbrandedProduct0.xml
@@ -8,7 +8,7 @@
           <coding>
             <extension url="http://hl7.org.au/fhir/StructureDefinition/medication-type">
               <valueCoding>
-                <system value="http://hl7.org.au/fhir/CodeSystem/medication-type"/>
+                <system value="http://terminology.hl7.org.au/CodeSystem/medication-type"/>
                 <code value="UPDSF"/>
                 <display value="Unbranded product with strengths and form"/>
               </valueCoding>
@@ -27,7 +27,7 @@
             <coding>
               <extension url="http://hl7.org.au/fhir/StructureDefinition/medication-type">
                 <valueCoding>
-                  <system value="http://hl7.org.au/fhir/CodeSystem/medication-type"/>
+                  <system value="http://terminology.hl7.org.au/CodeSystem/medication-type"/>
                   <code value="UPD"/>
                   <display value="Unbranded product with no strengths or form"/>
                 </valueCoding>

--- a/examples/medication-UnbrandedProduct1.xml
+++ b/examples/medication-UnbrandedProduct1.xml
@@ -8,7 +8,7 @@
           <coding>
             <extension url="http://hl7.org.au/fhir/StructureDefinition/medication-type">
               <valueCoding>
-                <system value="http://hl7.org.au/fhir/CodeSystem/medication-type"/>
+                <system value="http://terminology.hl7.org.au/CodeSystem/medication-type"/>
                 <code value="UPDSF"/>
                 <display value="Unbranded product with strengths and form"/>
               </valueCoding>
@@ -27,7 +27,7 @@
             <coding>
               <extension url="http://hl7.org.au/fhir/StructureDefinition/medication-type">
                 <valueCoding>
-                  <system value="http://hl7.org.au/fhir/CodeSystem/medication-type"/>
+                  <system value="http://terminology.hl7.org.au/CodeSystem/medication-type"/>
                   <code value="UPD"/>
                   <display value="Unbranded product with no strengths or form"/>
                 </valueCoding>

--- a/examples/medication-UnbrandedProduct2.xml
+++ b/examples/medication-UnbrandedProduct2.xml
@@ -8,7 +8,7 @@
           <coding>
             <extension url="http://hl7.org.au/fhir/StructureDefinition/medication-type">
               <valueCoding>
-                <system value="http://hl7.org.au/fhir/CodeSystem/medication-type"/>
+                <system value="http://terminology.hl7.org.au/CodeSystem/medication-type"/>
                 <code value="UPDSF"/>
                 <display value="Unbranded product with strengths and form"/>
               </valueCoding>
@@ -27,7 +27,7 @@
             <coding>
               <extension url="http://hl7.org.au/fhir/StructureDefinition/medication-type">
                 <valueCoding>
-                  <system value="http://hl7.org.au/fhir/CodeSystem/medication-type"/>
+                  <system value="http://terminology.hl7.org.au/CodeSystem/medication-type"/>
                   <code value="UPD"/>
                   <display value="Unbranded product with no strengths or form"/>
                 </valueCoding>

--- a/examples/medicationstatement-MedicationStatementexample0.xml
+++ b/examples/medicationstatement-MedicationStatementexample0.xml
@@ -9,7 +9,7 @@
         <coding>
             <extension url="http://hl7.org.au/fhir/StructureDefinition/medication-type">
                 <valueCoding>
-                    <system value="http://hl7.org.au/fhir/CodeSystem/medication-type"/>
+                    <system value="http://terminology.hl7.org.au/CodeSystem/medication-type"/>
                     <code value="BPDSF"/>
                     <display value="Branded product with strengths and form"/>
                 </valueCoding>

--- a/examples/medicationstatement-MedicationStatementexample1.xml
+++ b/examples/medicationstatement-MedicationStatementexample1.xml
@@ -12,7 +12,7 @@
         <coding>
             <extension url="http://hl7.org.au/fhir/StructureDefinition/medication-type">
                 <valueCoding>
-                    <system value="http://hl7.org.au/fhir/CodeSystem/medication-type"/>
+                    <system value="http://terminology.hl7.org.au/CodeSystem/medication-type"/>
                     <code value="BPD"/>
                     <display value="Branded product with no strengths or form"/>
                 </valueCoding>

--- a/examples/medicationstatement-MedicationStatementexample2.xml
+++ b/examples/medicationstatement-MedicationStatementexample2.xml
@@ -9,7 +9,7 @@
         <coding>
             <extension url="http://hl7.org.au/fhir/StructureDefinition/medication-type">
                 <valueCoding>
-                    <system value="http://hl7.org.au/fhir/CodeSystem/medication-type"/>
+                    <system value="http://terminology.hl7.org.au/CodeSystem/medication-type"/>
                     <code value="BPDSF"/>
                     <display value="Branded product with strengths and form"/>
                 </valueCoding>


### PR DESCRIPTION
Fixes #604

This reduces the error count from 90 to 33.
Note that there are still other errors still apparent in medication examples that remain to be fixed. 