### PR TITLE
Fixing 2 composition hyperlink examples

### DIFF
--- a/examples/composition-different-authors.xml
+++ b/examples/composition-different-authors.xml
@@ -27,12 +27,6 @@
     <title value="Discharge Summary"/>
 
     <section>
-        <extension url="http://hl7.org.au/fhir/StructureDefinition/section-author">
-            <valueReference>
-                <reference value="Practitioner/example0"/>
-                <display value="Doctor Mayo"/>
-            </valueReference>
-        </extension>
         <title value="Reason for admission"/>
         <code>
             <coding>
@@ -41,6 +35,10 @@
                 <display value="Reason for visit Narrative"/>
             </coding>
         </code>
+        <author>
+            <reference value="Practitioner/example0"/>
+            <display value="Doctor Mayo"/> 
+        </author>
         <text>
             <status value="extensions"/>
             <div xmlns="http://www.w3.org/1999/xhtml">
@@ -53,12 +51,6 @@
     </section>
 
     <section>
-        <extension url="http://hl7.org.au/fhir/StructureDefinition/section-author">
-            <valueReference>
-                <reference value="PractitionerRole/example0"/>
-                <display value="Cardiologist"/>
-            </valueReference>
-        </extension>
         <title value="Medications on Discharge"/> 
         <code> 
             <coding> 
@@ -67,6 +59,10 @@
                 <display value="Hospital discharge medications Narrative"/> 
             </coding> 
         </code> 
+        <author>
+            <reference value="PractitionerRole/example0"/>
+            <display value="Cardiologist"/>
+        </author>
         <text>
             <status value="extensions"/>
             <div xmlns="http://www.w3.org/1999/xhtml">

--- a/examples/composition-example0.xml
+++ b/examples/composition-example0.xml
@@ -32,13 +32,11 @@
 
   <!-- Related Person as Attester Party -->
   <attester>
-    <extension url="http://hl7.org.au/fhir/StructureDefinition/attester-related-party">
-      <valueReference>
-        <reference value="RelatedPerson/example0"/>
-      </valueReference>
-    </extension>
     <mode value="personal"/>
     <time value="2018-03-04T12:30:02Z"/>
+    <party>
+      <reference value="RelatedPerson/example0"/>
+    </party>
   </attester>
 
   <section>

--- a/resources/ig.xml
+++ b/resources/ig.xml
@@ -1628,6 +1628,18 @@
     </resource>
     <resource>
       <reference>
+        <reference value="Composition/composition-different-authors"/>
+      </reference>
+      <name value="​Composition with some sections having a different section author to the composition author"/>
+    </resource>
+    <resource>
+      <reference>
+        <reference value="Composition/example0"/>
+      </reference>
+      <name value="Patient’s preference upon death"/>
+    </resource>
+    <resource>
+      <reference>
         <reference value="MedicationStatement/MedicationStatementexample0"/>
       </reference>
       <name value="Medication Statement"/>


### PR DESCRIPTION
Added references to two examples to ig

Within examples removed redundant extensions and added relevant element to capture information contained in extension.

Reduces Build QA errors by 2. 

Addresses #536