### PR TITLE
AU Base AllergyIntolerance QA fix incl exposureRoute binding

### DIFF
--- a/ignoreWarnings.txt
+++ b/ignoreWarnings.txt
@@ -77,6 +77,7 @@ The valueSet reference https://healthterminologies.gov.au/fhir/ValueSet/immunisa
 The valueSet reference https://healthterminologies.gov.au/fhir/ValueSet/immunisation-route-of-administration-1 on element Immunization.route.coding could not be resolved
 The valueSet reference https://healthterminologies.gov.au/fhir/ValueSet/reason-vaccine-administered-1 on element Immunization.reasonCode could not be resolved
 The valueSet reference https://healthterminologies.gov.au/fhir/ValueSet/vaccination-target-disease-1 on element Immunization.protocolApplied.targetDisease could not be resolved
+The valueSet reference https://healthterminologies.gov.au/fhir/ValueSet/route-of-administration-1 on element AllergyIntolerance.reaction.exposureRoute could not be resolved
 
 ValueSet https://healthterminologies.gov.au/fhir/ValueSet/adverse-reaction-agent-1 not found by validator
 ValueSet https://healthterminologies.gov.au/fhir/ValueSet/australian-indigenous-status-1 not found by validator

--- a/pages/_includes/au-allergyintolerance-intro.md
+++ b/pages/_includes/au-allergyintolerance-intro.md
@@ -1,11 +1,14 @@
 **AU Base Allergy Intolerance** *[[FMM Level 1](guidance.html)]*
+This profile defines an allergy intolerance structure that localises core concepts, including identifiers and terminology, for use in an Australian context.
 
-This profile defines an allergy intolerance structure including core localisation concepts for use in an Australian context.
+The purpose of this profile is to provide national level agreement on core localised concepts. 
+
+This profile does not force conformance to core localised concepts. It enables implementers and modellers to make their own rules, i.e. [profiling](http://hl7.org/fhir/profiling.html), about how to support these concepts for specific implementation needs.
 
 #### Extensions
 No extensions are used in this profile.
 
-**Examples**
+#### Examples
 
 [Ibuprofen allergy, with a manifestation of urticaria](AllergyIntolerance-allergyintolerance-example0.html)
 

--- a/resources/au-allergyintolerance.xml
+++ b/resources/au-allergyintolerance.xml
@@ -2,11 +2,11 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="au-allergyintolerance" />
   <url value="http://hl7.org.au/fhir/StructureDefinition/au-allergyintolerance" />
-  <version value="2.1.0" />
+  <version value="2.2.0" />
   <name value="AUBaseAllergyIntolerance" />
   <title value="AU Base Allergy Intolerance" />
   <status value="draft" />
-  <date value="2020-08-20" />
+  <date value="2021-06-28" />
   <publisher value="Health Level Seven Australia" />
   <contact>
     <telecom>
@@ -38,7 +38,6 @@
       <path value="AllergyIntolerance.code" />
       <binding>
         <strength value="preferred" />
-        <description value="Preferred SNOMED-CT coding for type of the substance/product, allergy or intolerance condition, or negation/exclusion codes for reporting no known allergies." />
         <valueSet value="https://healthterminologies.gov.au/fhir/ValueSet/indicator-hypersensitivity-intolerance-to-substance-2" />
       </binding>
     </element>
@@ -49,7 +48,6 @@
       <path value="AllergyIntolerance.reaction.substance" />
       <binding>
         <strength value="preferred" />
-        <description value="Preferred SNOMED-CT coding defining the type of the substance (including pharmaceutical products)." />
         <valueSet value="https://healthterminologies.gov.au/fhir/ValueSet/adverse-reaction-agent-1" />
       </binding>
     </element>
@@ -57,8 +55,14 @@
       <path value="AllergyIntolerance.reaction.manifestation" />
       <binding>
         <strength value="preferred" />
-        <description value="Preferred SNOMED-CT coding of clinical symptoms and/or signs that are observed or associated with an Adverse Reaction Event." />
         <valueSet value="https://healthterminologies.gov.au/fhir/ValueSet/clinical-finding-1" />
+      </binding>
+    </element>
+    <element id="AllergyIntolerance.reaction.exposureRoute">
+      <path value="AllergyIntolerance.reaction.exposureRoute" />
+      <binding>
+        <strength value="preferred" />
+        <valueSet value="https://healthterminologies.gov.au/fhir/ValueSet/route-of-administration-1" />
       </binding>
     </element>
   </differential>


### PR DESCRIPTION
Fixes #572 AllergyIntolerance: Binding to exposureRoute is 'example'.

Updated date and version, removed binding.description - not necessary and is repeat of element description.

Additionally style fixes to intro material:
- Examples heading style fix
- Standard intro statement added

Added warning for exposureRoute element to ignoreWarnings.txt so that it builds clean (current agreement from PA WG to do this while getting snapshot ready for ballot)