### PR TITLE
Bugfix/QA Fix v2 extensions missing urls plus style QA fixes

### DIFF
--- a/examples/composition-multiple-information-recipients.xml
+++ b/examples/composition-multiple-information-recipients.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Composition xmlns="http://hl7.org/fhir">
-    <id value="multiple-information-recipients-and-author-role"/>
+    <id value="multiple-information-recipients"/>
     <meta>
         <lastUpdated value="2013-05-28T22:12:21Z"/>
         <profile value="http://hl7.org.au/fhir/StructureDefinition/au-composition"/>

--- a/pages/_includes/address-identifier-intro.md
+++ b/pages/_includes/address-identifier-intro.md
@@ -1,10 +1,10 @@
 **Extension: Address Identifier** *[[FMM Level 0](guidance.html)]*
 
-This extension applies to the Address datatype and is used to represent an identifier for an address. 
+This extension applies to the [Address](http://hl7.org/fhir/R4/datatypes.html#Address) datatype and is used to represent an identifier for an address. 
 
 An address identifier does not form part of the address itself, e.g. a street number. It is a unique identifier associated with a location address and may be used to look up an address, validate an address, or link to other data relating to an address.
 
 
-**Examples**
+#### Examples
 
 [Postal address (with DPID and G-NAF Identifier) and work address in Darwin, NT](Patient-address-example3.html)

--- a/pages/_includes/associated-healthcareservice-intro.md
+++ b/pages/_includes/associated-healthcareservice-intro.md
@@ -1,3 +1,7 @@
 **Extension: Associated Healthcare Service**  *[[FMM Level 1](guidance.html)]*
 
-This extension allows references to healthcare services relating to a resource, e.g. healthcare services under which the patient was managed during an encounter.
+This extension applies to any resource and allows reference to one or more associated HealthcareService resources, e.g. representing healthcare services under which the patient was managed during an encounter.
+
+#### Examples
+
+No examples are available for this extension.

--- a/pages/_includes/attester-related-party-intro.md
+++ b/pages/_includes/attester-related-party-intro.md
@@ -2,6 +2,6 @@
 
 This extension applies to the Composition resource and provides an extension for an attester who is a related person.
 
-#### Examples
+**Examples**
 
 [Patient's preference upon death](composition-example0.html)

--- a/pages/_includes/attester-related-party-intro.md
+++ b/pages/_includes/attester-related-party-intro.md
@@ -2,6 +2,6 @@
 
 This extension applies to the Composition resource and provides an extension for an attester who is a related person.
 
-**Examples**
+#### Examples
 
 [Patient's preference upon death](composition-example0.html)

--- a/pages/_includes/au-assigningauthority-intro.md
+++ b/pages/_includes/au-assigningauthority-intro.md
@@ -1,4 +1,4 @@
-**Assigning Authority Extension**  *[[FMM Level 2](guidance.html)]*
+**Extension: Assigning Authority**  *[[FMM Level 2](guidance.html)]*
 
 This extension applies to the [Identifier](http://hl7.org/fhir/datatypes.html#identifier) datatype and defines a HL7v2 assigning authority value for HL7v2 identification for routing.
 

--- a/pages/_includes/au-assigningauthority-intro.md
+++ b/pages/_includes/au-assigningauthority-intro.md
@@ -1,6 +1,9 @@
 **Assigning Authority Extension**  *[[FMM Level 2](guidance.html)]*
 
-This extension defines a HL7v2 assigning authority value for HL7v2 identification for routing.
+This extension applies to the [Identifier](http://hl7.org/fhir/datatypes.html#identifier) datatype and defines a HL7v2 assigning authority value for HL7v2 identification for routing.
+
+
+#### Usage Notes
 
 This content provides the values for a sender to use where assigning authority components should be valued in fields in HL7 messages. 
 
@@ -9,6 +12,9 @@ Example HL7v2 fields that will use this are:
 * PRD-7 Provider Identifiers (CM)
 * PV1-9 Consulting Doctor (XCN) field
 * OBR-28 Result copies to (XCN)
+
+
+#### Examples
 
 [Cardiologist with Medicare provider number and vendor directory identifier, with HL7 V2 Assigning Authority](PractitionerRole-example4.html)
 

--- a/pages/_includes/au-composition-intro.md
+++ b/pages/_includes/au-composition-intro.md
@@ -2,21 +2,26 @@
 
 This profile defines a composition structure that includes core localisation concepts for use in an Australian context.
 
+
+#### Usage Notes
+
 When capturing a composition practitioner role as the sole author of the composition, a practitioner linked to that practitioner role is required to be supplied as a composition author. Where there is more than one author this is not necessary or recommended.
 
 Where practicable it is preferred that the assertion of clinical judgement that there are no known items for this list is handled via an entry with the appropriate negation code over making use of section emptyReason. For example the instantiation of an AllergyIntolerance with code that is a child of 716186003 \|No known allergy\| from SNOMED CT[<sup>[1]</sup>](https://www.snomed.org).
+
 
 #### Extensions 
 Extensions used in this profile:   
 * Composition: Information Recipient[<sup>[1]</sup>](http://hl7.org.au/fhir/StructureDefinition/information-recipient)
 
+
 #### Conversion
 
 NOTE: AU Base on STU3 included three extensions Composition Author Role, Related Person Attester Party, andRelated Person Attester Party which are now no longer required as direct R4 support is available.
 
-**Examples**
+#### Examples
 
-[Composition with multiple information recipients and one author role](Composition-multiple-information-recipients-and-author-role.html)
+[Composition with multiple information recipients](Composition-multiple-information-recipients.html)
 
 [Composition with some sections having a different section author to the composition author](Composition-composition-different-authors.html)
 

--- a/pages/_includes/au-receivingapplication-intro.md
+++ b/pages/_includes/au-receivingapplication-intro.md
@@ -1,7 +1,10 @@
-**Receiving Application Extension** *[[FMM Level 2](guidance.html)]*
+**Extension: Receiving Application** *[[FMM Level 2](guidance.html)]*
 
-This extension defines a HL7v2 receiving application value for HL7v2 routing purposes associated with an endpoint.
+This extension applies to the Endpoint resource and defines a HL7v2 receiving application value for HL7v2 routing purposes associated with an endpoint.
 This content allows a sender using these endpoint details to include Receiving Application (MSH-5) information in HL7v2 messages sent via this channel which allow correct delivery within the receiving system.
+
+
+#### Examples
 
 [Endpoint with secure message extensions](Endpoint-example0.html)
 

--- a/pages/_includes/au-receivingfacility-intro.md
+++ b/pages/_includes/au-receivingfacility-intro.md
@@ -1,7 +1,10 @@
-**Receiving Facility Extension** *[[FMM Level 2](guidance.html)]*
+**Extension: Receiving Facility** *[[FMM Level 2](guidance.html)]*
 
-This extension defines a HL7v2 receiving facility value for HL7v2 routing purposes associated with an endpoint.
+This extension applies to the Endpoint resource and defines a HL7v2 receiving facility value for HL7v2 routing purposes associated with an endpoint.
 This content allows a sender using these endpoint details to include Receiving Facility (MSH-6) information in HL7v2 messages sent via this channel which allow correct delivery within the receiving system.
+
+
+#### Examples
 
 [Endpoint with secure message extensions](Endpoint-example0.html)
 

--- a/pages/_includes/au-timezone-intro.md
+++ b/pages/_includes/au-timezone-intro.md
@@ -1,8 +1,9 @@
 **Extension: Australian Time Zone** *[[FMM Level 1](guidance.html)]*
 
-This extension applies to time and is used to represent Australian time zone.
+This extension applies to the [time](http://hl7.org/fhir/R4/datatypes.html#time) datatype and is used to represent an Australian time zone.
 
-**Examples**
+#### Examples
 
-* [Albion Hospital Radiology Service](HealthcareService-example1.html)
-* [Pathologist with ABN-scoped employee number and SNOMED-CT coded specialty](PractitionerRole-example2.html)
+[Albion Hospital Radiology Service](HealthcareService-example1.html)
+
+[Pathologist with ABN-scoped employee number and SNOMED-CT coded specialty](PractitionerRole-example2.html)

--- a/pages/_includes/author-related-person-intro.md
+++ b/pages/_includes/author-related-person-intro.md
@@ -1,3 +1,8 @@
 **Extension: Author as a RelatedPerson**  *[[FMM Level 1](guidance.html)]*
 
-This extension allows recording an author who is a related person.
+This extension applies to any resource allows recording an author who is a related person.
+
+
+#### Examples
+
+No examples are available for this extension.

--- a/pages/_includes/author-related-person-intro.md
+++ b/pages/_includes/author-related-person-intro.md
@@ -1,6 +1,6 @@
 **Extension: Author as a RelatedPerson**  *[[FMM Level 1](guidance.html)]*
 
-This extension applies to any resource allows recording an author who is a related person.
+This extension applies to any resource and allows recording an author who is a related person.
 
 
 #### Examples

--- a/pages/_includes/change-description-intro.md
+++ b/pages/_includes/change-description-intro.md
@@ -2,8 +2,13 @@
 
 This extension applies to the List resource and provides a narrative description of the change to an item in a list entry. The narrative description may include the reason for the change to an item. 
 
+
+#### Usage Notes
+
 This extension may be used in conjunction with the flag element of a list entry, for example in a medicine list a medication item flagged as ceased may use this extension to hold the reason for cessation such as the medication item has caused serious adverse effects.
 
 
+#### Examples
 
+[Current and ceased medicines](List-0ebc46a8-4ea8-11e9-8647-d663bd873d93.html)
 

--- a/pages/_includes/contact-purpose-intro.md
+++ b/pages/_includes/contact-purpose-intro.md
@@ -1,6 +1,6 @@
 **Extension: Contact Purpose** *[[FMM Level 1](guidance.html)]*
 
-This extension applies to the ContactPoint datatype and is used to represent the purpose for which a contact can be reached, e.g. after hours or billing.
+This extension applies to the [ContactPoint](http://hl7.org/fhir/datatypes.html#ContactPoint) datatype and is used to represent the purpose for which a contact can be reached, e.g. after hours or billing.
 
 
 #### Examples

--- a/pages/_includes/contact-purpose-intro.md
+++ b/pages/_includes/contact-purpose-intro.md
@@ -3,7 +3,7 @@
 This extension applies to the ContactPoint datatype and is used to represent the purpose for which a contact can be reached, e.g. after hours or billing.
 
 
-**Examples**
+#### Examples
 
 [HealthcareService with HPI-O and SNOMED-CT coded specialty](HealthcareService-example0.html)
 

--- a/pages/_includes/encounter-description-intro.md
+++ b/pages/_includes/encounter-description-intro.md
@@ -4,7 +4,7 @@ This extension applies to the Encounter resource and provides narrative about th
 
 The description may include a summary of the issues or problems, management strategies, outcomes or progress, possible prognosis, and the patient’s understanding of the healthcare event. The description may capture text about the encounter that is not captured in other fields.
 
-**Examples**
+#### Examples
 
 [Admitted for elective bronchoscopy](Encounter-encounter-example0.html)
 

--- a/pages/_includes/encryption-certificate-pem-x509-intro.md
+++ b/pages/_includes/encryption-certificate-pem-x509-intro.md
@@ -1,9 +1,15 @@
 **Encryption Certificate PEM X509**  *[[FMM Level 3](guidance.html)]*
-This extension is defined to support encrypting certficate content for use with an endpoint.
+This extension applies to the Endpoint resource and is defined to support encrypting certficate content for use with an endpoint.
 
 This allows an endpoint entry to define a suitable certficate for use in communications on the associated channel.
 
-The value recorded is an X509 certificate in PEM format as per [RFC7468](https://tools.ietf.org/html/rfc7468)
+
+#### Usage Notes
+
+The value recorded is an X509 certificate in PEM format as per [RFC7468](https://tools.ietf.org/html/rfc7468).
+
+
+#### Examples
 
 [Endpoint with secure message extensions](Endpoint-example0.html)
 

--- a/pages/_includes/extensions.md
+++ b/pages/_includes/extensions.md
@@ -41,17 +41,17 @@ Related to administration records such as patient, practitioner, practitioner ro
 
 
 ## HL7 V2 Identity
-* [HL7 V2 Receiving Application](StructureDefinition-au-receivingapplication.html) - identity attribute for v2 endpoints
-* [HL7 V2 Receiving Facility](StructureDefinition-au-receivingfacility.html) - identity attribute for v2 endpoints
-* [HL7 V2 Assigning Authority](StructureDefinition-au-assigningauthority.html) - v2 namespace for an identifier
+* [Receiving Application](StructureDefinition-au-receivingapplication.html) - identity attribute for v2 endpoints
+* [Receiving Facility](StructureDefinition-au-receivingfacility.html) - identity attribute for v2 endpoints
+* [Assigning Authority](StructureDefinition-au-assigningauthority.html) - v2 namespace for an identifier
 
 
 ## Endpoint Attributes
-* [HL7 V2 Receiving Application](StructureDefinition-au-receivingapplication.html) - identity attribute for v2 endpoints
-* [HL7 V2 Receiving Facility](StructureDefinition-au-receivingfacility.html) - identity attribute for v2 endpoints
+* [Receiving Application](StructureDefinition-au-receivingapplication.html) - identity attribute for v2 endpoints
+* [Receiving Facility](StructureDefinition-au-receivingfacility.html) - identity attribute for v2 endpoints
 * [Encryption Ceritficate PEM x509](StructureDefinition-encryption-certificate-pem-x509.html) - encrypting public certificate attribute for an endpoint
 
 
 ## Data types
 * [Australian Time Zone](StructureDefinition-au-timezone.html) - Australian time zone
-* [Identifier Routability](StructureDefinition-identifier-routability.html) - Supports identifier selection for routing
+* [Identifier Routability](StructureDefinition-identifier-routability.html) - supports identifier selection for routing

--- a/pages/_includes/identifier-routability-intro.md
+++ b/pages/_includes/identifier-routability-intro.md
@@ -1,7 +1,10 @@
 **Extension: Identifier Routability** *[[FMM Level 0](guidance.html)]*
 
-This extension applies to the [Identifier datatype](http://hl7.org/fhir/datatypes.html#identifier) 
+This extension applies to the [Identifier](http://hl7.org/fhir/datatypes.html#identifier) datatype. 
 
 Identifier routability preferences for an asserter.
 
-**Examples**
+
+#### Examples
+
+No examples are available for this extension.

--- a/pages/_includes/information-recipient-intro.md
+++ b/pages/_includes/information-recipient-intro.md
@@ -2,6 +2,6 @@
 
 This extension applies to the Composition resource and allows recording of intended recipients of the composition.
 
-**Examples**
+#### Examples
 
-[Composition with multiple information recipients and one author role](Composition-multiple-information-recipients-and-author-role.html)
+[Composition with multiple information recipients](Composition-multiple-information-recipients.html)

--- a/pages/_includes/no-fixed-address-intro.md
+++ b/pages/_includes/no-fixed-address-intro.md
@@ -1,7 +1,7 @@
 **Extension: No Fixed Address**  *[[FMM Level 2](guidance.html)]*
 
-This extension applies to the Address datatype and indicates that there is an assertion that there is no fixed address.
+This extension applies to the [Address](http://hl7.org/fhir/R4/datatypes.html#Address) datatype and indicates that there is an assertion that there is no fixed address.
 
-**Examples**
+#### Examples
 
 [No fixed address in Melbourne, VIC](Patient-address-example2.html)

--- a/resources/ig.xml
+++ b/resources/ig.xml
@@ -1643,9 +1643,9 @@
     </resource>
     <resource>
       <reference>
-        <reference value="Composition/multiple-information-recipients-and-author-role"/>
+        <reference value="Composition/multiple-information-recipients"/>
       </reference>
-      <name value="composition-multiple-information-recipients-and-author-role"/>
+      <name value="composition-multiple-information-recipients"/>
       <description
         value="Shows a typical example of a composition author role and multiple information recipients of different resource type"
       />

--- a/resources/structuredefinition-au-assigningauthority.xml
+++ b/resources/structuredefinition-au-assigningauthority.xml
@@ -2,11 +2,11 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="au-assigningauthority" />
   <url value="http://hl7.org.au/fhir/StructureDefinition/au-assigningauthority" />
-  <version value="2.1.0"/>
+  <version value="2.1.1"/>
   <name value="HL7V2AssigningAuthority" />
   <title value="HL7 V2 Assigning Authority" />
   <status value="active" />
-  <date value="2019-07-24" />
+  <date value="2021-06-29" />
   <publisher value="Health Level Seven Australia (Patient Administration WG)" />
   <contact>
     <telecom>
@@ -110,6 +110,10 @@
       <type>
         <code value="string" />
       </type>
+    </element>
+    <element id="Extension.url">
+      <path value="Extension.url"/>
+      <fixedUri value="http://hl7.org.au/fhir/StructureDefinition/au-assigningauthority"/>
     </element>
     <element id="Extension.value[x]">
       <path value="Extension.value[x]" />

--- a/resources/structuredefinition-au-receivingapplication.xml
+++ b/resources/structuredefinition-au-receivingapplication.xml
@@ -2,11 +2,11 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="au-receivingapplication" />
   <url value="http://hl7.org.au/fhir/StructureDefinition/au-receivingapplication" />
-  <version value="2.1.0"/>
+  <version value="2.1.1"/>
   <name value="HL7V2ReceivingApplication" />
   <title value="HL7 V2 Receiving Application" />
   <status value="draft" />
-  <date value="2019-07-24" />
+  <date value="2021-06-29" />
   <publisher value="Health Level Seven Australia (Patient Administration WG)" />
   <contact>
     <telecom>
@@ -107,6 +107,10 @@
       <type>
         <code value="string" />
       </type>
+    </element>
+    <element id="Extension.url">
+      <path value="Extension.url"/>
+      <fixedUri value="http://hl7.org.au/fhir/StructureDefinition/au-receivingapplication"/>
     </element>
     <element id="Extension.value[x]">
       <path value="Extension.value[x]" />

--- a/resources/structuredefinition-au-receivingfacility.xml
+++ b/resources/structuredefinition-au-receivingfacility.xml
@@ -2,11 +2,11 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="au-receivingfacility" />
   <url value="http://hl7.org.au/fhir/StructureDefinition/au-receivingfacility" />
-  <version value="2.1.0"/>
+  <version value="2.1.1"/>
   <name value="HL7V2ReceivingFacility" />
   <title value="HL7 V2 Receiving Facility" />
   <status value="active" />
-  <date value="2019-07-24" />
+  <date value="2021-06-29" />
   <publisher value="Health Level Seven Australia (Patient Administration WG)" />
   <contact>
     <telecom>
@@ -110,6 +110,10 @@
       <type>
         <code value="string" />
       </type>
+    </element>
+    <element id="Extension.url">
+      <path value="Extension.url"/>
+      <fixedUri value="http://hl7.org.au/fhir/StructureDefinition/au-receivingfacility"/>
     </element>
     <element id="Extension.value[x]">
       <path value="Extension.value[x]" />

--- a/resources/structuredefinition-encryption-certificate-pem-x509.xml
+++ b/resources/structuredefinition-encryption-certificate-pem-x509.xml
@@ -2,11 +2,11 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="encryption-certificate-pem-x509" />
   <url value="http://hl7.org.au/fhir/StructureDefinition/encryption-certificate-pem-x509" />
-  <version value="2.1.0"/>
+  <version value="2.1.1"/>
   <name value="EncryptionCertificatePEMx509" />
   <title value="Encryption Certificate PEM X509" />
   <status value="draft" />
-  <date value="2019-07-24" />
+  <date value="2021-06-29" />
   <publisher value="Health Level Seven Australia (Patient Administration WG)" />
   <contact>
     <telecom>
@@ -38,6 +38,10 @@
       <path value="Extension" />
       <short value="PEM X509 Certificate" />
       <definition value="Mechanism hold the value of an X509 certificate as a string (base64 encoded PEM certificate)" />
+    </element>
+    <element id="Extension.url">
+      <path value="Extension.url"/>
+      <fixedUri value="http://hl7.org.au/fhir/StructureDefinition/encryption-certificate-pem-x509"/>
     </element>
     <element id="Extension.value[x]:valueString">
       <path value="Extension.valueString" />


### PR DESCRIPTION
Fixes #615, Fixes #614, Fixes #613, Fixes #596.

Fix style and wording in extension.md and intro.md for extensions that aren't subject of forthcoming PRs (medication, patient, ahpra).