### PR TITLE
AU Assertion No Relevant Finding QA fixes

### DIFF
--- a/pages/_includes/au-norelevantfinding-intro.md
+++ b/pages/_includes/au-norelevantfinding-intro.md
@@ -1,12 +1,20 @@
-**AU Assertion of No Relevant Finding Profile** *[[FMM Level 1](guidance.html)]*
+**AU Assertion of No Relevant Finding** *[[FMM Level 1](guidance.html)]*
 
 This profile provides an observation information structure for asserting a clinical judgement that there are no items of specific interest, e.g. allergies, no medications, for a patient.
 
-This observation may be time bound, e.g. the patient is not currently taking medications on this date. In such a scenario it is expected that status will be 'final'.
+An assertion of no relevant finding may be used in continuity of care or transfer or care related lists and composition sections.
 
-An assertion of no relevant finding may be used in continuity of care or transfer or care related lists and composition sections. One possible use scenario is in a summary document to positively state that there is no known history of conditions for  a patient. In such a scenario it is expected that status will be 'final'.
+#### Extensions
+No extensions are used in this profile.
 
-**Examples**
+
+#### Usage Notes
+This observation may be time bound, e.g. the patient is not currently taking medications on this date. In such a scenario status should be 'final'.
+
+In a summary document, this observation may be used to positively state that there is no known history of conditions for  a patient. In such a scenario status should be 'final'.
+
+
+#### Examples
 
 [No history of procedure](Observation-norelevantfinding-example0.html)
 

--- a/resources/au-norelevantfinding.xml
+++ b/resources/au-norelevantfinding.xml
@@ -2,11 +2,11 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="au-norelevantfinding"/>
   <url value="http://hl7.org.au/fhir/StructureDefinition/au-norelevantfinding"/>
-  <version value="2.1.0"/>
+  <version value="2.1.1"/>
   <name value="AUAssertionNoRelevantFinding"/>
   <title value="AU Assertion of No Relevant Finding"/>
   <status value="draft"/>
-  <date value="2020-07-29"/>
+  <date value="2021-07-01"/>
   <publisher value="Health Level Seven Australia (Orders and Observations WG)"/>
   <contact>
     <telecom>
@@ -17,7 +17,7 @@
   </contact>
   <description
     value="This profile provides an observation information structure for asserting a clinical judgement that there are no items of specific interest, e.g. allergies, no medications, for a patient."/>
-  <jurisdiction>
+  <jurisdiction>                                                                    
     <coding>
       <system value="urn:iso:std:iso:3166"/>
       <code value="AU"/>
@@ -62,18 +62,7 @@
     </element>
     <element id="Observation.value[x]">
       <path value="Observation.value[x]"/>
-      <slicing>
-        <discriminator>
-          <type value="type"/>
-          <path value="$this"/>
-        </discriminator>
-        <rules value="open"/>
-      </slicing>
-    </element>
-    <element id="Observation.value[x]:valueCodeableConcept">
-      <path value="Observation.value[x]"/>
-      <sliceName value="valueCodeableConcept"/>
-      <short value="Coded value of the observation"/>
+      <definition value="An assertion that a procedure did not occur or that there are no items of specific interest (e.g. allergies, no current medications) for a patient or patient group." />
       <min value="1"/>
       <type>
         <code value="CodeableConcept"/>
@@ -82,10 +71,6 @@
         <strength value="extensible"/>
         <valueSet value="https://healthterminologies.gov.au/fhir/ValueSet/assertion-of-absence-1"/>
       </binding>
-    </element>
-    <element id="Observation.dataAbsentReason">
-      <path value="Observation.dataAbsentReason"/>
-      <max value="0"/>
     </element>
   </differential>
 </StructureDefinition>


### PR DESCRIPTION
Fixes #616 Assertion of No Relevant Finding - needs refactoring to remove slicing and erroneous prohibition:
- Removed slicing on value
- Removed prohibition on dataAbsentValue
- Improved wording around value

Intro QA fixes to align with current style including fix title, add headings, move content into Usage Notes
