### PR TITLE
AU Base Medication Statement QA fixes

### DIFF
--- a/pages/_includes/au-medicationstatement-intro.md
+++ b/pages/_includes/au-medicationstatement-intro.md
@@ -2,6 +2,10 @@
 
 This profile defines a medication statement structure including core localisation concepts for use in an Australian context. 
 
+The purpose of this profile is to provide national level agreement on core localised concepts. 
+
+This profile does not force conformance to core localised concepts. It enables implementers and modellers to make their own rules, i.e. [profiling](http://hl7.org/fhir/profiling.html), about how to support these concepts for specific implementation needs.
+
 #### Medication Reference/Coding
 Full medication definitions as a Medication resource can be referenced or codings are use be used to define relevant drug/medication concepts. This includes coding as:
 * PBS Item Code - Pharmaceutical Benefits Scheme coding, claiming context is not relevant as medicine coding.
@@ -11,15 +15,29 @@ Full medication definitions as a Medication resource can be referenced or coding
 
 #### Extensions
 Extensions used in this profile:
-* Long Term [<sup>[1]</sup>](http://hl7.org.au/fhir/StructureDefinition/medication-long-term)
-* MedicationStatement.medication.coding: Medication Type [<sup>[1]</sup>](http://hl7.org.au/fhir/StructureDefinition/medication-type)
-* Medication Brand Name [<sup>[1]</sup>](http://hl7.org.au/fhir/StructureDefinition/medication-brand-name) - Not to be used if medicationReference is used. This text-only extension is supplied to support a brand name where no brand concept coding is available. Use medicationCodeableConcept if a brand concept coding is available. 
-* Medication Generic Drug Name [<sup>[1]</sup>](http://hl7.org.au/fhir/StructureDefinition/medication-generic-name) - Not to be used if medicationReference is used. This text-only extension is supplied to support a generic name where no generic concept coding is available. Use medicationCodeableConcept if a generic concept coding is available.
-* NOTE: if extensions Medication Brand Name or Medication Generic Drug Name are used then medicationCodeableConcept must also be used. 
+* MedicationStatement: [Long Term](StructureDefinition-medication-long-term.html)
+* MedicationStatement: [Medication Brand Name](StructureDefinition-medication-brand-name.html)
+* MedicationStatement: [Medication Generic Drug Name](StructureDefinition-medication-generic-name.html)
+* MedicationStatement.medication.coding: [Medication Type](StructureDefinition-medication-type.html)
 
 
-**Examples**
+#### Usage Notes
+A full medication definition as medicationReference or medicationCodeableConcept can be included to define the drug/medication concept. Medication definition includes coding as:
+* [PBS Item Code](https://www.pbs.gov.au/pbs/home) - Pharmaceutical Benefits Scheme coding, claiming context is not relevant as medicine coding
+* [Medication Package Global Trade Item Number](https://www.gs1.org/standards/id-keys/gtin) - Global Trade Item Number (GTIN) physical product reference
+* [AMT Medicines](https://www.healthterminologies.gov.au/integration/R4/fhir/ValueSet/australian-medication-1) - Australian Medicines Terminology, national drug terminology
+* [MIMS Package](https://www.mims.com.au/index.php) - commonly used medicine coding
 
+When supplying a medicationReference, the extensions Medication Brand Name and Medication Generic Drug Name are not be used. These extensions are available on the referenced Medication resource and should be instantiated there if this information is included.
+
+Where a system cannot include a coded value (only MedicationStatement.medicationCodeableConcept.text can be supplied) it is expected that:
+* where a system has both brand name and generic name, brand name will form part of the MedicationStatement.medicationCodeableConcept.text and optionally be supplied in brand name extension, and generic name is supplied in the generic name extension
+* where a system only has brand name, the brand name form part of MedicationStatement.medicationCodeableConcept.text and optionally be supplied in the brand name extension
+* where a system only has generic name, the generic name form part of MedicationStatement.medicationCodeableConcept.text and optionally be supplied in the generic name extension
+* where a system is unable to determine if the text is brand name or generic name, the text will only be supplied MedicationStatement.medicationCodeableConcept.text
+
+
+#### Examples
 [Practitioner reports patient is taking Roferon-A three times a week on Mon Wed Sat](MedicationStatement-MedicationStatementexample0.html)
 
 [Long-term use of medication Zoloft](MedicationStatement-MedicationStatementexample1.html)

--- a/pages/_includes/au-medicationstatement-intro.md
+++ b/pages/_includes/au-medicationstatement-intro.md
@@ -6,12 +6,6 @@ The purpose of this profile is to provide national level agreement on core local
 
 This profile does not force conformance to core localised concepts. It enables implementers and modellers to make their own rules, i.e. [profiling](http://hl7.org/fhir/profiling.html), about how to support these concepts for specific implementation needs.
 
-#### Medication Reference/Coding
-Full medication definitions as a Medication resource can be referenced or codings are use be used to define relevant drug/medication concepts. This includes coding as:
-* PBS Item Code - Pharmaceutical Benefits Scheme coding, claiming context is not relevant as medicine coding.
-* GTIN - Global Trade Item Number, physical product reference.
-* AMT Code - Australian Medicines Terminology, national drug terminology.
-* MIMS Package - commonly used medicine coding.
 
 #### Extensions
 Extensions used in this profile:

--- a/resources/au-medicationstatement.xml
+++ b/resources/au-medicationstatement.xml
@@ -185,6 +185,16 @@
       <min value="1"/>
       <fixedUri value="http://www.mims.com.au/codes"/>
     </element>
+    <element id="MedicationStatement.medication[x]:medicationCodeableConcept.text">
+      <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable">
+        <valueBoolean value="true"/>
+      </extension>
+      <path value="MedicationStatement.medication[x].text"/>
+      <short value="Medication primary text"/>
+      <definition
+        value="A human language representation of the concept as seen/selected/uttered by the user who entered the data and/or which represents the intended meaning of the user.&#xD;&#xA;&#xD;&#xA;This may be a brand or generic name as suitable for the intent of the entry."
+      />
+    </element>
     <element id="MedicationStatement.medication[x]:medicationReference">
       <path value="MedicationStatement.medicationReference"/>
       <sliceName value="medicationReference"/>

--- a/resources/au-medicationstatement.xml
+++ b/resources/au-medicationstatement.xml
@@ -2,11 +2,11 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="au-medicationstatement"/>
   <url value="http://hl7.org.au/fhir/StructureDefinition/au-medicationstatement"/>
-  <version value="2.1.0"/>
+  <version value="2.1.1"/>
   <name value="AUBaseMedicationStatement"/>
   <title value="AU Base Medication Statement"/>
   <status value="draft"/>
-  <date value="2020-07-29"/>
+  <date value="2021-07-01"/>
   <publisher value="Health Level Seven Australia (Medications WG)"/>
   <contact>
     <telecom>
@@ -59,10 +59,7 @@
     <element id="MedicationStatement.extension:brandName">
       <path value="MedicationStatement.extension"/>
       <sliceName value="brandName"/>
-      <short value="Medication Brand Name"/>
-      <definition
-        value="The brand medication text name for an associated medication, this may be supplied if a coded brand name is not available for medicationCodeableConcept but the brand name is needed."/>
-      <type>
+          <type>
         <code value="Extension"/>
         <profile value="http://hl7.org.au/fhir/StructureDefinition/medication-brand-name"/>
       </type>
@@ -70,9 +67,6 @@
     <element id="MedicationStatement.extension:genericName">
       <path value="MedicationStatement.extension"/>
       <sliceName value="genericName"/>
-      <short value="Medication Generic Drug Name"/>
-      <definition
-        value="The generic medication text name for an associated medication, this may not be the same as the medicationCodeableConcept medication (prescribed, dispensed or stated) but may be used to provide an additional or equivalent drug name that is a generic medication concept. "/>
       <type>
         <code value="Extension"/>
         <profile value="http://hl7.org.au/fhir/StructureDefinition/medication-generic-name"/>
@@ -164,9 +158,6 @@
       id="MedicationStatement.medication[x]:medicationCodeableConcept.coding:amt.extension:medicationClass">
       <path value="MedicationStatement.medication[x].coding.extension"/>
       <sliceName value="medicationClass"/>
-      <short value="Class of Medication Coding"/>
-      <definition
-        value="General category of coding to allow usage of codes to be distinguished from the same CodeSystem"/>
       <max value="1"/>
       <type>
         <code value="Extension"/>


### PR DESCRIPTION
MedicationStatement
- removed unnecessary shorts and definitions; kept the long-term extension short as it is more explanatory than what would come from the extension
- added MedicationStatement.medicationCodeableConcept.text short - this now matches other meds profiles, and might make Usage Notes easier to understand
- updated date and version

intro.md
- added two standard AU Base profiles paragraphs (2nd and 3rd)
- hyperlinked extensions to their definitions
- moved content from Medication Reference/Coding into the Usage Notes -
usage notes content now pretty much matches AU Base MedicationDispense Usage Notes now with small tweaks for MedicationStatement
- changed Examples heading style