### PR TITLE
Australian Address profile QA fixes

### DIFF
--- a/examples/address-example1.xml
+++ b/examples/address-example1.xml
@@ -5,6 +5,7 @@
     <id value="address-example1"/>
     
     <address>
+        <text value="Level 1, 300 George St, Brisbane, QLD 4000" />
         <line value="Level 1"/>
         <line value="300 George St"/>
         <city value="Brisbane"/>

--- a/examples/address-example1.xml
+++ b/examples/address-example1.xml
@@ -5,7 +5,11 @@
     <id value="address-example1"/>
     
     <address>
-        <text value="Level 1, 300 George St, Brisbane, QLD 4000" />
+        <line value="Level 1"/>
+        <line value="300 George St"/>
+        <city value="Brisbane"/>
+        <state value="QLD"/>
+        <postalCode value="4000"/>
         <country value="AU"/>
     </address>
     

--- a/examples/address-example1.xml
+++ b/examples/address-example1.xml
@@ -6,8 +6,7 @@
     
     <address>
         <text value="Level 1, 300 George St, Brisbane, QLD 4000" />
-        <line value="Level 1"/>
-        <line value="300 George St"/>
+        <line value="Level 1 300 George St"/>
         <city value="Brisbane"/>
         <state value="QLD"/>
         <postalCode value="4000"/>

--- a/pages/_includes/au-address-intro.md
+++ b/pages/_includes/au-address-intro.md
@@ -2,10 +2,7 @@
 
 This profile defines an address structure that localises core concepts, including identifiers and terminology, for use in an Australian context, to specifically represent an Australian (location) address.
 
-The purpose of this profile is to provide best practice guidance on Australian address representation, where some constraint on content is desirable to guarantee the quality of an Australian address whilst still supporting
-other uses such as unstructured addresses. As such it is not bound to any elements in this implementation guide directly.
-
-Non-Australian addresses can be represented using the core Address data type.
+The purpose of this profile is to provide best practice guidance on Australian address representation, where some constraint on content is desirable to guarantee the quality of an Australian address.
 
 #### Identifiers
 These definitions, defined as profiles of [Identifier](http://hl7.org/fhir/R4/datatypes.html#Identifier), represent common data held in the [Address Identifier](StructureDefinition-address-identifier.html) extension:
@@ -27,7 +24,7 @@ Potentially useful core extensions:
 * Address.line: [Street Name Base](http://hl7.org/fhir/R4/extension-iso21090-adxp-streetnamebase.html)
 
 #### Usage Notes
-An unstructured address can be represented using Address.text or Address.line.
+Non-Australian addresses can be represented using the core [Address](http://hl7.org/fhir/R4/datatypes.html#Address) data type.
 
 #### Examples
 

--- a/pages/_includes/au-address-intro.md
+++ b/pages/_includes/au-address-intro.md
@@ -1,14 +1,16 @@
-**Australian Address Profile** *[[FMM Level 2](guidance.html)]*
+**Australian Address** *[[FMM Level 2](guidance.html)]*
 
-This profile is provided for use in an Australian context where some constraint on content is desirable to guarantee the quality of an Australian address whilst still supporting
-other uses such as unstructured addresses. 
+This profile defines an address structure that localises core concepts, including identifiers and terminology, for use in an Australian context, to specifically represent an Australian (location) address.
+
+The purpose of this profile is to provide best practice guidance on Australian address representation, where some constraint on content is desirable to guarantee the quality of an Australian address whilst still supporting
+other uses such as unstructured addresses. As such it is not bound to any elements in this implementation guide directly.
+
+Non-Australian addresses can be represented using the core Address data type.
 
 #### Identifiers
-These definitions, defined as profiles of [Identifier](http://hl7.org/fhir/R4/datatypes.html#Identifier), represent common identifiers that may be sent using:
-* [Address Identifier](StructureDefinition-address-identifier.html)
+These definitions, defined as profiles of [Identifier](http://hl7.org/fhir/R4/datatypes.html#Identifier), represent common data held in the [Address Identifier](StructureDefinition-address-identifier.html) extension:
 * [Delivery Point Identifier](StructureDefinition-au-deliverypointidentifier.html)
 * [G-NAF Identifier](StructureDefinition-au-gnafidentifier.html)
-
 
 #### Extensions
 Extensions used in this profile:
@@ -16,7 +18,7 @@ Extensions used in this profile:
 * Address: [Address Identifier](StructureDefinition-address-identifier.html)
 * Address: [No Fixed Address](StructureDefinition-no-fixed-address.html)
 
-Potentially useful extensions:
+Potentially useful core extensions:
 
 * Address.line: [Unit](http://hl7.org/fhir/R4/extension-iso21090-adxp-unitid.html)
 * Address.line: [House Number](http://hl7.org/fhir/R4/extension-iso21090-adxp-housenumber.html)
@@ -24,19 +26,15 @@ Potentially useful extensions:
 * Address.line: [Street Name Type](http://hl7.org/fhir/R4/extension-iso21090-adxp-streetnametype.html)
 * Address.line: [Street Name Base](http://hl7.org/fhir/R4/extension-iso21090-adxp-streetnamebase.html)
 
-
 #### Usage Notes
-* Is for use when representing an Australian (location) address so country is fixed to AU.
-* Is not bound to any elements in this implementation guide directly.
-* Overseas addresses can be represented using the core Address data type.
-* May be used as needed in implementation guide by use cases.
-* Is provided as the best practice guidance on Australian address representation.
+An unstructured address can be represented using Address.text or Address.line.
 
-
-**Examples**
+#### Examples
 
 [Postal and work address in Darwin, NT](Patient-address-example0.html)
 
 [Level 1, 300 George St, Brisbane, QLD 4000](Patient-address-example1.html)
 
 [No fixed address in Melbourne, VIC](Patient-address-example2.html)
+
+[Postal address (with DPID and G-NAF Identifier) and work address in Darwin, NT](Patient-address-example3.html)

--- a/resources/au-address.xml
+++ b/resources/au-address.xml
@@ -2,11 +2,11 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="au-address" />
   <url value="http://hl7.org.au/fhir/StructureDefinition/au-address" />
-  <version value="2.1.0"/>
+  <version value="2.1.1"/>
   <name value="AustralianAddress" />
   <title value="Australian Address" />
   <status value="active" />
-  <date value="2019-07-30" />
+  <date value="2021-07-05" />
   <publisher value="Health Level Seven Australia (Patient Administration WG)" />
   <contact>
     <telecom>
@@ -15,7 +15,7 @@
       <use value="work" />
     </telecom>
   </contact>
-  <description value="This profile is provided for use in an Australian context where some constraint on content is desirable to guarantee the quality of an Australian address whilst still supporting other uses such as unstructured addresses." />
+  <description value="This profile defines an address structure that localises core concepts, including identifiers and terminology, for use in an Australian context, to specifically represent an Australian (location) address." />
   <jurisdiction>
     <coding>
       <system value="urn:iso:std:iso:3166"/>
@@ -87,7 +87,6 @@
     <element id="Address.extension:noFixedAddress">
       <path value="Address.extension" />
       <sliceName value="noFixedAddress" />
-      <definition value="No fixed address indicator." />
       <max value="1"/>
       <type>
         <code value="Extension" />
@@ -96,12 +95,11 @@
     </element>
     <element id="Address.city">
       <path value="Address.city" />
-      <short value="Name of city, town, suburb, etc." />
-      <definition value="The name of the city, town, village, suburb, or other community or delivery center." />
+      <short value="Name of city, town or suburb" />
     </element>
     <element id="Address.state">
       <path value="Address.state" />
-      <short value="Australian state and territory" />
+      <short value="Australian state or territory" />
       <binding>
         <strength value="required" />
         <valueSet value="https://healthterminologies.gov.au/fhir/ValueSet/australian-states-territories-2" />


### PR DESCRIPTION
## Updated au-address profile
- updated description to align with standardised patterns
- removed unnecessary definitions
- improved short names
- version patch bump & date updated

## Updated Australian Address profile intro text
- removed 'profile' from heading
- expanded introductory text to align to standard descriptions and added a purpose statement with text from the usage notes. Removed mention of unstructured address given that the profile is pitched at best practice guidance
- identifiers section - improved introductory sentence to include mention of the extension and removed the extension itself as a dot point from the list of identifiers
- extensions section - added 'core' to the potentially useful list
- usage notes - most content moved into introduction or removed as unnecessary
- examples section - heading changed to standard 4# and added a 4th example to the list

## Examples
- address-example1 - added structured elements to represent parts of the address in the text element