### PR TITLE
MedicationAdministration - add terminology bindings to dosage.site, dosage.route and dosage.method 

### DIFF
--- a/ignoreWarnings.txt
+++ b/ignoreWarnings.txt
@@ -98,6 +98,9 @@ The valueSet reference https://healthterminologies.gov.au/fhir/ValueSet/patholog
 The valueSet reference https://healthterminologies.gov.au/fhir/ValueSet/spia-pathology-reporting-1 on element Observation.code could not be resolved
 The valueSet reference https://healthterminologies.gov.au/fhir/ValueSet/spia-pathology-reporting-1 on element Observation.component.code could not be resolved
 The valueSet reference https://healthterminologies.gov.au/fhir/ValueSet/body-site-1 on element ServiceRequest.bodySite could not be resolved
+The valueSet reference https://healthterminologies.gov.au/fhir/ValueSet/body-site-1 on element MedicationAdministration.dosage.site could not be resolved
+The valueSet reference https://healthterminologies.gov.au/fhir/ValueSet/route-of-administration-1 on element MedicationAdministration.dosage.route could not be resolved
+
 
 ValueSet https://healthterminologies.gov.au/fhir/ValueSet/adverse-reaction-agent-1 not found by validator
 ValueSet https://healthterminologies.gov.au/fhir/ValueSet/australian-indigenous-status-1 not found by validator

--- a/resources/au-medicationadministration.xml
+++ b/resources/au-medicationadministration.xml
@@ -164,5 +164,26 @@
         <targetProfile value="http://hl7.org.au/fhir/StructureDefinition/au-medication"/>
       </type>
     </element>
+    <element id="MedicationAdministration.dosage.site">
+      <path value="MedicationAdministration.dosage.site"/>
+      <binding>
+        <strength value="preferred"/>
+        <valueSet value="https://healthterminologies.gov.au/fhir/ValueSet/body-site-1"/>
+      </binding>
+    </element>
+    <element id="MedicationAdministration.dosage.route">
+      <path value="MedicationAdministration.dosage.route"/>
+      <binding>
+        <strength value="preferred"/>
+        <valueSet value="https://healthterminologies.gov.au/fhir/ValueSet/route-of-administration-1"
+        />
+      </binding>
+    </element>
+    <element id="MedicationAdministration.dosage.method">
+      <path value="MedicationAdministration.dosage.method"/>
+      <binding>
+        <strength value="preferred"/>
+      </binding>
+    </element>
   </differential>
 </StructureDefinition>


### PR DESCRIPTION
Fixes #650.

Changes made:

- MedicationAdministration.dosage.site - add binding to 'https://healthterminologies.gov.au/fhir/ValueSet/body-site-1' with the strength of 'preferred'

- MedicationAdministration.dosage.route - add binding to 'https://healthterminologies.gov.au/fhir/ValueSet/route-of-administration-1' with the strength of 'preferred'

- MedicationAdministration.dosage.method - change binding strength from 'example' to 'preferred'