### PR TITLE
QA typo fixes on Location & IdentifierTypeAU

### DIFF
--- a/pages/_includes/au-location-intro.md
+++ b/pages/_includes/au-location-intro.md
@@ -25,7 +25,7 @@ An instantiation of Location may form part of defining a mobile or remotely deli
 Additionally a Location for a mobile service should instantiate additional instances of type to indicate the service is tailored for delivery in these kinds of locations (e.g. 'AMB', 'COMM', 'PTRES', 'SCHOOL', or 'WORK').
 
 As part of defining a remotely delivered service, Location should have:
-* mobile='kind'
+* mode='kind'
 * type='VI'
 * physicalType='vi'
 

--- a/resources/codesystem-au-v2-0203.xml
+++ b/resources/codesystem-au-v2-0203.xml
@@ -117,7 +117,7 @@
 	<concept>
 		<code value="NOI"/>
 		<display value="National Organisation Identifier"/>
-		<definition value="An identifier unique to a repository assigned by an identifier scheme managed at a national level, this is commonly a Healthcare Provider Identifier - Organisation (HPI-O) but may be a My Health Record Assigned Identity - Organisation (PAI-O) identifier."/>
+		<definition value="An identifier unique to an organisation assigned by an identifier scheme managed at a national level, this is commonly a Healthcare Provider Identifier - Organisation (HPI-O) but may be a My Health Record Assigned Identity - Organisation (PAI-O) identifier."/>
 	</concept>
 	<concept>
 		<code value="NPIO"/>


### PR DESCRIPTION
Location usage notes typo fixes #648
Corrected usage notes from "mobile='kind'" to "mode=’kind’".

IdentifierTypeAU NOI definition typo fixes #654
Corrected 'a repository' to 'an organisation'. 