### PR TITLE
Ballot fix: AU Base Immunisation profile- add constraints on route

### DIFF
--- a/resources/au-immunization.xml
+++ b/resources/au-immunization.xml
@@ -139,6 +139,11 @@
         />
       </binding>
     </element>
+    <element id="Immunization.route.coding:snomedRoute.system">
+      <path value="Immunization.route.coding.system" />
+      <min value="1" />
+      <fixedUri value="http://snomed.info/sct" />
+    </element>
     <element id="Immunization.performer">
       <path value="Immunization.performer"/>
       <slicing>


### PR DESCRIPTION
Slice on snomedRoute now has coding.system as 1..1 and fixed value of http://snomed.info/sct
Error re 'Could not match discriminator' has been eliminated.

Addresses HL7AU Ballot ticket [FHIRIG-158](https://jira.hl7australia.com/browse/FHIRIG-158)