### PR TITLE
Ballot Fix: Fixes of meta data & intro.md's for 5 profiles

### DIFF
--- a/pages/_includes/au-estimateddateofdelivery-intro.md
+++ b/pages/_includes/au-estimateddateofdelivery-intro.md
@@ -1,6 +1,6 @@
 **AU Estimated Date of Delivery Profile** *[[FMM Level 0](guidance.html)]*
 
-This profile is provided as a common representation of estimated date of delivery (EDD) related to pregnancy.
+This profile defines an observation structure that represents an estimated date of delivery (EDD) related to pregnancy, for use in an Australian context.
 This includes specific observations of EDD by scan, or EDD by last menstrual period (LMP).
 
 #### Usage Notes

--- a/pages/_includes/au-gravidity-intro.md
+++ b/pages/_includes/au-gravidity-intro.md
@@ -1,6 +1,6 @@
 **AU Gravidity Profile** *[[FMM Level 0](guidance.html)]*
 
-This profile is provided as a common representation of gravidity count related to pregnancies.
+This profile defines an observation structure that represents the gravidity count related to pregnancy, for use in an Australian context.
 
 #### Usage Notes
 * Used to record gravidity count at a point in time.

--- a/pages/_includes/au-lastmenstrualperiod-intro.md
+++ b/pages/_includes/au-lastmenstrualperiod-intro.md
@@ -1,6 +1,6 @@
 **AU Last Menstrual Period Profile** *[[FMM Level 0](guidance.html)]*
 
-This profile is provided as a common representation of last menstrual period.
+This profile defines an observation structure that represents the date of the last known menstrual period, for use in an Australian context.
 
 #### Usage Notes
 * Used to record last known menstrual period at a point in time

--- a/pages/_includes/au-parity-intro.md
+++ b/pages/_includes/au-parity-intro.md
@@ -1,6 +1,6 @@
 **AU Parity Profile** *[[FMM Level 0](guidance.html)]*
 
-This profile is provided as a common representation of parity count related to pregnancies.
+This profile defines an observation structure that represents the parity count related to pregnancy, for use in an Australian context.
 
 #### Usage Notes
 * Used to record parity count at a point in time.

--- a/pages/_includes/au-smokingstatus-intro.md
+++ b/pages/_includes/au-smokingstatus-intro.md
@@ -1,6 +1,6 @@
 **AU Base Smoking Status Profile** *[[FMM Level 0](guidance.html)]*
 
-This profile is provided as a common representation of smoking status. It is compatible for use with the International Patient Summmry implementation guide
+This profile defines an observation structure that represents smoking status, for use in an Australian context. It is compatible for use with the International Patient Summmry implementation guide
 
 #### Usage Notes
 * Is for use to record smoking status at a point in time.

--- a/resources/au-estimateddateofdelivery.xml
+++ b/resources/au-estimateddateofdelivery.xml
@@ -2,9 +2,20 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="au-estimateddateofdelivery" />
   <url value="http://hl7.org.au/fhir/StructureDefinition/au-estimateddateofdelivery" />
+  <version value="1.0.0" />
   <name value="AUEstimatedDateOfDelivery" />
   <title value="AU Estimated Date of Delivery" />
   <status value="draft" />
+  <date value="2021-11-15" />
+  <publisher value="Health Level Seven Australia (Patient Administration WG)" />
+  <contact>
+    <telecom>
+      <system value="url" />
+      <value value="http://hl7.com.au" />
+      <use value="work" />
+    </telecom>
+  </contact>
+  <description value="This profile defines an observation structure that represents an estimated date of delivery (EDD) related to pregnancy, for use in an Australian context." />
   <jurisdiction>
     <coding>
       <system value="urn:iso:std:iso:3166" />

--- a/resources/au-gravidity.xml
+++ b/resources/au-gravidity.xml
@@ -1,15 +1,28 @@
 <?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="au-gravidity" />
   <url value="http://hl7.org.au/fhir/StructureDefinition/au-gravidity" />
+  <version value="1.0.0" />
   <name value="AUGravidity" />
   <title value="AU Gravidity" />
   <status value="draft" />
+  <date value="2021-11-15" />
+  <publisher value="Health Level Seven Australia (Patient Administration WG)" />
+  <contact>
+    <telecom>
+      <system value="url" />
+      <value value="http://hl7.com.au" />
+      <use value="work" />
+    </telecom>
+  </contact>
+  <description value="This profile defines an observation structure that represents the gravidity count related to pregnancy, for use in an Australian context." />
   <jurisdiction>
     <coding>
       <system value="urn:iso:std:iso:3166" />
       <code value="AU" />
     </coding>
   </jurisdiction>
+  <copyright value="HL7 Australia© 2018+; Licensed Under Creative Commons No Rights Reserved." />
   <fhirVersion value="4.0.1" />
   <kind value="resource" />
   <abstract value="false" />

--- a/resources/au-lastmenstrualperiod.xml
+++ b/resources/au-lastmenstrualperiod.xml
@@ -2,15 +2,27 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="au-lastmenstrualperiod" />
   <url value="http://hl7.org.au/fhir/StructureDefinition/au-lastmenstrualperiod" />
+  <version value="1.0.0" />
   <name value="AULastMenstrualPeriod" />
   <title value="AU Last Menstrual Period" />
   <status value="draft" />
+  <date value="2021-11-15" />
+  <publisher value="Health Level Seven Australia (Patient Administration WG)" />
+  <contact>
+    <telecom>
+      <system value="url" />
+      <value value="http://hl7.com.au" />
+      <use value="work" />
+    </telecom>
+  </contact>
+  <description value="This profile defines an observation structure that represents the date of the last known menstrual period, for use in an Australian context." />
   <jurisdiction>
     <coding>
       <system value="urn:iso:std:iso:3166" />
       <code value="AU" />
     </coding>
   </jurisdiction>
+  <copyright value="HL7 Australia© 2018+; Licensed Under Creative Commons No Rights Reserved." />
   <fhirVersion value="4.0.1" />
   <kind value="resource" />
   <abstract value="false" />

--- a/resources/au-parity.xml
+++ b/resources/au-parity.xml
@@ -1,15 +1,28 @@
 <?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="au-parity" />
   <url value="http://hl7.org.au/fhir/StructureDefinition/au-parity" />
+  <version value="1.0.0" />
   <name value="AUParity" />
   <title value="AU Parity" />
   <status value="draft" />
+  <date value="2021-11-15" />
+  <publisher value="Health Level Seven Australia (Patient Administration WG)" />
+  <contact>
+    <telecom>
+      <system value="url" />
+      <value value="http://hl7.com.au" />
+      <use value="work" />
+    </telecom>
+  </contact>
+  <description value="This profile defines an observation structure that represents the parity count related to pregnancy, for use in an Australian context." />
   <jurisdiction>
     <coding>
       <system value="urn:iso:std:iso:3166" />
       <code value="AU" />
     </coding>
   </jurisdiction>
+  <copyright value="HL7 Australia© 2018+; Licensed Under Creative Commons No Rights Reserved." />
   <fhirVersion value="4.0.1" />
   <kind value="resource" />
   <abstract value="false" />

--- a/resources/au-smokingstatus.xml
+++ b/resources/au-smokingstatus.xml
@@ -2,9 +2,20 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="au-smokingstatus" />
   <url value="http://hl7.org.au/fhir/StructureDefinition/au-smokingstatus" />
+  <version value="1.0.0" />
   <name value="AUSmokingStatus" />
   <title value="AU Smoking Status" />
   <status value="draft" />
+  <date value="2021-11-15" />
+  <publisher value="Health Level Seven Australia (Patient Administration WG)" />
+  <contact>
+    <telecom>
+      <system value="url" />
+      <value value="http://hl7.com.au" />
+      <use value="work" />
+    </telecom>
+  </contact>
+  <description value="This profile defines an observation structure that represents smoking status, for use in an Australian context." />
   <jurisdiction>
     <coding>
       <system value="urn:iso:std:iso:3166" />


### PR DESCRIPTION
The meta data of 5 profiles were missing content according tho the AU Base meta data conventions at:
https://github.com/hl7au/au-fhir-base/wiki/HL7-AU-Conventions:-profile-and-extension-metadata.
Fixes issues in:
[FHIRIG-162](https://jira.hl7australia.com/browse/FHIRIG-162), [FHIRIG-160](https://jira.hl7australia.com/browse/FHIRIG-160), [FHIRIG-168](https://jira.hl7australia.com/browse/FHIRIG-168), [FHIRIG-166](https://jira.hl7australia.com/browse/FHIRIG-166) & [FHIRIG-164](https://jira.hl7australia.com/browse/FHIRIG-164)