### PR TITLE
Updates to AU Base Medication profile

### DIFF
--- a/resources/au-medication.xml
+++ b/resources/au-medication.xml
@@ -1,15 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="au-medication"/>
-  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-wg">
-    <valueCode value="phx"/>
-  </extension>
   <url value="http://hl7.org.au/fhir/StructureDefinition/au-medication"/>
   <version value="2.1.2"/>
   <name value="AUBaseMedication"/>
   <title value="AU Base Medication"/>
   <status value="active"/>
-  <date value="2021-07-05"/>
+  <date value="2021-12-20"/>
   <publisher value="Health Level Seven Australia (Medications WG)"/>
   <contact>
     <telecom>

--- a/resources/au-medication.xml
+++ b/resources/au-medication.xml
@@ -192,25 +192,6 @@
     </element>
     <element id="Medication.ingredient.item[x]">
       <path value="Medication.ingredient.item[x]"/>
-      <slicing>
-        <discriminator>
-          <type value="type"/>
-          <path value="$this"/>
-        </discriminator>
-        <rules value="closed"/>
-      </slicing>
-      <short value="Medication ingredient"/>
-    </element>
-    <element id="Medication.ingredient.item[x]:itemCodeableConcept">
-      <path value="Medication.ingredient.item[x]"/>
-      <sliceName value="itemCodeableConcept"/>
-      <short value="Coded Ingredient Product"/>
-      <definition
-        value="Coding for a substance or medicinal product  that is an ingredient of the medication."/>
-      <min value="0"/>
-      <type>
-        <code value="CodeableConcept"/>
-      </type>
       <binding>
         <strength value="preferred"/>
         <valueSet value="http://terminology.hl7.org.au/ValueSet/amt-mp-codes"/>


### PR DESCRIPTION
Changes included in this PR:  

- removed Medication.ingredient.item[x] slicing, and and placed preferred binding to AMT Medicinal Product and Substances value set on Medication.ingredient.item[x].
Fixes #674. 

- removed erroneous StructureDefinition.extension.