### PR TITLE
Ballot fix: remove medicationReference typing from 4 medication profiles from R4 HL7AU medication to R4 Base medication

### DIFF
--- a/resources/au-medicationadministration.xml
+++ b/resources/au-medicationadministration.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <url value="http://hl7.org.au/fhir/StructureDefinition/au-medicationadministration"/>
-  <version value="2.1.3"/>
+  <version value="2.1.4"/>
   <name value="AUBaseMedicationAdministration"/>
   <title value="AUBaseMedicationAdministration"/>
   <status value="draft"/>
-  <date value="2022-02-11"/>
+  <date value="2022-02-23"/>
   <publisher value="Health Level Seven Australia (Medications WG)"/>
   <contact>
     <telecom>
@@ -153,6 +153,16 @@
       <path value="MedicationAdministration.medication[x].coding.system"/>
       <min value="1"/>
       <fixedUri value="http://www.mims.com.au/codes"/>
+    </element>
+    <element id="MedicationAdministration.medication[x]:medicationReference">
+      <path value="MedicationAdministration.medication[x]"/>
+      <sliceName value="medicationReference"/>
+      <short value="Medication Reference"/>
+      <min value="0"/>
+      <type>
+        <code value="Reference"/>
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Medication"/>
+      </type>
     </element>
     <element id="MedicationAdministration.dosage.site">
       <path value="MedicationAdministration.dosage.site"/>

--- a/resources/au-medicationdispense.xml
+++ b/resources/au-medicationdispense.xml
@@ -2,11 +2,11 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="au-medicationdispense"/>
   <url value="http://hl7.org.au/fhir/StructureDefinition/au-medicationdispense"/>
-  <version value="2.1.3"/>
+  <version value="2.1.4"/>
   <name value="AUBaseMedicationDispense"/>
   <title value="AU Base Medication Dispense"/>
   <status value="draft"/>
-  <date value="2022-02-11"/>
+  <date value="2022-02-23"/>
   <publisher value="Health Level Seven Australia (Medications WG)"/>
   <contact>
     <telecom>
@@ -211,6 +211,16 @@
       <definition
         value="A human language representation of the concept as seen/selected/uttered by the user who entered the data and/or which represents the intended meaning of the user.&#xD;&#xA;&#xD;&#xA;This may be a brand or generic name as suitable for the intent of the entry."
       />
+    </element>
+    <element id="MedicationDispense.medication[x]:medicationReference">
+      <path value="MedicationDispense.medication[x]"/>
+      <sliceName value="medicationReference"/>
+      <short value="Dispensed Medication"/>
+      <min value="0"/>
+      <type>
+        <code value="Reference"/>
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Medication"/>
+      </type>
     </element>
     <element id="MedicationDispense.authorizingPrescription">
       <path value="MedicationDispense.authorizingPrescription"/>

--- a/resources/au-medicationrequest.xml
+++ b/resources/au-medicationrequest.xml
@@ -2,11 +2,11 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="au-medicationrequest"/>
   <url value="http://hl7.org.au/fhir/StructureDefinition/au-medicationrequest"/>
-  <version value="2.1.3"/>
+  <version value="2.1.4"/>
   <name value="AUBaseMedicationRequest"/>
   <title value="AU Base Medication Request"/>
   <status value="draft"/>
-  <date value="2022-02-11"/>
+  <date value="2022-02-23"/>
   <publisher value="Health Level Seven Australia (Medications WG)"/>
   <contact>
     <telecom>
@@ -199,6 +199,16 @@
       <definition
         value="A human language representation of the concept as seen/selected/uttered by the user who entered the data and/or which represents the intended meaning of the user.&#xD;&#xA;&#xD;&#xA;This may be a brand or generic name as suitable for the intent of the entry."
       />
+    </element>
+    <element id="MedicationRequest.medication[x]:medicationReference">
+      <path value="MedicationRequest.medication[x]"/>
+      <sliceName value="medicationReference"/>
+      <short value="Prescribed Medication"/>
+      <min value="0"/>
+      <type>
+        <code value="Reference"/>
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Medication"/>
+      </type>
     </element>
     <element id="MedicationRequest.supportingInformation">
       <path value="MedicationRequest.supportingInformation"/>

--- a/resources/au-medicationstatement.xml
+++ b/resources/au-medicationstatement.xml
@@ -2,11 +2,11 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="au-medicationstatement"/>
   <url value="http://hl7.org.au/fhir/StructureDefinition/au-medicationstatement"/>
-  <version value="2.1.3"/>
+  <version value="2.1.4"/>
   <name value="AUBaseMedicationStatement"/>
   <title value="AU Base Medication Statement"/>
   <status value="draft"/>
-  <date value="2022-02-11"/>
+  <date value="2022-02-23"/>
   <publisher value="Health Level Seven Australia (Medications WG)"/>
   <contact>
     <telecom>
@@ -194,6 +194,16 @@
       <definition
         value="A human language representation of the concept as seen/selected/uttered by the user who entered the data and/or which represents the intended meaning of the user.&#xD;&#xA;&#xD;&#xA;This may be a brand or generic name as suitable for the intent of the entry."
       />
+    </element>
+    <element id="MedicationStatement.medication[x]:medicationReference">
+      <path value="MedicationStatement.medicationReference"/>
+      <sliceName value="medicationReference"/>
+      <short value="Medication Reference"/>
+      <min value="0"/>
+      <type>
+        <code value="Reference"/>
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Medication"/>
+      </type>
     </element>
     <element id="MedicationStatement.reasonCode">
       <path value="MedicationStatement.reasonCode"/>


### PR DESCRIPTION
medicationReference typing has been removed from these 4 profiles from R4 HL7AU medication to R4 Base medication


- AU Base Medication Administration
- AU Base Medication Dispense
- AU Base Medication Request
- AU Base Medication Statement

Addresses ballot comment [FHIRIG-183](https://jira.hl7australia.com/browse/FHIRIG-183)

