### PR TITLE
AU Base Ballot: Added Conversion note to au-medicationrequest-intro.md

### DIFF
--- a/pages/_includes/au-medicationrequest-intro.md
+++ b/pages/_includes/au-medicationrequest-intro.md
@@ -31,6 +31,10 @@ A full medication definition as medicationReference or medicationCodeableConcept
 * [MIMS Package](https://www.mims.com.au/index.php) - commonly used medicine coding
 
 
+#### Conversion
+NOTE: AU Base on STU3 included the extension Minimum Interval Between Repeats which is now no longer required as direct R4 support is available. 
+
+
 #### Examples
 [Prescription for Stribild  with concurrent supply](MedicationRequest-medicationrequest-example1.html)
 


### PR DESCRIPTION
A Conversion note was added to au-medicationrequest-intro.md to show that the extension Minimal Interval Between Repeats is no longer needed in R4.

Issue is related to #688. 