### PR TITLE
 au sex assigned at birth update copyright notice for LOINC

### DIFF
--- a/resources/au-sexassignedatbirth.xml
+++ b/resources/au-sexassignedatbirth.xml
@@ -2,7 +2,7 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="au-sexassignedatbirth" />
   <url value="http://hl7.org.au/fhir/StructureDefinition/au-sexassignedatbirth" />
-  <version value="1.0.0" />
+  <version value="1.0.1" />
   <name value="AUBiologicalSexAssignedAtBirth" />
   <title value="AU Biological Sex Assigned at Birth" />
   <status value="draft" />
@@ -21,7 +21,7 @@
       <code value="AU" />
     </coding>
   </jurisdiction>
-  <copyright value="HL7 Australia© 2018+; Licensed Under Creative Commons No Rights Reserved. This resource includes SNOMED Clinical Terms™ (SNOMED CT®) which is used by permission of the International Health Terminology Standards Development Organisation (IHTSDO). All rights reserved. SNOMED CT®, was originally created by The College of American Pathologists. “SNOMED” and “SNOMED CT” are registered trademarks of the IHTSDO. The rights to use and implement or implementation of SNOMED CT content are limited to the extent it is necessary to allow for the end use of this material.  No further rights are granted in respect of the International Release and no further use of any SNOMED CT content by any other party is permitted. All copies of this resource must include this copyright statement and all information contained in this statement. This resource contains content from LOINC™ (http://loinc.org). The LOINC Table, LOINC Table Core, LOINC Panels and Forms File, LOINC Answer File, LOINC Part File, LOINC Group File, LOINC Document Ontology File, LOINC Hierarchies, LOINC Linguistic Variants File, LOINC/RSNA Radiology Playbook, and LOINC/IEEE Medical Device Code Mapping Table are copyright © 1995-2017, Regenstrief Institute, Inc. and the Logical Observation Identifiers Names and Codes (LOINC) Committee and is available at no cost under the license at http://loinc.org/license." />
+  <copyright value="HL7 Australia© 2018+; Licensed Under Creative Commons No Rights Reserved. This resource includes SNOMED Clinical Terms™ (SNOMED CT®) which is used by permission of the International Health Terminology Standards Development Organisation (IHTSDO). All rights reserved. SNOMED CT®, was originally created by The College of American Pathologists. “SNOMED” and “SNOMED CT” are registered trademarks of the IHTSDO. The rights to use and implement or implementation of SNOMED CT content are limited to the extent it is necessary to allow for the end use of this material.  No further rights are granted in respect of the International Release and no further use of any SNOMED CT content by any other party is permitted. All copies of this resource must include this copyright statement and all information contained in this statement. This material contains content from LOINC (http://loinc.org). LOINC is copyright © 1995-2022, Regenstrief Institute, Inc. and the Logical Observation Identifiers Names and Codes (LOINC) Committee and is available at no cost under the license at http://loinc.org/license. LOINC® is a registered United States trademark of Regenstrief Institute, Inc." />
   <fhirVersion value="4.0.1" />
   <kind value="resource" />
   <abstract value="false" />

--- a/resources/au-sexassignedatbirth.xml
+++ b/resources/au-sexassignedatbirth.xml
@@ -6,6 +6,7 @@
   <name value="AUBiologicalSexAssignedAtBirth" />
   <title value="AU Biological Sex Assigned at Birth" />
   <status value="draft" />
+  <date value="2022-03-23" />
   <publisher value="Health Level Seven Australia (Patient Administration WG)" />
   <contact>
     <telecom>


### PR DESCRIPTION
The LOINC copyright statement has been updated to align with the statement from LOINC (Regenstrief) at https://loinc.org/kb/license/ point 10.1 and the [HL7 AU profile conventions](https://github.com/hl7au/au-fhir-base/wiki/HL7-AU-Conventions:-profile-and-extension-metadata).

Closes #711 