### PR TITLE
Submission of Vaccine (Vial) Serial Number extension

### DIFF
--- a/examples/immunization-example3.xml
+++ b/examples/immunization-example3.xml
@@ -1,0 +1,87 @@
+<Immunization xmlns="http://hl7.org/fhir">
+	<id value="example3"/>
+	<meta>
+		<profile value="http://hl7.org.au/fhir/StructureDefinition/au-immunization"/>
+	</meta>
+	<extension url="http://hl7.org.au/fhir/StructureDefinition/vaccine-serial-number">
+		<!--Vial serial number below does not conform to reporting requirements to avoid conflict with real world values-->
+		<valueString value="vNo1111"/>
+	</extension>
+	<status value="completed"/>
+	<vaccineCode>
+		<coding>
+			<system value="https://www.humanservices.gov.au/organisations/health-professionals/enablers/air-vaccine-code-formats"/>
+			<code value="COMIRN"/>
+		</coding>
+		<coding>
+			<system value="http://snomed.info/sct"/>
+			<code value="1525011000168107"/>
+			<display value="Comirnaty"/>
+		</coding>
+		<text value="Pfizer Comirnaty"/>
+	</vaccineCode>
+	<patient>
+		<reference value="Patient/example5"/>
+		<identifier>
+			<type>
+				<coding>
+					<system value="http://terminology.hl7.org/CodeSystem/v2-0203"/>
+					<code value="MC"/>
+					<display value="Patient's Medicare number"/>
+				</coding>
+				<text value="Medicare Number"/>
+			</type>
+			<system value="http://ns.electronichealth.net.au/id/medicare-number"/>
+			<value value="22968184811"/>
+			<period>
+				<end value="2022-12"/>
+			</period>
+		</identifier>
+	</patient>
+	<occurrenceDateTime value="2021-11-17"/>
+	<recorded value="2021-11-17"/>
+	<primarySource value="true"/>
+	<location>
+		<reference value="Location/example3"/> 
+	</location>
+	<manufacturer>
+		<display value="Pfizer Australia Ltd" />
+	</manufacturer>
+	<!--Lot number below does not conform to batch number reporting requirements to avoid conflict with real world values-->
+	<lotNumber value="500000000P" />
+	<performer>
+		<function>
+			<coding>
+				<system value="http://terminology.hl7.org/CodeSystem/v2-0443"/>
+				<code value="AP"/>
+				<display value="Administering Provider"/>
+			</coding>
+			<text value="Administering Provider"/>
+		</function>
+		<actor>
+			<reference value="PractitionerRole/example3"/> 
+			<identifier>
+				<type>
+					<coding>
+						<system value="http://terminology.hl7.org.au/CodeSystem/v2-0203"/>
+						<code value="UPIN"/>
+					</coding>
+					<text value="Medicare Provider Number"/>
+				</type>
+				<system value="http://ns.electronichealth.net.au/id/medicare-provider-number"/>
+				<value value="1234561A"/>
+			</identifier>
+		</actor>
+	</performer>
+	<protocolApplied>
+		<targetDisease>
+			<coding>
+				<system value="http://snomed.info/sct"/>
+				<code value="840539006"/>
+				<display value="COVID-19"/>
+			</coding>
+			<text value="COVID-19"/>
+		</targetDisease>
+		<doseNumberPositiveInt value="1"/>
+	</protocolApplied>
+</Immunization>

--- a/ig.json
+++ b/ig.json
@@ -321,6 +321,10 @@
             "base": "StructureDefinition-information-recipient.html",
             "defns": "StructureDefinition-information-recipient-definitions.html"
         },
+        "StructureDefinition/vaccine-serial-number": {
+            "base": "StructureDefinition-vaccine-serial-number.html",
+            "defns": "StructureDefinition-vaccine-serial-number-definitions.html"
+        },
         "StructureDefinition/au-receivingfacility": {
             "base": "StructureDefinition-au-receivingfacility.html",
             "defns": "StructureDefinition-au-receivingfacility-definitions.html"

--- a/ignoreWarnings.txt
+++ b/ignoreWarnings.txt
@@ -136,6 +136,7 @@ ValueSet https://healthterminologies.gov.au/fhir/ValueSet/pathology-diagnostic-s
 ValueSet https://healthterminologies.gov.au/fhir/ValueSet/spia-pathology-reporting-1 not found by validator
 ValueSet https://healthterminologies.gov.au/fhir/ValueSet/evaluation-procedure-1 not found by validator
 ValueSet https://healthterminologies.gov.au/fhir/ValueSet/procedure-1 not found by validator
+ValueSet https://healthterminologies.gov.au/fhir/ValueSet/australian-immunisation-register-vaccine-1 not found by validator
 
 Error from server: Unable to provide support for code system https://healthterminologies.gov.au/fhir/CodeSystem/concurrent-supply-grounds-1
 

--- a/pages/_includes/au-immunization-intro.md
+++ b/pages/_includes/au-immunization-intro.md
@@ -10,6 +10,9 @@ This profile does not force conformance to core localised concepts. It enables i
 #### Extensions
 No extensions are used in this profile.
 
+Potentially useful extensions:
+* Immunization: [Vaccine Vial Serial Number](StructureDefinition-vaccine-serial-number.html) 
+
 
 #### Examples
 
@@ -18,3 +21,5 @@ No extensions are used in this profile.
 [Administration of a vaccine with administering provider and protocol](Immunization-immunization-example2.html)
 
 [Non-administration of varicella-zoster live vaccine due to refusal](Immunization-immunization-example0.html)
+
+[Administration of Pfizer Comirnaty dose 1 for Sarah Simmons](Immunization-example3.html)

--- a/pages/_includes/extensions.md
+++ b/pages/_includes/extensions.md
@@ -31,6 +31,7 @@ Related to administration records such as patient, practitioner, practitioner ro
 * [Medication Type](StructureDefinition-medication-type.html) *[[FMM 2](guidance.html)]* - drug code classification
 * [Minimum Interval Between Repeats](StructureDefinition-minimum-interval-between-repeats.html) *[[FMM 1](guidance.html)]* - minimum allowed dispensing interval
 * [Subsidised Concurrent Supply](StructureDefinition-subsidised-concurrent-supply.html) *[[FMM 2](guidance.html)]* - grounds for supplying multiple repeats of a medication prescription at one time
+* [Vaccine Vial Serial Number](StructureDefinition-vaccine-serial-number.html) *[[DRAFT 0](guidance.html)]* - serial number of the vial of a vaccine
 
 
 ## Clinical

--- a/pages/_includes/vaccine-serial-number-intro.md
+++ b/pages/_includes/vaccine-serial-number-intro.md
@@ -1,0 +1,8 @@
+**Extension: Vaccine Vial Serial Number** *[[DRAFT 0](guidance.html)]*
+
+This extension applies to the [Immunization](http://hl7.org/fhir/R4/immunization.html) and is used to represent the serial number of the vial of vaccine. Vial serial number is part of the [Australian Immunisation Register Rule 2015](https://www.legislation.gov.au/Latest/F2021C00234) data elements to report for COVID-19 vaccines. 
+
+
+#### Examples
+
+[Administration of Pfizer Comirnaty dose 1 for Sarah Simmons](Immunization-example3.html)

--- a/pages/_includes/vaccine-serial-number-intro.md
+++ b/pages/_includes/vaccine-serial-number-intro.md
@@ -1,6 +1,6 @@
 **Extension: Vaccine Vial Serial Number** *[[DRAFT 0](guidance.html)]*
 
-This extension applies to the [Immunization](http://hl7.org/fhir/R4/immunization.html) and is used to represent the serial number of the vial of vaccine. Vial serial number is part of the [Australian Immunisation Register Rule 2015](https://www.legislation.gov.au/Latest/F2021C00234) data elements to report for COVID-19 vaccines. 
+This extension applies to the [Immunization](http://hl7.org/fhir/R4/immunization.html) resource and is used to represent the serial number of the vial of vaccine. Vial serial number is part of the [Australian Immunisation Register Rule 2015](https://www.legislation.gov.au/Latest/F2021C00234) data elements to report for COVID-19 vaccines. 
 
 
 #### Examples

--- a/pages/_includes/vaccine-serial-number-search.md
+++ b/pages/_includes/vaccine-serial-number-search.md
@@ -1,0 +1,1 @@
+none defined

--- a/pages/_includes/vaccine-serial-number-summary.md
+++ b/pages/_includes/vaccine-serial-number-summary.md
@@ -1,0 +1,1 @@
+Note: This summary file is kept solely for IG Publisher and is not maintained.

--- a/pages/_includes/vaccine-serial-number-watermark.md
+++ b/pages/_includes/vaccine-serial-number-watermark.md
@@ -1,0 +1,1 @@
+UNTESTED<br/>DRAFT

--- a/resources/ig.xml
+++ b/resources/ig.xml
@@ -252,6 +252,13 @@
     </resource>
     <resource>
       <reference>
+        <reference value="StructureDefinition/vaccine-serial-number"/>
+      </reference>
+      <exampleBoolean value="false"/>
+      <groupingId value="p1"/>
+    </resource>
+    <resource>
+      <reference>
         <reference value="StructureDefinition/au-patient"/>
       </reference>
       <exampleBoolean value="false"/>
@@ -1098,7 +1105,14 @@
       <exampleBoolean value="true"/>
       <groupingId value="p1"/>
     </resource>
-
+    <resource>
+      <reference>
+        <reference value="Immunization/example3"/>
+      </reference>
+      <name value="Administration of Pfizer Comirnaty dose 1 for Sarah Simmons"/>
+      <exampleBoolean value="true"/>
+      <groupingId value="p1"/>
+    </resource>
     <resource>
       <reference>
         <reference value="Practitioner/example1"/>

--- a/resources/structuredefinition-vaccine-serial-number.xml
+++ b/resources/structuredefinition-vaccine-serial-number.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="vaccine-serial-number" />
+  <url value="http://hl7.org.au/fhir/StructureDefinition/vaccine-serial-number" />
+  <version value="1.0.0" />
+  <name value="VaccineSerialNumber" />
+  <title value="Vaccine Vial Serial Number" />
+  <status value="draft" />
+  <experimental value="false" />
+  <date value="2022-03-22"/>
+  <publisher value="Health Level Seven Australia (Medications WG)"/>
+  <contact>
+    <telecom>
+      <system value="url"/>
+      <value value="http://hl7.com.au"/>
+      <use value="work"/>
+    </telecom>
+  </contact>
+  <description value="This extension applies to the Immunization resource and is used to represent the serial number of the vial of vaccine." />
+  <jurisdiction>
+    <coding>
+      <system value="urn:iso:std:iso:3166"/>
+      <code value="AU"/>
+    </coding>
+  </jurisdiction>
+  <copyright value="HL7 Australia© 2018+; Licensed Under Creative Commons No Rights Reserved."/>
+  <fhirVersion value="4.0.1"/>
+  <kind value="complex-type" />
+  <abstract value="false" />
+  <context>
+    <type value="element"/>
+  <expression value="Immunization"/>
+  </context>
+  <type value="Extension" />
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Extension" />
+  <derivation value="constraint" />
+  <differential>
+    <element id="Extension">
+      <path value="Extension" />
+      <short value="Vaccine vial serial number" />
+      <definition value="Serial number for the vial of vaccine used in an administration." />
+      <max value="1" />
+    </element>
+    <element id="Extension.url">
+      <path value="Extension.url" />
+      <fixedUri value="http://hl7.org.au/fhir/StructureDefinition/vaccine-serial-number" />
+    </element>
+    <element id="Extension.value[x]">
+      <path value="Extension.value[x]" />
+      <min value="1" />
+      <type>
+        <code value="string" />
+      </type>
+    </element>
+  </differential>
+</StructureDefinition>


### PR DESCRIPTION
Addition of vaccine vial serial number extension in support of government reporting requirements for COVID-19 vaccinations. Closes #712

Closes https://github.com/AuDigitalHealth/ci-fhir-r4/issues/144