### PR TITLE
HL7 AU Ballot Fixes:  inconsistent status wrt fmm level

### DIFF
--- a/resources/structuredefinition-encryption-certificate-pem-x509.xml
+++ b/resources/structuredefinition-encryption-certificate-pem-x509.xml
@@ -2,11 +2,11 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="encryption-certificate-pem-x509" />
   <url value="http://hl7.org.au/fhir/StructureDefinition/encryption-certificate-pem-x509" />
-  <version value="2.1.3"/>
+  <version value="2.1.4"/>
   <name value="EncryptionCertificatePEMx509" />
   <title value="Encryption Certificate PEM X509" />
-  <status value="draft" />
-  <date value="2021-11-15" />
+  <status value="active" />
+  <date value="2022-03-23" />
   <publisher value="Health Level Seven Australia (Patient Administration WG)" />
   <contact>
     <telecom>

--- a/resources/structuredefinition-ethnicity.xml
+++ b/resources/structuredefinition-ethnicity.xml
@@ -2,11 +2,11 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="ethnicity" />
   <url value="http://hl7.org.au/fhir/StructureDefinition/ethnicity" />
-  <version value="1.0.2" />
+  <version value="1.0.3" />
   <name value="Ethnicity" />
   <title value="Ethnicity" />
-  <status value="active" />
-  <date value="2021-11-15" />
+  <status value="draft" />
+  <date value="2022-03-23" />
   <publisher value="Health Level Seven Australia (Patient Administration WG)" />
   <contact>
     <telecom>

--- a/resources/structuredefinition-medication-strength.xml
+++ b/resources/structuredefinition-medication-strength.xml
@@ -2,11 +2,11 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="medication-strength"/>
   <url value="http://hl7.org.au/fhir/StructureDefinition/medication-strength"/>
-  <version value="2.1.3"/>
+  <version value="2.1.4"/>
   <name value="MedicationStrength"/>
   <title value="Medication Strength"/>
-  <status value="active"/>
-  <date value="2021-11-15"/>
+  <status value="draft"/>
+  <date value="2022-03-23"/>
   <publisher value="Health Level Seven Australia (Medications WG)"/>
   <contact>
     <telecom>


### PR DESCRIPTION
There were some inconsistent status allocation wrt the FMM level there include :

1) Draft 0 profiles with status = "active" of: 
- structuredefinition-medication-strength
- structuredefinition-ethnicity
(where all other Draft 0 artifacts have status = "draft")
2) FMM level 3 profile with status = "draft" of:
- structuredefinition-encryption-certificate-pem-x509
(where all other FMM 3 artifacts have status = "active")

Profiles with FMM of "Draft 0" were changed to have a status ="draft" and;
profiles with FMM 3 were changed to have a status of "active".

Fixes #708 