### PR TITLE
Smoking status QA fixes

### DIFF
--- a/ig.json
+++ b/ig.json
@@ -681,10 +681,6 @@
             "base": "ValueSet-contact-purpose.html",
             "defns": "ValueSet-contact-purpose-definitions.html"
         },
-        "ValueSet/smoking-status": {
-            "base": "ValueSet-smoking-status.html",
-            "defns": "ValueSet-smoking-status-definitions.html"
-        },
         "CodeSystem/au-v2-0203": {
             "base": "CodeSystem-au-v2-0203.html",
             "defns": "CodeSystem-au-v2-0203-definitions.html"

--- a/ignoreWarnings.txt
+++ b/ignoreWarnings.txt
@@ -21,6 +21,7 @@ Code System URI 'http://www.abs.gov.au/ausstats/abs@.nsf/mf/1220.0' is unknown s
 The value set import https://healthterminologies.gov.au/fhir/ValueSet/substance-1 could not be found so cannot be checked
 
 
+The valueSet reference https://healthterminologies.gov.au/fhir/ValueSet/smoking-status-1 on element Observation.value[x] could not be resolved
 The valueSet reference https://healthterminologies.gov.au/fhir/ValueSet/australian-states-territories-2 on element Address.state could not be resolved
 The valueSet reference https://healthterminologies.gov.au/fhir/ValueSet/service-type-1 on element HealthcareService.type could not be resolved
 The valueSet reference https://healthterminologies.gov.au/fhir/ValueSet/clinical-specialty-1 on element HealthcareService.specialty could not be resolved

--- a/pages/_includes/au-smokingstatus-intro.md
+++ b/pages/_includes/au-smokingstatus-intro.md
@@ -1,11 +1,11 @@
 **AU Base Smoking Status** *[[DRAFT 0](guidance.html)]*
 
-This profile defines an observation structure that represents smoking status, for use in an Australian context. It is compatible for use with the International Patient Summmry implementation guide
+This profile defines an observation structure that represents smoking status, i.e. current behaviour for all types of tobacco smoking, for use in an Australian context.
 
-#### Usage Notes
-* Is for use to record smoking status at a point in time.
-* Compatible with the International Patient Summary implementation guide.
+At the time of publication of this guide this profile is compatible with the International Patient Summary implementation guide.
+
 
 **Examples**
 
-TODO
+There are no examples available for this profile.
+

--- a/pages/_includes/au-smokingstatus-intro.md
+++ b/pages/_includes/au-smokingstatus-intro.md
@@ -5,7 +5,7 @@ This profile defines an observation structure that represents smoking status, i.
 At the time of publication of this guide this profile is compatible with the International Patient Summary implementation guide.
 
 
-**Examples**
+#### Examples
 
 There are no examples available for this profile.
 

--- a/pages/_includes/au-smokingstatus-intro.md
+++ b/pages/_includes/au-smokingstatus-intro.md
@@ -1,8 +1,12 @@
-**AU Base Smoking Status** *[[DRAFT 0](guidance.html)]*
+**AU Smoking Status** *[[DRAFT 0](guidance.html)]*
 
 This profile defines an observation structure that represents smoking status, i.e. current behaviour for all types of tobacco smoking, for use in an Australian context.
 
 At the time of publication of this guide this profile is compatible with the International Patient Summary implementation guide.
+
+
+#### Extensions
+No extensions are used in this profile.
 
 
 #### Examples

--- a/pages/_includes/profiles.md
+++ b/pages/_includes/profiles.md
@@ -54,7 +54,7 @@ These Profiles have been defined for this implementation guide.
 * [AU Vital Signs Panel](StructureDefinition-au-vitalspanel.html) *[[DRAFT 0](guidance.html)]* - vital signs panel
 
 ## Lifestyle Factor Profiles
-* [AU Smoking Status](StructureDefinition-au-smokingstatus.html) *[[DRAFT 0](guidance.html)]* - smoking status lifestyle factor record
+* [AU Smoking Status](StructureDefinition-au-smokingstatus.html) *[[DRAFT 0](guidance.html)]* - smoking status lifestyle factor at a point in time
 
 ## Pregnancy Related Profiles
 * [AU Estimated Date of Delivery](StructureDefinition-au-estimateddateofdelivery.html) *[[DRAFT 0](guidance.html)]* - estimated date of delivery; may be my scan or last menstrual period

--- a/resources/au-smokingstatus.xml
+++ b/resources/au-smokingstatus.xml
@@ -2,11 +2,11 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="au-smokingstatus" />
   <url value="http://hl7.org.au/fhir/StructureDefinition/au-smokingstatus" />
-  <version value="1.0.2" />
+  <version value="1.0.3" />
   <name value="AUSmokingStatus" />
   <title value="AU Smoking Status" />
   <status value="draft" />
-  <date value="2022-03-22" />
+  <date value="2022-03-29" />
   <publisher value="Health Level Seven Australia (Patient Administration WG)" />
   <contact>
     <telecom>

--- a/resources/au-smokingstatus.xml
+++ b/resources/au-smokingstatus.xml
@@ -15,7 +15,7 @@
       <use value="work" />
     </telecom>
   </contact>
-  <description value="This profile defines an observation structure that represents smoking status, for use in an Australian context." />
+  <description value="This profile defines an observation structure that represents smoking status, i.e. current behaviour for all types of tobacco smoking, for use in an Australian context." />
   <jurisdiction>
     <coding>
       <system value="urn:iso:std:iso:3166" />
@@ -24,36 +24,6 @@
   </jurisdiction>
   <copyright value="HL7 Australia© 2018+; Licensed Under Creative Commons No Rights Reserved. This resource includes SNOMED Clinical Terms™ (SNOMED CT®) which is used by permission of the International Health Terminology Standards Development Organisation (IHTSDO). All rights reserved. SNOMED CT®, was originally created by The College of American Pathologists. “SNOMED” and “SNOMED CT” are registered trademarks of the IHTSDO. The rights to use and implement or implementation of SNOMED CT content are limited to the extent it is necessary to allow for the end use of this material.  No further rights are granted in respect of the International Release and no further use of any SNOMED CT content by any other party is permitted. All copies of this resource must include this copyright statement and all information contained in this statement. This material contains content from LOINC (http://loinc.org). LOINC is copyright © 1995-2022, Regenstrief Institute, Inc. and the Logical Observation Identifiers Names and Codes (LOINC) Committee and is available at no cost under the license at http://loinc.org/license. LOINC® is a registered United States trademark of Regenstrief Institute, Inc." />
   <fhirVersion value="4.0.1" />
-  <mapping>
-    <identity value="workflow" />
-    <uri value="http://hl7.org/fhir/workflow" />
-    <name value="Workflow Pattern" />
-  </mapping>
-  <mapping>
-    <identity value="sct-concept" />
-    <uri value="http://snomed.info/conceptdomain" />
-    <name value="SNOMED CT Concept Domain Binding" />
-  </mapping>
-  <mapping>
-    <identity value="v2" />
-    <uri value="http://hl7.org/v2" />
-    <name value="HL7 v2 Mapping" />
-  </mapping>
-  <mapping>
-    <identity value="rim" />
-    <uri value="http://hl7.org/v3" />
-    <name value="RIM Mapping" />
-  </mapping>
-  <mapping>
-    <identity value="w5" />
-    <uri value="http://hl7.org/fhir/fivews" />
-    <name value="FiveWs Pattern Mapping" />
-  </mapping>
-  <mapping>
-    <identity value="sct-attr" />
-    <uri value="http://snomed.org/attributebinding" />
-    <name value="SNOMED CT Attribute Binding" />
-  </mapping>
   <kind value="resource" />
   <abstract value="false" />
   <type value="Observation" />
@@ -62,8 +32,12 @@
   <differential>
     <element id="Observation">
       <path value="Observation" />
-      <short value="Smoking Status" />
-      <definition value="Smoking status statement at a specified time." />
+      <short value="Smoking status" />
+      <definition value="An observation of smoking status, i.e. current behaviour for all types of tobacco smoking, at a point in time." />
+    </element>
+    <element id="Observation.status">
+      <path value="Observation.status" />
+      <fixedCode value="final" />
     </element>
     <element id="Observation.code">
       <path value="Observation.code" />
@@ -127,9 +101,8 @@
         <code value="CodeableConcept" />
       </type>
       <binding>
-        <strength value="required" />
-        <description value="Smoking status" />
-        <valueSet value="http://terminology.hl7.org.au/ValueSet/smoking-status" />
+        <strength value="extensible" />
+        <valueSet value="https://healthterminologies.gov.au/fhir/ValueSet/smoking-status-1" />
       </binding>
     </element>
   </differential>

--- a/resources/ig.xml
+++ b/resources/ig.xml
@@ -896,13 +896,6 @@
     </resource>
     <resource>
       <reference>
-        <reference value="ValueSet/smoking-status"/>
-      </reference>
-      <exampleBoolean value="false"/>
-      <groupingId value="p1"/>
-    </resource>
-    <resource>
-      <reference>
         <reference value="ValueSet/dva-entitlement"/>
       </reference>
       <exampleBoolean value="false"/>


### PR DESCRIPTION
Completes the set of changes needed to be a complete profile at DRAFT 0 including copyright and other metadata, meaningful descriptions including shorts, slicenames etc, and terminology.

Addresses issues for Smoking status profile noted in https://github.com/hl7au/au-fhir-base/issues/667.

Also addresses https://jira.hl7australia.com/browse/FHIRIG-160 and https://jira.hl7australia.com/browse/FHIRIG-159