### PR TITLE
Terminology status and experimental flag corrections

### DIFF
--- a/resources/codesystem-au-location-physical-type.xml
+++ b/resources/codesystem-au-location-physical-type.xml
@@ -11,9 +11,9 @@
 	<version value="1.0.4" />
 	<name value="LocationTypePhysicalAU" />
 	<title value="Location Type (Physical) AU" />
-	<status value="draft" />
-	<experimental value="true"/>
-	<date value="2021-07-08" />
+	<status value="active" />
+	<experimental value="false"/>
+	<date value="2022-03-31" />
 	<publisher value="Health Level Seven Australia (Patient Administration WG)" />
 	<contact>
 		<telecom>

--- a/resources/codesystem-au-location-physical-type.xml
+++ b/resources/codesystem-au-location-physical-type.xml
@@ -8,7 +8,7 @@
 		<system value="urn:ietf:rfc:3986"/> 
 		<value value="urn:oid:2.16.840.1.113883.2.3.4.1.4.25"/> 
 	</identifier>
-	<version value="1.0.4" />
+	<version value="1.0.5" />
 	<name value="LocationTypePhysicalAU" />
 	<title value="Location Type (Physical) AU" />
 	<status value="active" />

--- a/resources/codesystem-au-location-type.xml
+++ b/resources/codesystem-au-location-type.xml
@@ -8,12 +8,12 @@
 		<system value="urn:ietf:rfc:3986"/> 
 		<value value="urn:oid:2.16.840.1.113883.2.3.4.1.4.26"/> 
 	</identifier>
-	<version value="1.0.3" />
+	<version value="1.0.4" />
 	<name value="LocationType" />
 	<title value="Location Type AU" />
-	<status value="draft" />
-	<experimental value="true"/>
-	<date value="2021-07-08" />
+	<status value="active" />
+	<experimental value="false"/>
+	<date value="2022-03-31" />
 	<publisher value="Health Level Seven Australia (Patient Administration WG)" />
 	<contact>
 		<telecom>

--- a/resources/codesystem-au-v2-0203.xml
+++ b/resources/codesystem-au-v2-0203.xml
@@ -8,12 +8,12 @@
 		<system value="urn:ietf:rfc:3986"/> 
 		<value value="urn:oid:2.16.840.1.113883.2.3.4.1.3.203"/> 
 	</identifier> 
-	<version value="2.1.2"/>
+	<version value="2.1.3"/>
 	<name value="IdentifierTypeAU"/>
 	<title value="IdentifierType AU"/>
 	<status value="active"/>
-	<experimental value="true"/>
-	<date value="2021-07-08"/>
+	<experimental value="false"/>
+	<date value="2022-03-31" />
 	<publisher value="Health Level Seven Australia (Patient Administration WG)"/>
 	<contact>
 		<telecom>

--- a/resources/codesystem-au-v2-0360.xml
+++ b/resources/codesystem-au-v2-0360.xml
@@ -8,12 +8,12 @@
 		<system value="urn:ietf:rfc:3986" />
 		<value value="urn:oid:2.16.840.1.113883.2.3.4.1.3.360" />
 	</identifier>
-	<version value="1.0.3" />
+	<version value="1.0.4" />
 	<name value="DegreeLicenseCertificateAU" />
 	<title value="DegreeLicenseCertificate AU" />
-	<status value="draft" />
-	<experimental value="true"/>
-	<date value="2021-07-08" />
+	<status value="active" />
+	<experimental value="false"/>
+	<date value="2022-03-31" />
 	<publisher value="Health Level Seven Australia (Patient Administration WG)" />
 	<contact>
 		<telecom>

--- a/resources/codesystem-au-v2-0443.xml
+++ b/resources/codesystem-au-v2-0443.xml
@@ -8,12 +8,12 @@
 		<system value="urn:ietf:rfc:3986"/>
 		<value value="urn:oid:2.16.840.1.113883.2.3.4.1.3.443"/>
 	</identifier>
-	<version value="2.1.4"/>
+	<version value="2.1.5"/>
 	<name value="ProviderRoleAU"/>
 	<title value="providerRole AU"/>
-	<status value="draft"/>
+	<status value="active"/>
 	<experimental value="false"/>
-	<date value="2021-07-08"/>
+	<date value="2022-03-31" />
 	<publisher value="Health Level Seven Australia (Patient Administration WG)"/>
 	<contact>
 		<telecom>

--- a/resources/codesystem-au-v3-ActCode.xml
+++ b/resources/codesystem-au-v3-ActCode.xml
@@ -8,7 +8,7 @@
 		<system value="urn:ietf:rfc:3986"/> 
 		<value value="urn:oid:2.16.840.1.113883.2.3.4.1.4.20"/> 
 	</identifier>
-	<version value="1.0.3"/>
+	<version value="1.0.4"/>
 	<name value="ActCodeAU"/>
 	<title value="ActCode AU"/>
 	<status value="active"/>

--- a/resources/codesystem-au-v3-ActCode.xml
+++ b/resources/codesystem-au-v3-ActCode.xml
@@ -11,9 +11,9 @@
 	<version value="1.0.3"/>
 	<name value="ActCodeAU"/>
 	<title value="ActCode AU"/>
-	<status value="draft"/>
-	<experimental value="true"/>
-	<date value="2021-07-08"/>
+	<status value="active"/>
+	<experimental value="false"/>
+	<date value="2022-03-31" />
 	<publisher value="Health Level Seven Australia (Patient Administration WG)"/>
 	<contact>
 		<telecom>

--- a/resources/codesystem-contact-purpose.xml
+++ b/resources/codesystem-contact-purpose.xml
@@ -8,12 +8,12 @@
 		<system value="urn:ietf:rfc:3986"/> 
 		<value value="urn:oid:2.16.840.1.113883.2.3.4.1.4.19"/> 
 	</identifier> 
-	<version value="1.0.1"/>
+	<version value="1.0.2"/>
 	<name value="ContactPurpose"/>
 	<title value="Contact Purpose"/>
-	<status value="draft"/>
-	<experimental value="true"/>
-	<date value="2021-07-06"/>
+	<status value="active"/>
+	<experimental value="false"/>
+	<date value="2022-03-31" />
 	<publisher value="Health Level Seven Australia (Patient Administration WG)"/>
 	<contact>
 		<telecom>

--- a/resources/codesystem-service-provision-conditions.xml
+++ b/resources/codesystem-service-provision-conditions.xml
@@ -8,12 +8,12 @@
 		<system value="urn:ietf:rfc:3986"/>
 		<value value="urn:oid:2.16.840.1.113883.2.3.4.1.4.2"/>
 	</identifier>
-	<version value="1.0.1"/>
+	<version value="1.0.2"/>
 	<name value="ServiceProvisionConditionsAustralianConcepts"/>
 	<title value="Service Provision Conditions Australian Concepts"/>
 	<status value="active"/>
 	<experimental value="false"/>
-	<date value="2021-07-08"/>
+	<date value="2022-03-31" />
 	<publisher value="Health Level Seven Australia (Patient Administration WG)"/>
 	<contact>
 		<name value="hl7.org.au"/>

--- a/resources/codesystem-service-provision-conditions.xml
+++ b/resources/codesystem-service-provision-conditions.xml
@@ -8,12 +8,12 @@
 		<system value="urn:ietf:rfc:3986"/>
 		<value value="urn:oid:2.16.840.1.113883.2.3.4.1.4.2"/>
 	</identifier>
-	<version value="1.0.2"/>
+	<version value="1.0.1"/>
 	<name value="ServiceProvisionConditionsAustralianConcepts"/>
 	<title value="Service Provision Conditions Australian Concepts"/>
 	<status value="active"/>
 	<experimental value="false"/>
-	<date value="2022-03-31" />
+	<date value="2021-07-08" />
 	<publisher value="Health Level Seven Australia (Patient Administration WG)"/>
 	<contact>
 		<name value="hl7.org.au"/>

--- a/resources/codesystem-service-provision-conditions.xml
+++ b/resources/codesystem-service-provision-conditions.xml
@@ -13,7 +13,7 @@
 	<title value="Service Provision Conditions Australian Concepts"/>
 	<status value="active"/>
 	<experimental value="false"/>
-	<date value="2021-07-08" />
+	<date value="2021-07-08"/>
 	<publisher value="Health Level Seven Australia (Patient Administration WG)"/>
 	<contact>
 		<name value="hl7.org.au"/>

--- a/resources/valueset-accession-number-type.xml
+++ b/resources/valueset-accession-number-type.xml
@@ -8,12 +8,12 @@
 		<system value="urn:ietf:rfc:3986"/> 
 		<value value="urn:oid:2.16.840.1.113883.2.3.4.2.4.23"/> 
 	</identifier> 
-	<version value="1.0.1"/>
+	<version value="1.0.2"/>
 	<name value="AccessionNumberType"/>
 	<title value="Accession Number Type"/>
-	<status value="draft"/>
-	<experimental value="true"/>
-	<date value="2021-07-08"/>
+	<status value="active"/>
+	<experimental value="false"/>
+	<date value="2022-03-31" />
 	<publisher value="Health Level Seven Australia (Orders and Observations WG)"/>
 	<contact>
 		<telecom>

--- a/resources/valueset-au-location-physical-type-extended.xml
+++ b/resources/valueset-au-location-physical-type-extended.xml
@@ -8,12 +8,12 @@
 		<system value="urn:ietf:rfc:3986"/> 
 		<value value="urn:oid:2.16.840.1.113883.2.3.4.2.4.25"/> 
 	</identifier>
-	<version value="1.1.2" />
+	<version value="1.1.3" />
 	<name value="LocationPhysicalTypeAUExtended" />
 	<title value="Location Type (Physical) - AU Extended" />
-	<status value="draft" />
+	<status value="active" />
 	<experimental value="true"/>
-	<date value="2021-07-08" />
+	<date value="2022-03-31" />
 	<publisher value="Health Level Seven Australia (Patient Administration WG)" />
 	<contact>
 		<telecom>

--- a/resources/valueset-au-location-physical-type-extended.xml
+++ b/resources/valueset-au-location-physical-type-extended.xml
@@ -12,7 +12,7 @@
 	<name value="LocationPhysicalTypeAUExtended" />
 	<title value="Location Type (Physical) - AU Extended" />
 	<status value="active" />
-	<experimental value="true"/>
+	<experimental value="false"/>
 	<date value="2022-03-31" />
 	<publisher value="Health Level Seven Australia (Patient Administration WG)" />
 	<contact>

--- a/resources/valueset-au-timezone.xml
+++ b/resources/valueset-au-timezone.xml
@@ -9,12 +9,12 @@
     <system value="urn:ietf:rfc:3986"/> 
     <value value="urn:oid:2.16.840.1.113883.2.3.4.2.4.27"/> 
   </identifier> 
-  <version value="1.0.2" />
+  <version value="1.0.3" />
   <name value="AUTimeZone" />
   <title value="AU Time Zone" />
-  <status value="draft" />
+  <status value="active" />
   <experimental value="true"/>
-  <date value="2021-07-08" />
+  <date value="2022-03-31" />
   <publisher value="Health Level Seven Australia (Patient Administration WG)" />
   <contact>
     <telecom>

--- a/resources/valueset-au-timezone.xml
+++ b/resources/valueset-au-timezone.xml
@@ -13,7 +13,7 @@
   <name value="AUTimeZone" />
   <title value="AU Time Zone" />
   <status value="active" />
-  <experimental value="true"/>
+  <experimental value="false"/>
   <date value="2022-03-31" />
   <publisher value="Health Level Seven Australia (Patient Administration WG)" />
   <contact>

--- a/resources/valueset-au-v2-0360-extended.xml
+++ b/resources/valueset-au-v2-0360-extended.xml
@@ -8,12 +8,12 @@
 		<system value="urn:ietf:rfc:3986" />
 		<value value="urn:oid:2.16.840.1.113883.2.3.4.2.3.360" />
 	</identifier>
-	<version value="1.0.3" />
+	<version value="1.0.4" />
 	<name value="Hl7VSDegreeLicenseCertificateAUExtended" />
 	<title value="hl7VS-degreeLicenseCertificate - AU Extended" />
-	<status value="draft" />
-	<experimental value="true"/>
-	<date value="2021-07-08" />
+	<status value="active" />
+	<experimental value="false"/>
+	<date value="2022-03-31" />
 	<publisher value="Health Level Seven Australia (Patient Administration WG)" />
 	<contact>
 		<telecom>

--- a/resources/valueset-au-v2-0443-extended.xml
+++ b/resources/valueset-au-v2-0443-extended.xml
@@ -8,12 +8,12 @@
 		<system value="urn:ietf:rfc:3986"/>
 		<value value="urn:oid:2.16.840.1.113883.2.3.4.2.3.443"/>
 	</identifier>
-	<version value="1.0.1"/>
+	<version value="1.0.2"/>
 	<name value="Hl7VSProviderRoleAUExtended"/>
 	<title value="hl7VS-providerRole - AU Extended"/>
-	<status value="draft"/>
+	<status value="active"/>
 	<experimental value="false"/>
-	<date value="2021-07-08"/>
+	<date value="2022-03-31" />
 	<publisher value="Health Level Seven Australia"/>
 	<contact>
 		<telecom>

--- a/resources/valueset-au-v3-ActEncounterCode-extended.xml
+++ b/resources/valueset-au-v3-ActEncounterCode-extended.xml
@@ -8,11 +8,11 @@
 		<system value="urn:ietf:rfc:3986"/> 
 		<value value="urn:oid:2.16.840.1.113883.2.3.4.2.4.20"/> 
 	</identifier>
-	<version value="1.0.3"/>
+	<version value="1.0.4"/>
 	<name value="ActEncounterCodeAUExtended"/>
 	<title value="ActEncounterCode - AU Extended"/>
-	<status value="draft"/>
-	<experimental value="true"/>
+	<status value="active"/>
+	<experimental value="false"/>
 	<date value="2021-07-08"/>
 	<publisher value="Health Level Seven Australia (Patient Administration WG)"/>
 	<contact>

--- a/resources/valueset-au-v3-ActEncounterCode-extended.xml
+++ b/resources/valueset-au-v3-ActEncounterCode-extended.xml
@@ -13,7 +13,7 @@
 	<title value="ActEncounterCode - AU Extended"/>
 	<status value="active"/>
 	<experimental value="false"/>
-	<date value="2021-07-08"/>
+	<date value="2022-03-31"/>
 	<publisher value="Health Level Seven Australia (Patient Administration WG)"/>
 	<contact>
 		<telecom>

--- a/resources/valueset-au-v3-ServiceDeliveryLocationRoleType-extended.xml
+++ b/resources/valueset-au-v3-ServiceDeliveryLocationRoleType-extended.xml
@@ -8,12 +8,12 @@
 		<system value="urn:ietf:rfc:3986"/> 
 		<value value="urn:oid:2.16.840.1.113883.2.3.4.2.4.26"/> 
 	</identifier>
-	<version value="1.0.3" />
+	<version value="1.0.4" />
 	<name value="ServiceDeliveryLocationRoleTypeAUExtended" />
 	<title value="ServiceDeliveryLocationRoleType - AU Extended" />
-	<status value="draft" />
-	<experimental value="true"/>
-	<date value="2021-07-08" />
+	<status value="active" />
+	<experimental value="false"/>
+	<date value="2022-03-31" />
 	<publisher value="Health Level Seven Australia (Patient Administration WG)" />
 	<contact>
 		<telecom>

--- a/resources/valueset-contact-purpose.xml
+++ b/resources/valueset-contact-purpose.xml
@@ -8,12 +8,12 @@
 		<system value="urn:ietf:rfc:3986"/> 
 		<value value="urn:oid:2.16.840.1.113883.2.3.4.2.4.19"/> 
 	</identifier> 
-	<version value="1.0.3"/>
+	<version value="1.0.4"/>
 	<name value="ContactPurpose"/>
 	<title value="Contact Purpose"/>
-	<status value="draft"/>
-	<experimental value="true"/>
-	<date value="2021-07-08"/>
+	<status value="active"/>
+	<experimental value="false"/>
+	<date value="2022-03-31" />
 	<publisher value="Health Level Seven Australia (Patient Administration WG)"/>
 	<contact>
 		<telecom>

--- a/resources/valueset-dva-entitlement.xml
+++ b/resources/valueset-dva-entitlement.xml
@@ -8,12 +8,12 @@
 		<system value="urn:ietf:rfc:3986"/> 
 		<value value="urn:oid:2.16.840.1.113883.2.3.4.2.4.22"/> 
 	</identifier> 
-	<version value="1.0.2"/>
+	<version value="1.0.3"/>
 	<name value="DVAEntitlement"/>
 	<title value="DVA Entitlement"/>
-	<status value="draft"/>
-	<experimental value="true"/>
-	<date value="2021-07-08"/>
+	<status value="active"/>
+	<experimental value="false"/>
+	<date value="2022-03-31" />
 	<publisher value="Health Level Seven Australia (Patient Administration WG)"/>
 	<contact>
 		<telecom>

--- a/resources/valueset-order-identifier-type.xml
+++ b/resources/valueset-order-identifier-type.xml
@@ -8,12 +8,12 @@
 		<system value="urn:ietf:rfc:3986"/> 
 		<value value="urn:oid:2.16.840.1.113883.2.3.4.2.4.24"/> 
 	</identifier> 
-	<version value="1.0.2"/>
+	<version value="1.0.3"/>
 	<name value="OrderIdentifierType"/>
 	<title value="Order Identifier Type"/>
-	<status value="draft"/>
-	<experimental value="true"/>
-	<date value="2021-07-08"/>
+	<status value="active"/>
+	<experimental value="false"/>
+	<date value="2022-03-31" />
 	<publisher value="Health Level Seven Australia (Orders and Observations WG)"/>
 	<contact>
 		<telecom>


### PR DESCRIPTION
Completed update for Terminology that has gone through ballot and testing now has status=active experimental=false.