### PR TITLE
Ballot: further editorial fixes

### DIFF
--- a/input/intro-notes/StructureDefinition-au-patient-intro.md
+++ b/input/intro-notes/StructureDefinition-au-patient-intro.md
@@ -2,9 +2,9 @@
 
 **Profile specific implementation guidance:**
 - This profile supports patient gender identity aligned to [Australian Bureau of Statics Standard for Sex, Gender, Variations of Sex Characteristics and Sexual Orientation Variables, 2020](https://www.abs.gov.au/statistics/standards/standard-sex-gender-variations-sex-characteristics-and-sexual-orientation-variables/latest-release#gender) using the [genderIdentity extension](http://hl7.org/fhir/StructureDefinition/patient-genderIdentity) and [Gender Identity Response](https://healthterminologies.gov.au/fhir/ValueSet/gender-identity-response-1) value set.
-  - *Man or male* may be represented by sending the SNOMED CT code 446151000124109 \| Identifies as male gender \|
-  - *Woman or female* may be represented by sending the SNOMED CT code 446141000124107 \| Identifies as female gender \|
-  - *Non-binary* may be represented by sending the SNOMED CT code 33791000087105 \| Identifies as nonbinary gender \|, see example [Patient/example4](Patient-example4.html)
+  - *Man or male* may be represented by sending the SNOMED CT code 446151000124109\|Identifies as male gender\|
+  - *Woman or female* may be represented by sending the SNOMED CT code 446141000124107\|Identifies as female gender\|
+  - *Non-binary* may be represented by sending the SNOMED CT code 33791000087105\|Identifies as nonbinary gender\|, see example [Patient/example4](Patient-example4.html)
   - *[I/They] use a different term (please specify)*  may be represented by sending only text and no code, see example [Patient/example7](Patient-example7.html)
   - *Prefer not to answer* may be represented by sending the code "asked-declined", see example [Patient/example0](Patient-example0.html)
   - *Not stated or inadequately described* may be represented by the code "unknown"

--- a/input/intro-notes/StructureDefinition-au-patient-intro.md
+++ b/input/intro-notes/StructureDefinition-au-patient-intro.md
@@ -2,9 +2,9 @@
 
 **Profile specific implementation guidance:**
 - This profile supports patient gender identity aligned to [Australian Bureau of Statics Standard for Sex, Gender, Variations of Sex Characteristics and Sexual Orientation Variables, 2020](https://www.abs.gov.au/statistics/standards/standard-sex-gender-variations-sex-characteristics-and-sexual-orientation-variables/latest-release#gender) using the [genderIdentity extension](http://hl7.org/fhir/StructureDefinition/patient-genderIdentity) and [Gender Identity Response](https://healthterminologies.gov.au/fhir/ValueSet/gender-identity-response-1) value set.
-  - *Man or male* may be represented by sending the code "446151000124109" (Identifies as male gender)
-  - *Woman or female* may be represented by sending the code "446141000124107" (Identifies as female gender)
-  - *Non-binary* may be represented by sending the code "33791000087105" (Identifies as nonbinary gender), see example [Patient/example4](Patient-example4.html)
+  - *Man or male* may be represented by sending the SNOMED CT code 446151000124109 \| Identifies as male gender \|
+  - *Woman or female* may be represented by sending the SNOMED CT code 446141000124107 \| Identifies as female gender \|
+  - *Non-binary* may be represented by sending the SNOMED CT code 33791000087105 \| Identifies as nonbinary gender \|, see example [Patient/example4](Patient-example4.html)
   - *[I/They] use a different term (please specify)*  may be represented by sending only text and no code, see example [Patient/example7](Patient-example7.html)
   - *Prefer not to answer* may be represented by sending the code "asked-declined", see example [Patient/example0](Patient-example0.html)
   - *Not stated or inadequately described* may be represented by the code "unknown"

--- a/input/pagecontent/examples.md
+++ b/input/pagecontent/examples.md
@@ -1,7 +1,7 @@
 
 ### Description
 
-The following examples are published with this guide and all available as a downloadable as zip file [here](downloads.html#examples).
+The following examples are published with this guide and all are available as a downloadable as zip file [here](downloads.html#examples).
 
 {% include nonnormative-example-boilerplate.md %}
 

--- a/input/pagecontent/guidance.md
+++ b/input/pagecontent/guidance.md
@@ -60,6 +60,7 @@ Defined in this implementation guide are profiles for business identifiers for u
    - `Patient.identifier`
    - `RelatedPerson.identifier`
    - `Practitioner.identifier`
+   - `Practitioner.qualification.identifier`
    - `PractitionerRole.identifier`
    - `ServiceRequest.identifier`
           


### PR DESCRIPTION
The following changes have been made:

- Guidance markdown page - add missing element for business identifiers
- Examples markdown page - fix typo
- AU Base Patient intro - represent SNOMED CT codes and displays using pipe notation (see ballot ticket [FHIRIG-234](https://jira.hl7australia.com/browse/FHIRIG-234))