### PR TITLE
AU Base Diagnostic Imaging Result: moved bodysite extension to Observation.bodySite

### DIFF
--- a/input/intro-notes/StructureDefinition-au-imagingresult-intro.md
+++ b/input/intro-notes/StructureDefinition-au-imagingresult-intro.md
@@ -3,7 +3,7 @@
 **Profile specific implementation guidance:**
 - The [bodySite](http://hl7.org/fhir/R4/extension-bodysite.html) extension may be suitable for use where
    - body site is not implicit in the code found in `Observation.code` and  
-   - body site information is to be handled as a separate resource (e.g. to identify and track separately) instead of an inline coded element in `Observation.bodySite`.
+   - body site information cannot be adequately captured by a single inline coded element in `Observation.bodySite`.
 - When sending an observation that represents a study series or panel:
   - the group / panel code is sent in `Observation.code`
   - the overall comments are sent in `Observation.note`

--- a/input/resources/au-imagingresult.xml
+++ b/input/resources/au-imagingresult.xml
@@ -26,24 +26,6 @@
         <expression value="value.exists() or dataAbsentReason.exists() or hasMember.exists() or component.value.exists() or component.dataAbsentReason.exists()" />
       </constraint>
     </element>
-    <element id="Observation.extension">
-      <path value="Observation.extension" />
-      <slicing>
-        <discriminator>
-          <type value="value" />
-          <path value="url" />
-        </discriminator>
-        <rules value="open" />
-      </slicing>
-    </element>
-    <element id="Observation.extension:bodySite">
-      <path value="Observation.extension" />
-      <sliceName value="bodySite" />
-      <type>
-        <code value="Extension" />
-        <profile value="http://hl7.org/fhir/StructureDefinition/bodySite" />
-      </type>
-    </element>
     <element id="Observation.category">
       <path value="Observation.category"/>
       <slicing>
@@ -137,6 +119,25 @@
         <strength value="preferred" />
         <valueSet value="https://healthterminologies.gov.au/fhir/ValueSet/body-site-1" />
       </binding>
+    </element>
+    <element id="Observation.bodySite.extension">
+      <path value="Observation.bodySite.extension" />
+      <slicing>
+        <discriminator>
+          <type value="value" />
+          <path value="url" />
+        </discriminator>
+        <rules value="open" />
+      </slicing>
+    </element>
+    <element id="Observation.bodySite.extension:bodySite">
+      <path value="Observation.bodySite.extension" />
+      <sliceName value="bodySite" />
+      <max value="1"/>
+      <type>
+        <code value="Extension" />
+        <profile value="http://hl7.org/fhir/StructureDefinition/bodySite" />
+      </type>
     </element>
     <element id="Observation.hasMember">
       <path value="Observation.hasMember" />


### PR DESCRIPTION
Changed the profile and updated intro guidance to move the bodysite extension from Observation.extension(bodySite) to the correct position Observation.bodySite.extension(bodySite).

Closes https://github.com/hl7au/au-fhir-base/issues/788