### PR TITLE
Added CodeSystem-au-coverage-selfpay and ValueSet-au-coverage-selfpay…

### DIFF
--- a/input/resources/CodeSystem-au-coverage-selfpay.xml
+++ b/input/resources/CodeSystem-au-coverage-selfpay.xml
@@ -1,0 +1,15 @@
+<CodeSystem xmlns="http://hl7.org/fhir">
+  <id value="au-coverage-selfpay"/>
+  <url value="http://teminology.hl7.org.au/CodeSystem/coverage-selfpay"/>
+  <name value="CoverageSelfPayCodesAU"/>
+  <title value="Coverage SelfPay Codes AU"/>
+  <status value="draft"/>
+  <description value="Extended concept codes for Coverage SelfPay Codes for use in an Australian context."/>
+  <content value="complete"/>
+  <count value="1"/>
+  <concept>
+    <code value="payconc"/>
+    <display value="Concession"/>
+    <definition value="An individual or organization is paying directly a concessional fee for goods and services"/>
+  </concept>
+</CodeSystem>

--- a/input/resources/ValueSet-au-coverage-selfpay-extended.xml
+++ b/input/resources/ValueSet-au-coverage-selfpay-extended.xml
@@ -1,0 +1,16 @@
+<ValueSet xmlns="http://hl7.org/fhir">
+  <id value="au-coverage-selfpay-extended"/>
+  <url value="http://teminology.hl7.org.au/ValueSet/coverage-selfpay-extended"/>
+  <name value="CoverageSelfPayCodesAUExtended"/>
+  <title value="Coverage SelfPay Codes - AU Extended"/>
+  <status value="draft"/>
+  <description value="Coverage SelfPay Codes extended for use in an Australian context."/>
+  <compose>
+    <include>
+      <system value="http://terminology.hl7.org/CodeSystem/coverage-selfpay"/>
+    </include>
+    <include>
+      <system value="http://teminology.hl7.org.au/CodeSystem/coverage-selfpay"/>
+    </include>
+  </compose>
+</ValueSet>


### PR DESCRIPTION
Added CodeSystem-au-coverage-selfpay and ValueSet-au-coverage-selfpay-extended to support concession Coverage type

https://github.com/hl7au/au-fhir-base/issues/793