### PR TITLE
Applied AU Base conventions to the invariant key

### DIFF
--- a/input/resources/structuredefinition-identifier-routability.xml
+++ b/input/resources/structuredefinition-identifier-routability.xml
@@ -25,7 +25,7 @@
       <definition value="Asserted routing preferences for the associated identifier." />
       <max value="1" />
       <constraint>
-        <key value="inv-routability-preference" />
+        <key value="inv-idrout-0" />
         <severity value="error" />
         <human value="preference is required when flag is true" />
         <expression value="extension('routability-flag').valueBoolean implies extension('routability-preference').exists()" />

--- a/input/resources/structuredefinition-identifier-routability.xml
+++ b/input/resources/structuredefinition-identifier-routability.xml
@@ -28,7 +28,7 @@
         <key value="inv-idrout-0" />
         <severity value="error" />
         <human value="preference is required when flag is true" />
-        <expression value="extension('routability-flag').valueBoolean implies extension('routability-preference').exists()" />
+        <expression value="extension('routability-flag').value implies extension('routability-preference').exists()" />
         <source value="http://hl7.org.au/fhir/StructureDefinition/identifier-routability" />
       </constraint>
     </element>


### PR DESCRIPTION
Applied AU Base conventions to the invariant inv-routability-preference key, so that it becomes inv-idrout-0.
Fixes #804.
