### PR TITLE
Change IG version number following the 4.1.2-preview snapshot release

### DIFF
--- a/input/ig.xml
+++ b/input/ig.xml
@@ -5,7 +5,7 @@
 		<valueCode value="trial-use"/>
 	</extension>
 	<url value="http://hl7.org.au/fhir/ImplementationGuide/hl7.fhir.au.base"/>
-	<version value="4.1.1"/>
+	<version value="4.1.3"/>
 	<name value="AUBaseImplementationGuide"/>
 	<title value="AU Base Implementation Guide"/>
 	<status value="active"/>


### PR DESCRIPTION
Change IG version number following the 4.1.2-preview snapshot release. Version number changed to 4.1.3.