### PR TITLE
Fix Jira issue tracker link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@ This guide alone does not constrain profiles sufficiently to ensure implementati
 For an implementation guide that has basic constraints to support many uses it is recommended that the [AU Core implementation guide](http://build.fhir.org/ig/hl7au/au-fhir-core/) is used. The implementable AU Core specification references and uses AU Base profiles, this constrains elements further and defines an expected level of interface interaction support around profiles. If an implementation is AU Core conformant this allows a level of core capability to be assumed.
 
 ## Did you find an error?
-Search the Issues list in [Jira issue tracker](https://jira.hl7.org/browse/FHIR-43719?filter=21312) to ensure the error was not already reported.
+Search the Issues list in [Jira issue tracker](https://jira.hl7.org/issues/?filter=21326) to ensure the error was not already reported.
 
 If you're unable to find an open bug addressing the problem, please create a bug report or issue in this project. You can use the ![Propose-a-change](https://github.com/hl7au/au-fhir-core/assets/116611317/642b45cb-c82e-4fb5-a24c-37b263289fac)
  option at the bottom of each page of the IG to trigger the creation of a Jira issue.
@@ -24,7 +24,7 @@ If you have a question, feature request, or proposed change, the best place to s
 
 ### 3. Log an issue in Jira
 
-Search the Issues list in [Jira issue tracker](https://jira.hl7.org/browse/FHIR-43719?filter=21312) to ensure the error was not already reported.
+Search the Issues list in [Jira issue tracker](https://jira.hl7.org/issues/?filter=21326) to ensure the error was not already reported.
 
 If you're unable to find an open bug addressing the problem, please create a bug report or issue in this project. You can use the ![Propose-a-change](https://github.com/hl7au/au-fhir-core/assets/116611317/642b45cb-c82e-4fb5-a24c-37b263289fac)
  option at the bottom of each page of the IG to trigger the creation of a Jira issue.


### PR DESCRIPTION
Jira issue tracker link was broken, replaced with a link to AU Base filter.