### PR TITLE
IdentifierType AU CodeSystem - fix incorrect definition for code 'VDI'

### DIFF
--- a/input/resources/codesystem-au-v2-0203.xml
+++ b/input/resources/codesystem-au-v2-0203.xml
@@ -154,6 +154,6 @@
 	<concept>
 		<code value="VDI"/>
 		<display value="Vendor Directory Identifier"/>
-		<definition value="A unique vendor identifier allocated to a provider directory entry (PractitionerRole or HealthcareService), typically used for routing secure messages."/>
+		<definition value="A unique vendor identifier allocated to a provider directory entry (PractitionerRole or HealthcareService)."/>
 	</concept>
 </CodeSystem>


### PR DESCRIPTION
This PR fixes #808