### PR TITLE
Fix code system value in practitioner-example-sex-and-gender

### DIFF
--- a/input/examples/practitioner-example-sex-and-gender.xml
+++ b/input/examples/practitioner-example-sex-and-gender.xml
@@ -44,7 +44,7 @@
         <extension url="type">
             <valueCodeableConcept>
                 <coding>
-                    <system value="http://terminology.hl7.org.au/CodeSystem/au-recorded-sex-or-gender-type"/>
+                    <system value="http://terminology.hl7.org.au/CodeSystem/rsg-type"/>
                     <code value="au-ahpra"/>
                     <display value="Australian Health Practitioner Regulation Agency"/>
                 </coding>


### PR DESCRIPTION
Fix code system value from 
`<system` value="http://terminology.hl7.org.au/CodeSystem/au-recorded-sex-or-gender-type"/>`
to 
`<system value="http://terminology.hl7.org.au/CodeSystem/rsg-type"/>`
in practitioner-example-sex-and-gender. 
This change was missed in #838.