### PR TITLE
Gender Identity, Individual Pronouns and RSG FHIRPath expression fixes 

### DIFF
--- a/input/resources/au-patient.xml
+++ b/input/resources/au-patient.xml
@@ -30,35 +30,35 @@
         <key value="inv-pat-1" />
         <severity value="warning" />
         <human value="Individual gender identity shall be a member of the Gender Identity Response value set if any codes within that value set can apply" />
-        <expression value="extension('http://hl7.org/fhir/StructureDefinition/individual-genderIdentity').empty() or extension('http://hl7.org/fhir/StructureDefinition/individual-genderIdentity').value.memberOf('https://healthterminologies.gov.au/fhir/ValueSet/gender-identity-response-1')"/>
+        <expression value="extension('http://hl7.org/fhir/StructureDefinition/individual-genderIdentity').empty() or extension('http://hl7.org/fhir/StructureDefinition/individual-genderIdentity').extension('value').value.memberOf('https://healthterminologies.gov.au/fhir/ValueSet/gender-identity-response-1')"/>
         <source value="http://hl7.org.au/fhir/StructureDefinition/au-patient" />
       </constraint>
       <constraint>
         <key value="inv-pat-2" />
         <severity value="warning" />
         <human value="Individual pronouns shall be a member of the Australian Pronouns value set if any codes within that value set can apply" />
-        <expression value="extension('http://hl7.org/fhir/StructureDefinition/individual-pronouns').empty() or extension('http://hl7.org/fhir/StructureDefinition/individual-pronouns').value.memberOf('https://healthterminologies.gov.au/fhir/ValueSet/australian-pronouns-1')"/>
+        <expression value="extension('http://hl7.org/fhir/StructureDefinition/individual-pronouns').empty() or extension('http://hl7.org/fhir/StructureDefinition/individual-pronouns').extension('value').value.memberOf('https://healthterminologies.gov.au/fhir/ValueSet/australian-pronouns-1')"/>
         <source value="http://hl7.org.au/fhir/StructureDefinition/au-patient" />
       </constraint>
       <constraint>
         <key value="inv-pat-3" />
         <severity value="warning" />
         <human value="Recorded sex or gender type shall be a member of the Common AU Recorded Sex or Gender Type value set if any codes within that value set can apply" />
-        <expression value="extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').empty() or extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').extension('type').empty() or extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').extension('type').value.memberOf('http://terminology.hl7.org.au/ValueSet/rsg-type')"/>
+        <expression value="extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').extension('type').empty() or extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').extension('type').value.memberOf('http://terminology.hl7.org.au/ValueSet/rsg-type')"/>
         <source value="http://hl7.org.au/fhir/StructureDefinition/au-patient" />
       </constraint>
       <constraint>
         <key value="inv-pat-4" />
         <severity value="warning" />
         <human value="Recorded sex or gender source document type shall be a member of the Common AU Recorded Sex or Gender (RSG) Source Document Type value set if any codes within that value set can apply" />
-        <expression value="extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').empty() or extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').extension('sourceDocument').empty() or extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').extension('sourceDocument').value.memberOf('http://terminology.hl7.org.au/ValueSet/rsg-source-document-type')"/>
+        <expression value="extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').extension('sourceDocument').empty() or extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').extension('sourceDocument').value.memberOf('http://terminology.hl7.org.au/ValueSet/rsg-source-document-type')"/>
         <source value="http://hl7.org.au/fhir/StructureDefinition/au-patient" />
       </constraint>
   <constraint>
         <key value="inv-pat-5" />
         <severity value="warning" />
         <human value="Recorded sex or gender jurisdiction shall be a member of the Common AU Recorded Sex or Gender (RSG) Source Document Jurisdiction value set if any codes within that value set can apply" />
-        <expression value="extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').empty() or extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').extension('jurisdiction').empty() or extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').extension('jurisdiction').value.memberOf('http://terminology.hl7.org.au/ValueSet/rsg-source-document-jurisdiction')"/> 
+        <expression value="extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').extension('jurisdiction').empty() or extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').extension('jurisdiction').value.memberOf('http://terminology.hl7.org.au/ValueSet/rsg-source-document-jurisdiction')"/> 
         <source value="http://hl7.org.au/fhir/StructureDefinition/au-patient" />
   </constraint>
  </element>

--- a/input/resources/au-patient.xml
+++ b/input/resources/au-patient.xml
@@ -30,35 +30,35 @@
         <key value="inv-pat-1" />
         <severity value="warning" />
         <human value="Individual gender identity shall be a member of the Gender Identity Response value set if any codes within that value set can apply" />
-        <expression value="extension('http://hl7.org/fhir/StructureDefinition/individual-genderIdentity').empty() or extension('http://hl7.org/fhir/StructureDefinition/individual-genderIdentity').extension('value').value.memberOf('https://healthterminologies.gov.au/fhir/ValueSet/gender-identity-response-1')"/>
+        <expression value="extension('http://hl7.org/fhir/StructureDefinition/individual-genderIdentity').empty() or extension('http://hl7.org/fhir/StructureDefinition/individual-genderIdentity').all(extension('value').value.memberOf('https://healthterminologies.gov.au/fhir/ValueSet/gender-identity-response-1'))"/>
         <source value="http://hl7.org.au/fhir/StructureDefinition/au-patient" />
       </constraint>
       <constraint>
         <key value="inv-pat-2" />
         <severity value="warning" />
         <human value="Individual pronouns shall be a member of the Australian Pronouns value set if any codes within that value set can apply" />
-        <expression value="extension('http://hl7.org/fhir/StructureDefinition/individual-pronouns').empty() or extension('http://hl7.org/fhir/StructureDefinition/individual-pronouns').extension('value').value.memberOf('https://healthterminologies.gov.au/fhir/ValueSet/australian-pronouns-1')"/>
+        <expression value="extension('http://hl7.org/fhir/StructureDefinition/individual-pronouns').empty() or extension('http://hl7.org/fhir/StructureDefinition/individual-pronouns').all(extension('value').value.memberOf('https://healthterminologies.gov.au/fhir/ValueSet/australian-pronouns-1'))"/>
         <source value="http://hl7.org.au/fhir/StructureDefinition/au-patient" />
       </constraint>
       <constraint>
         <key value="inv-pat-3" />
         <severity value="warning" />
         <human value="Recorded sex or gender type shall be a member of the Common AU Recorded Sex or Gender Type value set if any codes within that value set can apply" />
-        <expression value="extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').extension('type').empty() or extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').extension('type').value.memberOf('http://terminology.hl7.org.au/ValueSet/rsg-type')"/>
+        <expression value="extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').extension('type').empty() or extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').all(extension('type').value.memberOf('http://terminology.hl7.org.au/ValueSet/rsg-type'))"/>
         <source value="http://hl7.org.au/fhir/StructureDefinition/au-patient" />
       </constraint>
       <constraint>
         <key value="inv-pat-4" />
         <severity value="warning" />
         <human value="Recorded sex or gender source document type shall be a member of the Common AU Recorded Sex or Gender (RSG) Source Document Type value set if any codes within that value set can apply" />
-        <expression value="extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').extension('sourceDocument').empty() or extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').extension('sourceDocument').value.memberOf('http://terminology.hl7.org.au/ValueSet/rsg-source-document-type')"/>
+        <expression value="extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').extension('sourceDocument').empty() or extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').all(extension('sourceDocument').value.memberOf('http://terminology.hl7.org.au/ValueSet/rsg-source-document-type'))"/>
         <source value="http://hl7.org.au/fhir/StructureDefinition/au-patient" />
       </constraint>
   <constraint>
         <key value="inv-pat-5" />
         <severity value="warning" />
         <human value="Recorded sex or gender jurisdiction shall be a member of the Common AU Recorded Sex or Gender (RSG) Source Document Jurisdiction value set if any codes within that value set can apply" />
-        <expression value="extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').extension('jurisdiction').empty() or extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').extension('jurisdiction').value.memberOf('http://terminology.hl7.org.au/ValueSet/rsg-source-document-jurisdiction')"/> 
+        <expression value="extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').extension('jurisdiction').empty() or extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').all(extension('jurisdiction').value.memberOf('http://terminology.hl7.org.au/ValueSet/rsg-source-document-jurisdiction'))"/> 
         <source value="http://hl7.org.au/fhir/StructureDefinition/au-patient" />
   </constraint>
  </element>

--- a/input/resources/au-practitioner.xml
+++ b/input/resources/au-practitioner.xml
@@ -22,35 +22,35 @@
         <key value="inv-pra-2" />
         <severity value="warning" />
         <human value="Individual gender identity shall be a member of the Gender Identity Response value set if any codes within that value set can apply" />
-        <expression value="extension('http://hl7.org/fhir/StructureDefinition/individual-genderIdentity').empty() or extension('http://hl7.org/fhir/StructureDefinition/individual-genderIdentity').value.memberOf('https://healthterminologies.gov.au/fhir/ValueSet/gender-identity-response-1')"/>
+        <expression value="extension('http://hl7.org/fhir/StructureDefinition/individual-genderIdentity').empty() or extension('http://hl7.org/fhir/StructureDefinition/individual-genderIdentity').extension('value').value.memberOf('https://healthterminologies.gov.au/fhir/ValueSet/gender-identity-response-1')"/>
         <source value="http://hl7.org.au/fhir/StructureDefinition/au-practitioner" />
       </constraint>
       <constraint>
         <key value="inv-pra-3" />
         <severity value="warning" />
         <human value="Individual pronouns shall be a member of the Australian Pronouns value set if any codes within that value set can apply" />
-        <expression value="extension('http://hl7.org/fhir/StructureDefinition/individual-pronouns').empty() or extension('http://hl7.org/fhir/StructureDefinition/individual-pronouns').value.memberOf('https://healthterminologies.gov.au/fhir/ValueSet/australian-pronouns-1')"/>
+        <expression value="extension('http://hl7.org/fhir/StructureDefinition/individual-pronouns').empty() or extension('http://hl7.org/fhir/StructureDefinition/individual-pronouns').extension('value').value.memberOf('https://healthterminologies.gov.au/fhir/ValueSet/australian-pronouns-1')"/>
         <source value="http://hl7.org.au/fhir/StructureDefinition/au-practitioner" />
       </constraint>
       <constraint>
         <key value="inv-pra-4" />
         <severity value="warning" />
         <human value="Recorded sex or gender type shall be a member of the Common AU Recorded Sex or Gender Type value set if any codes within that value set can apply" />
-        <expression value="extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').empty() or extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').extension('type').empty() or extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').extension('type').value.memberOf('http://terminology.hl7.org.au/ValueSet/rsg-type')"/>
+        <expression value="extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').extension('type').empty() or extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').extension('type').value.memberOf('http://terminology.hl7.org.au/ValueSet/rsg-type')"/>
         <source value="http://hl7.org.au/fhir/StructureDefinition/au-practitioner" />
       </constraint>
       <constraint>
         <key value="inv-pra-5" />
         <severity value="warning" />
         <human value="Recorded sex or gender source document type shall be a member of the Common AU Recorded Sex or Gender (RSG) Source Document Type value set if any codes within that value set can apply" />
-        <expression value="extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').empty() or extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').extension('sourceDocument').empty() or extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').extension('sourceDocument').value.memberOf('http://terminology.hl7.org.au/ValueSet/rsg-document-type')"/>
+        <expression value="extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').extension('sourceDocument').empty() or extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').extension('sourceDocument').value.memberOf('http://terminology.hl7.org.au/ValueSet/rsg-document-type')"/>
         <source value="http://hl7.org.au/fhir/StructureDefinition/au-practitioner" />
       </constraint>
       <constraint>
         <key value="inv-pra-6" />
         <severity value="warning" />
         <human value="Recorded sex or gender jurisdiction shall be a member of the Common AU Recorded Sex or Gender (RSG) Source Document Jurisdiction value set if any codes within that value set can apply" />
-        <expression value="extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').empty() or extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').extension('jurisdiction').empty() or extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').extension('jurisdiction').value.memberOf('http://terminology.hl7.org.au/ValueSet/rsg-source-document-jurisdiction')"/>
+        <expression value="extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').extension('jurisdiction').empty() or extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').extension('jurisdiction').value.memberOf('http://terminology.hl7.org.au/ValueSet/rsg-source-document-jurisdiction')"/>
         <source value="http://hl7.org.au/fhir/StructureDefinition/au-practitioner" />
       </constraint>
     </element>

--- a/input/resources/au-practitioner.xml
+++ b/input/resources/au-practitioner.xml
@@ -22,35 +22,35 @@
         <key value="inv-pra-2" />
         <severity value="warning" />
         <human value="Individual gender identity shall be a member of the Gender Identity Response value set if any codes within that value set can apply" />
-        <expression value="extension('http://hl7.org/fhir/StructureDefinition/individual-genderIdentity').empty() or extension('http://hl7.org/fhir/StructureDefinition/individual-genderIdentity').extension('value').value.memberOf('https://healthterminologies.gov.au/fhir/ValueSet/gender-identity-response-1')"/>
+        <expression value="extension('http://hl7.org/fhir/StructureDefinition/individual-genderIdentity').empty() or extension('http://hl7.org/fhir/StructureDefinition/individual-genderIdentity').all(extension('value').value.memberOf('https://healthterminologies.gov.au/fhir/ValueSet/gender-identity-response-1'))"/>
         <source value="http://hl7.org.au/fhir/StructureDefinition/au-practitioner" />
       </constraint>
       <constraint>
         <key value="inv-pra-3" />
         <severity value="warning" />
         <human value="Individual pronouns shall be a member of the Australian Pronouns value set if any codes within that value set can apply" />
-        <expression value="extension('http://hl7.org/fhir/StructureDefinition/individual-pronouns').empty() or extension('http://hl7.org/fhir/StructureDefinition/individual-pronouns').extension('value').value.memberOf('https://healthterminologies.gov.au/fhir/ValueSet/australian-pronouns-1')"/>
+        <expression value="extension('http://hl7.org/fhir/StructureDefinition/individual-pronouns').empty() or extension('http://hl7.org/fhir/StructureDefinition/individual-pronouns').all(extension('value').value.memberOf('https://healthterminologies.gov.au/fhir/ValueSet/australian-pronouns-1'))"/>
         <source value="http://hl7.org.au/fhir/StructureDefinition/au-practitioner" />
       </constraint>
       <constraint>
         <key value="inv-pra-4" />
         <severity value="warning" />
         <human value="Recorded sex or gender type shall be a member of the Common AU Recorded Sex or Gender Type value set if any codes within that value set can apply" />
-        <expression value="extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').extension('type').empty() or extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').extension('type').value.memberOf('http://terminology.hl7.org.au/ValueSet/rsg-type')"/>
+        <expression value="extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').extension('type').empty() or extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').all(extension('type').value.memberOf('http://terminology.hl7.org.au/ValueSet/rsg-type'))"/>
         <source value="http://hl7.org.au/fhir/StructureDefinition/au-practitioner" />
       </constraint>
       <constraint>
         <key value="inv-pra-5" />
         <severity value="warning" />
         <human value="Recorded sex or gender source document type shall be a member of the Common AU Recorded Sex or Gender (RSG) Source Document Type value set if any codes within that value set can apply" />
-        <expression value="extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').extension('sourceDocument').empty() or extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').extension('sourceDocument').value.memberOf('http://terminology.hl7.org.au/ValueSet/rsg-document-type')"/>
+        <expression value="extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').extension('sourceDocument').empty() or extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').all(extension('sourceDocument').value.memberOf('http://terminology.hl7.org.au/ValueSet/rsg-document-type'))"/>
         <source value="http://hl7.org.au/fhir/StructureDefinition/au-practitioner" />
       </constraint>
       <constraint>
         <key value="inv-pra-6" />
         <severity value="warning" />
         <human value="Recorded sex or gender jurisdiction shall be a member of the Common AU Recorded Sex or Gender (RSG) Source Document Jurisdiction value set if any codes within that value set can apply" />
-        <expression value="extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').extension('jurisdiction').empty() or extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').extension('jurisdiction').value.memberOf('http://terminology.hl7.org.au/ValueSet/rsg-source-document-jurisdiction')"/>
+        <expression value="extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').extension('jurisdiction').empty() or extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').all(extension('jurisdiction').value.memberOf('http://terminology.hl7.org.au/ValueSet/rsg-source-document-jurisdiction'))"/>
         <source value="http://hl7.org.au/fhir/StructureDefinition/au-practitioner" />
       </constraint>
     </element>

--- a/input/resources/au-relatedperson.xml
+++ b/input/resources/au-relatedperson.xml
@@ -22,35 +22,35 @@
         <key value="inv-relper-0" />
         <severity value="warning" />
         <human value="Individual gender identity shall be a member of the Gender Identity Response value set if any codes within that value set can apply" />
-        <expression value="extension('http://hl7.org/fhir/StructureDefinition/individual-genderIdentity').empty() or extension('http://hl7.org/fhir/StructureDefinition/individual-genderIdentity').value.memberOf('https://healthterminologies.gov.au/fhir/ValueSet/gender-identity-response-1')"/>
+        <expression value="extension('http://hl7.org/fhir/StructureDefinition/individual-genderIdentity').empty() or extension('http://hl7.org/fhir/StructureDefinition/individual-genderIdentity').extension('value').value.memberOf('https://healthterminologies.gov.au/fhir/ValueSet/gender-identity-response-1')"/>
         <source value="http://hl7.org.au/fhir/StructureDefinition/au-relatedperson" />
       </constraint>
       <constraint>
         <key value="inv-relper-1" />
         <severity value="warning" />
         <human value="Individual pronouns shall be a member of the Australian Pronouns value set if any codes within that value set can apply" />
-        <expression value="extension('http://hl7.org/fhir/StructureDefinition/individual-pronouns').empty() or extension('http://hl7.org/fhir/StructureDefinition/individual-pronouns').value.memberOf('https://healthterminologies.gov.au/fhir/ValueSet/australian-pronouns-1')"/>
+        <expression value="extension('http://hl7.org/fhir/StructureDefinition/individual-pronouns').empty() or extension('http://hl7.org/fhir/StructureDefinition/individual-pronouns').extension('value').value.memberOf('https://healthterminologies.gov.au/fhir/ValueSet/australian-pronouns-1')"/>
         <source value="http://hl7.org.au/fhir/StructureDefinition/au-relatedperson" />
         </constraint>
          <constraint>
         <key value="inv-relper-2" />
         <severity value="warning" />
         <human value="Recorded sex or gender type shall be a member of the Common AU Recorded Sex or Gender Type value set if any codes within that value set can apply" />
-        <expression value="extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').empty() or extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').extension('type').empty() or extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').extension('type').value.memberOf('http://terminology.hl7.org.au/ValueSet/rsg-type')"/>
+        <expression value="extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').extension('type').empty() or extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').extension('type').value.memberOf('http://terminology.hl7.org.au/ValueSet/rsg-type')"/>
         <source value="http://hl7.org.au/fhir/StructureDefinition/au-relatedperson" />
       </constraint>
       <constraint>
           <key value="inv-relper-3" />
           <severity value="warning" />
           <human value="Recorded sex or gender source document type shall be a member of the Common AU Recorded Sex or Gender (RSG) Source Document Type value set if any codes within that value set can apply" />
-          <expression value="extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').empty() or extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').extension('sourceDocument').empty() or extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').extension('sourceDocument').value.memberOf('http://terminology.hl7.org.au/ValueSet/rsg-source-document-type')"/>
+          <expression value="extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').extension('sourceDocument').empty() or extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').extension('sourceDocument').value.memberOf('http://terminology.hl7.org.au/ValueSet/rsg-source-document-type')"/>
           <source value="http://hl7.org.au/fhir/StructureDefinition/au-relatedperson" />
       </constraint>
       <constraint>
           <key value="inv-relper-4" />
           <severity value="warning" />
           <human value="Recorded sex or gender jurisdiction shall be a member of the Common AU Recorded Sex or Gender (RSG) Source Document Jurisdiction value set if any codes within that value set can apply" />
-          <expression value="extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').empty() or extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').extension('jurisdiction').empty() or extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').extension('jurisdiction').value.memberOf('http://terminology.hl7.org.au/ValueSet/rsg-source-document-jurisdiction')"/> 
+        <expression value="extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').extension('jurisdiction').empty() or extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').extension('jurisdiction').value.memberOf('http://terminology.hl7.org.au/ValueSet/rsg-source-document-jurisdiction')"/>
           <source value="http://hl7.org.au/fhir/StructureDefinition/au-relatedperson" />
         </constraint>
     </element>

--- a/input/resources/au-relatedperson.xml
+++ b/input/resources/au-relatedperson.xml
@@ -22,35 +22,35 @@
         <key value="inv-relper-0" />
         <severity value="warning" />
         <human value="Individual gender identity shall be a member of the Gender Identity Response value set if any codes within that value set can apply" />
-        <expression value="extension('http://hl7.org/fhir/StructureDefinition/individual-genderIdentity').empty() or extension('http://hl7.org/fhir/StructureDefinition/individual-genderIdentity').extension('value').value.memberOf('https://healthterminologies.gov.au/fhir/ValueSet/gender-identity-response-1')"/>
+        <expression value="extension('http://hl7.org/fhir/StructureDefinition/individual-genderIdentity').empty() or extension('http://hl7.org/fhir/StructureDefinition/individual-genderIdentity').all(extension('value').value.memberOf('https://healthterminologies.gov.au/fhir/ValueSet/gender-identity-response-1'))"/>
         <source value="http://hl7.org.au/fhir/StructureDefinition/au-relatedperson" />
       </constraint>
       <constraint>
         <key value="inv-relper-1" />
         <severity value="warning" />
         <human value="Individual pronouns shall be a member of the Australian Pronouns value set if any codes within that value set can apply" />
-        <expression value="extension('http://hl7.org/fhir/StructureDefinition/individual-pronouns').empty() or extension('http://hl7.org/fhir/StructureDefinition/individual-pronouns').extension('value').value.memberOf('https://healthterminologies.gov.au/fhir/ValueSet/australian-pronouns-1')"/>
+        <expression value="extension('http://hl7.org/fhir/StructureDefinition/individual-pronouns').empty() or extension('http://hl7.org/fhir/StructureDefinition/individual-pronouns').all(extension('value').value.memberOf('https://healthterminologies.gov.au/fhir/ValueSet/australian-pronouns-1'))"/>
         <source value="http://hl7.org.au/fhir/StructureDefinition/au-relatedperson" />
         </constraint>
          <constraint>
         <key value="inv-relper-2" />
         <severity value="warning" />
         <human value="Recorded sex or gender type shall be a member of the Common AU Recorded Sex or Gender Type value set if any codes within that value set can apply" />
-        <expression value="extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').extension('type').empty() or extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').extension('type').value.memberOf('http://terminology.hl7.org.au/ValueSet/rsg-type')"/>
+        <expression value="extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').extension('type').empty() or extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').all(extension('type').value.memberOf('http://terminology.hl7.org.au/ValueSet/rsg-type'))"/>
         <source value="http://hl7.org.au/fhir/StructureDefinition/au-relatedperson" />
       </constraint>
       <constraint>
           <key value="inv-relper-3" />
           <severity value="warning" />
           <human value="Recorded sex or gender source document type shall be a member of the Common AU Recorded Sex or Gender (RSG) Source Document Type value set if any codes within that value set can apply" />
-          <expression value="extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').extension('sourceDocument').empty() or extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').extension('sourceDocument').value.memberOf('http://terminology.hl7.org.au/ValueSet/rsg-source-document-type')"/>
+          <expression value="extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').extension('sourceDocument').empty() or extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').all(extension('sourceDocument').value.memberOf('http://terminology.hl7.org.au/ValueSet/rsg-source-document-type'))"/>
           <source value="http://hl7.org.au/fhir/StructureDefinition/au-relatedperson" />
       </constraint>
       <constraint>
           <key value="inv-relper-4" />
           <severity value="warning" />
           <human value="Recorded sex or gender jurisdiction shall be a member of the Common AU Recorded Sex or Gender (RSG) Source Document Jurisdiction value set if any codes within that value set can apply" />
-        <expression value="extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').extension('jurisdiction').empty() or extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').extension('jurisdiction').value.memberOf('http://terminology.hl7.org.au/ValueSet/rsg-source-document-jurisdiction')"/>
+        <expression value="extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').extension('jurisdiction').empty() or extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').all(extension('jurisdiction').value.memberOf('http://terminology.hl7.org.au/ValueSet/rsg-source-document-jurisdiction'))"/>
           <source value="http://hl7.org.au/fhir/StructureDefinition/au-relatedperson" />
         </constraint>
     </element>


### PR DESCRIPTION
This PR addresses https://jira.hl7.org/browse/FHIR-46176. 

- Updated invariant expressions related to genderIdentity and individualPronouns in AU Base Patient, AU Base RelatedPerson and AU Base Practitioner:
  - added missing structure
  - added function .all() to apply the condition to each instance of the extension
- Updated invariant expressions related to recordedSexOrGender in AU Base Patient, AU Base RelatedPerson and AU Base Practitioner:
  - removed empty check 
  - added function .all() to apply the condition to each instance of the extension
   
