### PR TITLE
Fixes for FHIR-46428: changed codesystem & example

### DIFF
--- a/input/examples/practitioner-example-sex-and-gender.xml
+++ b/input/examples/practitioner-example-sex-and-gender.xml
@@ -45,7 +45,7 @@
             <valueCodeableConcept>
                 <coding>
                     <system value="http://terminology.hl7.org.au/CodeSystem/rsg-type"/>
-                    <code value="Sex/Gender"/>
+                    <code value="sex-gender"/>
                 </coding>
             </valueCodeableConcept>
         </extension>

--- a/input/examples/practitioner-example-sex-and-gender.xml
+++ b/input/examples/practitioner-example-sex-and-gender.xml
@@ -45,8 +45,7 @@
             <valueCodeableConcept>
                 <coding>
                     <system value="http://terminology.hl7.org.au/CodeSystem/rsg-type"/>
-                    <code value="au-ahpra"/>
-                    <display value="Australian Health Practitioner Regulation Agency"/>
+                    <code value="Sex/Gender"/>
                 </coding>
             </valueCodeableConcept>
         </extension>

--- a/input/resources/codesystem-rsg-type.xml
+++ b/input/resources/codesystem-rsg-type.xml
@@ -23,72 +23,9 @@
     <compositional value="false" />
     <versionNeeded value="false" />
     <content value="complete" /> 
-    <property>
-        <code value="not-selectable"/>
-        <uri value="http://hl7.org/fhir/concept-properties#notSelectable"/>
-        <description value="Codes with this property set are not intended to appear in instances. They are for grouping/subsetting purposes only."/>
-        <type value="boolean"/>
-    </property>
     <concept>
        <code value="sex-gender"/>
         <display value="Sex/Gender"/>
         <definition value="A sex or gender recorded as an interchangeable sex and/or gender value."/>
-    </concept>
-    <concept>
-       <code value="document"/>
-        <display value="Document"/>
-        <definition value="Sex or gender recorded in a document."/>
-    </concept>
-    <concept>
-        <code value="insurance-scheme"/>
-        <display value="Insurance Scheme"/>
-        <definition value="The sex or gender recorded through enrolment in an insurance scheme."/>
-        <property>
-          <code value="not-selectable"/>
-          <valueBoolean value="true"/>
-        </property>
-        <concept>
-            <code value="au-medicare"/>
-            <display value="Australian Medicare"/>
-            <definition value="The sex or gender recorded through enrolment in the Australian Medicare universal healthcare insurance scheme."/>
-        </concept>       
-    </concept>
-    <concept>
-        <code value="registration-and-accreditation-scheme"/>
-        <display value="Registration and accreditation scheme"/>
-        <definition value="The sex or gender recorded through registration in a registration and/or accreditation scheme."/>
-        <property>
-          <code value="not-selectable"/>
-          <valueBoolean value="true"/>
-        </property>
-        <concept>
-            <code value="au-ahpra"/>
-            <display value="Australian Health Practitioner Regulation Agency"/>
-            <definition value="The sex or gender recorded through registration in the Australian Health Practitioner Regulation Agency (AHPRA) registration and accreditation scheme."/>
-        </concept>       
-    </concept>
-    <concept>
-        <code value="digital-health-infrastructure-service"/>
-        <display value="Digital Health Infrastructure Service"/>
-        <definition value="The sex or gender recorded in a digital health infrastructure service."/>
-        <property>
-          <code value="not-selectable"/>
-          <valueBoolean value="true"/>
-        </property>
-        <concept>
-            <code value="au-hi-service"/>
-            <display value="Australian Healthcare Identifiers Service"/>
-            <definition value="The sex or gender recorded in the Australian Healthcare Identifiers (HI) Service."/>
-        </concept>
-        <concept>
-            <code value="au-my-health-record"/>
-            <display value="Australian My Health Record System"/>
-            <definition value="The sex or gender recorded in the Australian My Health Record System."/>
-        </concept>
-        <concept>
-            <code value="au-nhsd"/>
-            <display value="Australian National Health Services Directory"/>
-            <definition value="The sex or gender recorded in the Australian National Health Services Directory (NHSD)."/>
-        </concept>           
     </concept>
 </CodeSystem>


### PR DESCRIPTION
This PR partially addresses [FHIR-46428](https://jira.hl7.org/browse/FHIR-46428) Recorded Sex or Gender type should not be populated with source values:
- changed AU rsg type code system as per JIRA
- updated Practitioner sex-gender example (only example to use the AU rsg type code system)

NOTE: The guidance part of FHIR-46428 will be addressed in a separate PR that will handle the AU Base sex & gender guidance changes.