### PR TITLE
Add new identifier profiles to Coverage.identifier (FHIR-47191)

### DIFF
--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -93,6 +93,7 @@ To help implementers, only the more significant changes are listed here.
     </ul>
   </li>
   <li>Changed context of extension <a href="StructureDefinition-indigenous-status.html">Australian Indigenous Status</a> to add Person and RelatedPerson.</li>
+  <li>Added AU Pensioner Concession Card Number, AU Commonwealth Seniors Health Card Number and AU Health Care Card Number to Coverage.identifier in <a href="StructureDefinition-au-coverage.html">AU Base Coverage</a> (<a href="https://jira.hl7.org/browse/FHIR-47191">FHIR-47191</a>).</li>
   <li>Changed Observation.code to add additional bindings for component value sets in <a href="StructureDefinition-au-pathologyresult.html">AU Base Pathology Result</a> (<a href="https://jira.hl7.org/browse/FHIR-46080">FHIR-46080</a>).</li>
   <li>Changed Medication.code to replace slices with Additional Bindings as 'preferred' in <a href="StructureDefinition-au-medication.html">AU Base Medication</a> (<a href="https://jira.hl7.org/browse/FHIR-44823">FHIR-44823</a>).</li>
   <li>Changed MedicationAdministration.medicationCodeableConcept to replace slices with Additional Bindings as 'preferred' in <a href="StructureDefinition-au-medicationadministration.html">AU Base Medication Administration</a> (<a href="https://jira.hl7.org/browse/FHIR-44823">FHIR-44823</a>).</li>

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -93,7 +93,7 @@ To help implementers, only the more significant changes are listed here.
     </ul>
   </li>
   <li>Changed context of extension <a href="StructureDefinition-indigenous-status.html">Australian Indigenous Status</a> to add Person and RelatedPerson.</li>
-  <li>Added AU Pensioner Concession Card Number, AU Commonwealth Seniors Health Card Number and AU Health Care Card Number to Coverage.identifier in <a href="StructureDefinition-au-coverage.html">AU Base Coverage</a> (<a href="https://jira.hl7.org/browse/FHIR-47191">FHIR-47191</a>).</li>
+  <li>Changed Coverage.identifier type in <a href="StructureDefinition-au-coverage.html">AU Base Coverage</a> to add AU Pensioner Concession Card Number, AU Commonwealth Seniors Health Card Number and AU Health Care Card Number (<a href="https://jira.hl7.org/browse/FHIR-47191">FHIR-47191</a>).</li>
   <li>Changed Observation.code to add additional bindings for component value sets in <a href="StructureDefinition-au-pathologyresult.html">AU Base Pathology Result</a> (<a href="https://jira.hl7.org/browse/FHIR-46080">FHIR-46080</a>).</li>
   <li>Changed Medication.code to replace slices with Additional Bindings as 'preferred' in <a href="StructureDefinition-au-medication.html">AU Base Medication</a> (<a href="https://jira.hl7.org/browse/FHIR-44823">FHIR-44823</a>).</li>
   <li>Changed MedicationAdministration.medicationCodeableConcept to replace slices with Additional Bindings as 'preferred' in <a href="StructureDefinition-au-medicationadministration.html">AU Base Medication Administration</a> (<a href="https://jira.hl7.org/browse/FHIR-44823">FHIR-44823</a>).</li>

--- a/input/resources/au-coverage.xml
+++ b/input/resources/au-coverage.xml
@@ -26,6 +26,9 @@
         <profile value="http://hl7.org.au/fhir/StructureDefinition/au-medicarecardnumber" />
         <profile value="http://hl7.org.au/fhir/StructureDefinition/au-dvanumber" />
         <profile value="http://hl7.org.au/fhir/StructureDefinition/au-insurancemembernumber" />
+        <profile value="http://hl7.org.au/fhir/StructureDefinition/au-pensionerconcessioncardnumber" />
+        <profile value="http://hl7.org.au/fhir/StructureDefinition/au-cwlthseniorshealthcardnumber" />
+        <profile value="http://hl7.org.au/fhir/StructureDefinition/au-healthcarecardnumber" />
       </type>
     </element>
   </differential>


### PR DESCRIPTION
Fix for [FHIR-47191](https://jira.hl7.org/browse/FHIR-47191)

* Add AU Pensioner Concession Card Number, AU Commonwealth Seniors Health Card Number, AU Health Care Card Number to AU Base Coverage.identifier.
* Change log entry