### PR TITLE
Change CodeSystems and ValueSets to use meta profile Complete CodeSystem 4 and Composed ValueSet 4

### DIFF
--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -115,6 +115,10 @@ To help implementers, only the more significant changes are listed here.
       <li><a href="StructureDefinition-name-context.html">Name Context</a> extension, <a href="ValueSet-name-context.html">Name Context</a> value set, <a href="CodeSystem-name-context.html">Name Context</a> code system (<a href="https://jira.hl7.org/browse/FHIR-46535">FHIR-46535</a>)</li>
     </ul>
   </li>
+  <li>CodeSystem and ValueSet profile changed to align with NCTS <a href="https://healthterminologies.gov.au/fhir/StructureDefinition/complete-code-system-4">Complete CodeSystem 4</a> and <a href="https://healthterminologies.gov.au/fhir/StructureDefinition/composed-value-set-4"> Composed ValueSet 4</a> (<a href="https://jira.hl7.org/browse/FHIR-47148">FHIR-47148</a> and <a href="https://jira.hl7.org/browse/FHIR-47149">FHIR-47149</a>) 
+  </li>
+  <li>CodeSystem properties updated to align with NCTS <a href="https://healthterminologies.gov.au/fhir/StructureDefinition/complete-code-system-4">Complete CodeSystem 4</a> (<a href="https://jira.hl7.org/browse/FHIR-47148">FHIR-47148</a>) 
+  </li>
 </ul>
 
 ### Release 4.1.0

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -117,7 +117,7 @@ To help implementers, only the more significant changes are listed here.
   </li>
   <li>Updated AU Base CodeSystem resources to remove conformance to HL7 International <a href="http://hl7.org/fhir/StructureDefinition/shareablecodesystem">ShareableCodeSystem</a> and instead claim conformance to <a href="https://healthterminologies.gov.au/fhir/StructureDefinition/complete-code-system-4"> NCTS Complete CodeSystem</a> (<a href="https://jira.hl7.org/browse/FHIR-47148">FHIR-47148</a>) 
   </li>
-  <li>ValueSet profile updated to remove conformance to HL7 International <a href="http://hl7.org/fhir/StructureDefinition/shareablevalueset">ShareableValueSet</a> and instead claim conformance to <a href="https://healthterminologies.gov.au/fhir/StructureDefinition/composed-value-set-4"> NCTS Composed ValueSet</a> (<a href="https://jira.hl7.org/browse/FHIR-47149">FHIR-47149</a>) 
+  <li>Updated AU Base ValueSet resources to remove conformance to HL7 International <a href="http://hl7.org/fhir/StructureDefinition/shareablevalueset">ShareableValueSet</a> and instead claim conformance to <a href="https://healthterminologies.gov.au/fhir/StructureDefinition/composed-value-set-4"> NCTS Composed ValueSet</a> (<a href="https://jira.hl7.org/browse/FHIR-47149">FHIR-47149</a>) 
   </li>
 </ul>
 

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -115,9 +115,9 @@ To help implementers, only the more significant changes are listed here.
       <li><a href="StructureDefinition-name-context.html">Name Context</a> extension, <a href="ValueSet-name-context.html">Name Context</a> value set, <a href="CodeSystem-name-context.html">Name Context</a> code system (<a href="https://jira.hl7.org/browse/FHIR-46535">FHIR-46535</a>)</li>
     </ul>
   </li>
-  <li>CodeSystem profile and properties updated to conform to <a href="https://healthterminologies.gov.au/fhir/StructureDefinition/complete-code-system-4"> NCTS Complete CodeSystem</a> (<a href="https://jira.hl7.org/browse/FHIR-47148">FHIR-47148</a>) 
+  <li>Updated AU Base CodeSystem resources to remove conformance to HL7 International <a href="http://hl7.org/fhir/StructureDefinition/shareablecodesystem">ShareableCodeSystem</a> and instead claim conformance to <a href="https://healthterminologies.gov.au/fhir/StructureDefinition/complete-code-system-4"> NCTS Complete CodeSystem</a> (<a href="https://jira.hl7.org/browse/FHIR-47148">FHIR-47148</a>) 
   </li>
-  <li>ValueSet profile updated to conform to <a href="https://healthterminologies.gov.au/fhir/StructureDefinition/composed-value-set-4"> NCTS Composed ValueSet</a> (<a href="https://jira.hl7.org/browse/FHIR-47149">FHIR-47149</a>) 
+  <li>ValueSet profile updated to remove conformance to HL7 International <a href="http://hl7.org/fhir/StructureDefinition/shareablevalueset">ShareableValueSet</a> and instead claim conformance to <a href="https://healthterminologies.gov.au/fhir/StructureDefinition/composed-value-set-4"> NCTS Composed ValueSet</a> (<a href="https://jira.hl7.org/browse/FHIR-47149">FHIR-47149</a>) 
   </li>
 </ul>
 

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -115,9 +115,9 @@ To help implementers, only the more significant changes are listed here.
       <li><a href="StructureDefinition-name-context.html">Name Context</a> extension, <a href="ValueSet-name-context.html">Name Context</a> value set, <a href="CodeSystem-name-context.html">Name Context</a> code system (<a href="https://jira.hl7.org/browse/FHIR-46535">FHIR-46535</a>)</li>
     </ul>
   </li>
-  <li>CodeSystem and ValueSet profile changed to align with NCTS <a href="https://healthterminologies.gov.au/fhir/StructureDefinition/complete-code-system-4">Complete CodeSystem 4</a> and <a href="https://healthterminologies.gov.au/fhir/StructureDefinition/composed-value-set-4"> Composed ValueSet 4</a> (<a href="https://jira.hl7.org/browse/FHIR-47148">FHIR-47148</a> and <a href="https://jira.hl7.org/browse/FHIR-47149">FHIR-47149</a>) 
+  <li>CodeSystem profile and properties updated to conform to <a href="https://healthterminologies.gov.au/fhir/StructureDefinition/complete-code-system-4"> NCTS Complete CodeSystem</a> (<a href="https://jira.hl7.org/browse/FHIR-47148">FHIR-47148</a>) 
   </li>
-  <li>CodeSystem properties updated to align with NCTS <a href="https://healthterminologies.gov.au/fhir/StructureDefinition/complete-code-system-4">Complete CodeSystem 4</a> (<a href="https://jira.hl7.org/browse/FHIR-47148">FHIR-47148</a>) 
+  <li>ValueSet profile updated to conform to <a href="https://healthterminologies.gov.au/fhir/StructureDefinition/composed-value-set-4"> NCTS Composed ValueSet</a> (<a href="https://jira.hl7.org/browse/FHIR-47149">FHIR-47149</a>) 
   </li>
 </ul>
 

--- a/input/resources/CodeSystem-name-context.xml
+++ b/input/resources/CodeSystem-name-context.xml
@@ -1,32 +1,39 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CodeSystem xmlns="http://hl7.org/fhir">
-  <id value="name-context"/>
+  <id value="name-context" />
   <meta>
-    <profile value="http://hl7.org/fhir/StructureDefinition/shareablecodesystem"/>
+    <profile
+      value="https://healthterminologies.gov.au/fhir/StructureDefinition/complete-code-system-4" />
   </meta>
   <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
-    <valueInteger value="1"/>
+    <valueInteger value="1" />
   </extension>
-  <url value="http://terminology.hl7.org.au/CodeSystem/name-context"/>
+  <url value="http://terminology.hl7.org.au/CodeSystem/name-context" />
   <identifier>
-    <system value="urn:ietf:rfc:3986"/>
-    <value value="urn:oid:2.16.840.1.113883.2.3.4.1.4.31"/>
+    <system value="urn:ietf:rfc:3986" />
+    <value value="urn:oid:2.16.840.1.113883.2.3.4.1.4.31" />
   </identifier>
-  <name value="NameContext"/>
-  <title value="Name Context"/>
-  <status value="active"/>
-  <experimental value="false"/>
-  <description value="The Name Context code system defines concepts describing usage of names. This provides well known concepts that can be used to indicate usage to achieve an associated purpose e.g. identifier validation or (in)appropriate cultural, religious or social usage of names."/>
-  <caseSensitive value="true"/>
-  <content value="complete"/>
+  <name value="NameContext" />
+  <title value="Name Context" />
+  <status value="active" />
+  <experimental value="false" />
+  <description
+    value="The Name Context code system defines concepts describing usage of names. This provides well known concepts that can be used to indicate usage to achieve an associated purpose e.g. identifier validation or (in)appropriate cultural, religious or social usage of names." />
+  <caseSensitive value="true" />
+  <compositional value="false" />
+  <versionNeeded value="false" />
+  <count value="2" />
+  <content value="complete" />
   <concept>
-    <code value="ihi-validation"/>
-    <display value="IHI Validation"/>
-    <definition value="Indicates associated name is for IHI (Individual Healthcare Identifier) validation."/>
+    <code value="ihi-validation" />
+    <display value="IHI Validation" />
+    <definition
+      value="Indicates associated name is for IHI (Individual Healthcare Identifier) validation." />
   </concept>
   <concept>
-    <code value="hpii-validation"/>
-    <display value="HPI-I Validation"/>
-    <definition value="Indicates associated name is for HPI-I (Healthcare Provider Identifier - Individual) validation."/>
+    <code value="hpii-validation" />
+    <display value="HPI-I Validation" />
+    <definition
+      value="Indicates associated name is for HPI-I (Healthcare Provider Identifier - Individual) validation." />
   </concept>
 </CodeSystem>

--- a/input/resources/ValueSet-name-context.xml
+++ b/input/resources/ValueSet-name-context.xml
@@ -2,7 +2,7 @@
 <ValueSet xmlns="http://hl7.org/fhir">
   <id value="name-context"/>
   <meta>
-    <profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset"/>
+    <profile value="https://healthterminologies.gov.au/fhir/StructureDefinition/composed-value-set-4"/>
   </meta>
   <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
     <valueInteger value="1"/>

--- a/input/resources/codesystem-au-location-physical-type.xml
+++ b/input/resources/codesystem-au-location-physical-type.xml
@@ -1,55 +1,59 @@
 <CodeSystem xmlns="http://hl7.org/fhir">
 	<id value="au-location-physical-type" />
 	<meta>
-		<profile value="http://hl7.org/fhir/StructureDefinition/shareablecodesystem" />
+		<profile
+			value="https://healthterminologies.gov.au/fhir/StructureDefinition/complete-code-system-4" />
 	</meta>
 	<extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
-		<valueInteger value="1"/>
+		<valueInteger value="1" />
 	</extension>
 	<url value="http://terminology.hl7.org.au/CodeSystem/location-physical-type" />
-	<identifier> 
-		<system value="urn:ietf:rfc:3986"/> 
-		<value value="urn:oid:2.16.840.1.113883.2.3.4.1.4.25"/> 
+	<identifier>
+		<system value="urn:ietf:rfc:3986" />
+		<value value="urn:oid:2.16.840.1.113883.2.3.4.1.4.25" />
 	</identifier>
 	<name value="LocationTypePhysicalAU" />
 	<title value="Location Type (Physical) AU" />
 	<status value="active" />
-	<experimental value="false"/>
+	<experimental value="false" />
 	<description
 		value="Additional concept codes for location physical type defined for use in Australian context. These codes are used as extensions to the HL7 International code set." />
 	<caseSensitive value="true" />
-	<valueSet value="http://terminology.hl7.org.au/ValueSet/location-physical-type"/>
+	<valueSet value="http://terminology.hl7.org.au/ValueSet/location-physical-type" />
 	<compositional value="false" />
 	<versionNeeded value="false" />
+	<count value="1" />
 	<content value="complete" />
-	<property> 
-		<code value="status"/> 
-		<uri value="http://hl7.org/fhir/concept-properties#status"/> 
-		<description value="A property that indicates the status of the concept. One of active, experimental,
-		deprecated, retired"/> 
-		<type value="code"/> 
-	</property> 
-	<property> 
-		<code value="deprecationDate"/> 
-		<uri value="http://hl7.org/fhir/concept-properties#deprecationDate"/> 
-		<description value="The date at which a concept was deprecated. Concepts that are deprecated but not
-		inactive can still be used, but their use is discouraged"/> 
-		<type value="dateTime"/> 
-	</property> 
+	<property>
+		<code value="status" />
+		<uri value="http://hl7.org/fhir/concept-properties#status" />
+		<description
+			value="A property that indicates the status of the concept. One of active, experimental,
+		deprecated, retired" />
+		<type value="code" />
+	</property>
+	<property>
+		<code value="deprecationDate" />
+		<uri value="http://hl7.org/fhir/concept-properties#deprecationDate" />
+		<description
+			value="The date at which a concept was deprecated. Concepts that are deprecated but not
+		inactive can still be used, but their use is discouraged" />
+		<type value="dateTime" />
+	</property>
 	<concept>
 		<code value="vi" />
 		<display value="Virtual" />
 		<definition
 			value="Location of services delivered at a virtual location, such as by phone or on-line.
 ***Deprecation Comment:*** This code has been deprecated as it has been replaced by an equivalent term provided by HL7 international."
-		 />
-		 <property>
-      			<code value="status"/>
-     			 <valueCode value="deprecated"/>
-   		 </property>
-		  <property>
-      			<code value="deprecationDate"/>
-      			<valueDateTime value="2023-02-15"/>
-    		</property>
+		/>
+		<property>
+			<code value="status" />
+			<valueCode value="deprecated" />
+		</property>
+		<property>
+			<code value="deprecationDate" />
+			<valueDateTime value="2023-02-15" />
+		</property>
 	</concept>
 </CodeSystem>

--- a/input/resources/codesystem-au-location-type.xml
+++ b/input/resources/codesystem-au-location-type.xml
@@ -1,7 +1,7 @@
 <CodeSystem xmlns="http://hl7.org/fhir">
 	<id value="au-location-type" />
 	<meta>
-		<profile value="http://hl7.org/fhir/StructureDefinition/shareablecodesystem" />
+		<profile value="https://healthterminologies.gov.au/fhir/StructureDefinition/complete-code-system-4" />
 	</meta>
 	<extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
 		<valueInteger value="1"/>
@@ -20,6 +20,7 @@
 	<valueSet value="http://terminology.hl7.org.au/ValueSet/location-type"/>
 	<compositional value="false" />
 	<versionNeeded value="false" />
+	<count value="1" />
 	<content value="complete" />
 	<concept>
 		<code value="VI" />

--- a/input/resources/codesystem-au-observation-category.xml
+++ b/input/resources/codesystem-au-observation-category.xml
@@ -1,29 +1,33 @@
 <CodeSystem xmlns="http://hl7.org/fhir">
-	<id value="au-observation-category"/>
+	<id value="au-observation-category" />
 	<meta>
-		<profile value="http://hl7.org/fhir/StructureDefinition/shareablecodesystem"/>
+		<profile
+			value="https://healthterminologies.gov.au/fhir/StructureDefinition/complete-code-system-4" />
 	</meta>
 	<extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
-		<valueInteger value="1"/>
+		<valueInteger value="1" />
 	</extension>
-	<url value="http://terminology.hl7.org.au/CodeSystem/observation-category"/>
-	<identifier> 
-		<system value="urn:ietf:rfc:3986"/> 
-		<value value="urn:oid:2.16.840.1.113883.2.3.4.1.4.27"/> 
-	</identifier> 
-	<name value="ObservationCategoryCodesAU"/>
-	<title value="Observation Category Codes AU"/>
-	<status value="draft"/>
-	<experimental value="false"/>
-	<description value="Additional concept codes for observation category codes defined for use in an Australian context. These codes are used as extensions to the HL7 International code set."/>
-	<caseSensitive value="true"/>
-	<valueSet value="http://terminology.hl7.org.au/ValueSet/observation-category"/>
-	<compositional value="false"/>
-	<versionNeeded value="false"/>
-	<content value="complete"/>
+	<url value="http://terminology.hl7.org.au/CodeSystem/observation-category" />
+	<identifier>
+		<system value="urn:ietf:rfc:3986" />
+		<value value="urn:oid:2.16.840.1.113883.2.3.4.1.4.27" />
+	</identifier>
+	<name value="ObservationCategoryCodesAU" />
+	<title value="Observation Category Codes AU" />
+	<status value="draft" />
+	<experimental value="false" />
+	<description
+		value="Additional concept codes for observation category codes defined for use in an Australian context. These codes are used as extensions to the HL7 International code set." />
+	<caseSensitive value="true" />
+	<valueSet value="http://terminology.hl7.org.au/ValueSet/observation-category" />
+	<compositional value="false" />
+	<versionNeeded value="false" />
+	<count value="1" />
+	<content value="complete" />
 	<concept>
-		<code value="program"/>
-		<display value="Program"/>
-		<definition value="Observations that describe an individual’s participation in one or more health programs such as treatment or prevention or public health (e.g. disease screening or substance use therapy)."/>
+		<code value="program" />
+		<display value="Program" />
+		<definition
+			value="Observations that describe an individual’s participation in one or more health programs such as treatment or prevention or public health (e.g. disease screening or substance use therapy)." />
 	</concept>
 </CodeSystem>

--- a/input/resources/codesystem-au-v2-0203.xml
+++ b/input/resources/codesystem-au-v2-0203.xml
@@ -1,7 +1,7 @@
 <CodeSystem xmlns="http://hl7.org/fhir">
 	<id value="au-v2-0203"/>
 	<meta>
-		<profile value="http://hl7.org/fhir/StructureDefinition/shareablecodesystem"/>
+		<profile value="https://healthterminologies.gov.au/fhir/StructureDefinition/complete-code-system-4"/>
 	</meta>
 	<extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
 		<valueInteger value="2"/>
@@ -21,6 +21,7 @@
 	<compositional value="false"/>
 	<versionNeeded value="true"/>
 	<content value="complete"/>
+	<count value="27" />
 	<concept>
 		<code value="AHPRA"/>
 		<display value="Australian Health Practitioner Regulation Agency Registration Number"/>

--- a/input/resources/codesystem-au-v2-0360.xml
+++ b/input/resources/codesystem-au-v2-0360.xml
@@ -1,10 +1,10 @@
 <CodeSystem xmlns="http://hl7.org/fhir">
 	<id value="au-v2-0360" />
 	<meta>
-		<profile value="http://hl7.org/fhir/StructureDefinition/shareablecodesystem"/>
+		<profile value="https://healthterminologies.gov.au/fhir/StructureDefinition/complete-code-system-4" />
 	</meta>
 	<extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
-		<valueInteger value="1"/>
+		<valueInteger value="1" />
 	</extension>
 	<url value="http://terminology.hl7.org.au/CodeSystem/v2-0360" />
 	<identifier>
@@ -14,12 +14,14 @@
 	<name value="DegreeLicenseCertificateAU" />
 	<title value="DegreeLicenseCertificate AU" />
 	<status value="active" />
-	<experimental value="false"/>
-	<description value="Additional concept codes for qualification defined for use in an Australian context. These codes are used as extensions to the HL7 International code set." />
+	<experimental value="false" />
+	<description
+		value="Additional concept codes for qualification defined for use in an Australian context. These codes are used as extensions to the HL7 International code set." />
 	<caseSensitive value="true" />
-	<valueSet value="http://terminology.hl7.org.au/ValueSet/v2-0360"/>
+	<valueSet value="http://terminology.hl7.org.au/ValueSet/v2-0360" />
 	<compositional value="false" />
 	<versionNeeded value="true" />
+	<count value="2" />
 	<content value="complete" />
 	<concept>
 		<code value="AUAHPRAProfession" />
@@ -28,12 +30,12 @@
 			value="An Australian Health Practitioner Regulation Authority (Ahpra) profession." />
 		<designation>
 			<use>
-				<system value="http://snomed.info/sct"/>
-				<code value="900000000000013009"/>
+				<system value="http://snomed.info/sct" />
+				<code value="900000000000013009" />
 			</use>
-			<value value="Ahpra Profession"/>
+			<value value="Ahpra Profession" />
 		</designation>
-	</concept>	
+	</concept>
 	<concept>
 		<code value="AUAHPRARegistration" />
 		<display value="AHPRA Registration" />
@@ -41,10 +43,10 @@
 			value="An Australian Health Practitioner Regulation Authority (Ahpra) registration." />
 		<designation>
 			<use>
-				<system value="http://snomed.info/sct"/>
-				<code value="900000000000013009"/>
+				<system value="http://snomed.info/sct" />
+				<code value="900000000000013009" />
 			</use>
-			<value value="Ahpra Registration"/>
+			<value value="Ahpra Registration" />
 		</designation>
 	</concept>
 </CodeSystem>

--- a/input/resources/codesystem-au-v2-0443.xml
+++ b/input/resources/codesystem-au-v2-0443.xml
@@ -1,29 +1,31 @@
 <CodeSystem xmlns="http://hl7.org/fhir">
-	<id value="au-v2-0443"/>
+	<id value="au-v2-0443" />
 	<meta>
-		<profile value="http://hl7.org/fhir/StructureDefinition/shareablecodesystem"/>
+		<profile value="https://healthterminologies.gov.au/fhir/StructureDefinition/complete-code-system-4" />
 	</meta>
 	<extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
-		<valueInteger value="2"/>
+		<valueInteger value="2" />
 	</extension>
-	<url value="http://terminology.hl7.org.au/CodeSystem/v2-0443"/>
+	<url value="http://terminology.hl7.org.au/CodeSystem/v2-0443" />
 	<identifier>
-		<system value="urn:ietf:rfc:3986"/>
-		<value value="urn:oid:2.16.840.1.113883.2.3.4.1.3.443"/>
+		<system value="urn:ietf:rfc:3986" />
+		<value value="urn:oid:2.16.840.1.113883.2.3.4.1.3.443" />
 	</identifier>
-	<name value="ProviderRoleAU"/>
-	<title value="providerRole AU"/>
-	<status value="active"/>
-	<experimental value="false"/>
-	<description value="Additional concept codes for specifying the functional involvement with the activity being transmitted (e.g., Case Manager, Evaluator, Transcriber, Nurse Care Practitioner, Midwife, Physician Assistant, etc.) defined for use in an Australian context. These codes are used as extensions to the HL7 International code set."/>
-	<caseSensitive value="true"/>
-	<valueSet value="http://terminology.hl7.org.au/ValueSet/v2-0443"/>
-	<compositional value="false"/>
-	<versionNeeded value="true"/>
-	<content value="complete"/>
+	<name value="ProviderRoleAU" />
+	<title value="providerRole AU" />
+	<status value="active" />
+	<experimental value="false" />
+	<description
+		value="Additional concept codes for specifying the functional involvement with the activity being transmitted (e.g., Case Manager, Evaluator, Transcriber, Nurse Care Practitioner, Midwife, Physician Assistant, etc.) defined for use in an Australian context. These codes are used as extensions to the HL7 International code set." />
+	<caseSensitive value="true" />
+	<valueSet value="http://terminology.hl7.org.au/ValueSet/v2-0443" />
+	<compositional value="false" />
+	<versionNeeded value="true" />
+	<count value="1" />
+	<content value="complete" />
 	<concept>
-		<code value="WIT"/>
-		<display value="Witness"/>
-		<definition value="Witness to a procedure or medication administration"/>
+		<code value="WIT" />
+		<display value="Witness" />
+		<definition value="Witness to a procedure or medication administration" />
 	</concept>
 </CodeSystem>

--- a/input/resources/codesystem-au-v3-ActCode.xml
+++ b/input/resources/codesystem-au-v3-ActCode.xml
@@ -1,7 +1,7 @@
 <CodeSystem xmlns="http://hl7.org/fhir">
 	<id value="au-v3-ActCode"/>	
 	<meta> 
-		<profile value="http://hl7.org/fhir/StructureDefinition/shareablecodesystem"/> 
+		<profile value="https://healthterminologies.gov.au/fhir/StructureDefinition/complete-code-system-4"/> 
 	</meta>
 	<extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
 		<valueInteger value="1"/>
@@ -20,6 +20,7 @@
 	<valueSet value="http://terminology.hl7.org.au/ValueSet/v3-ActCode"/>
 	<compositional value="false"/>
 	<versionNeeded value="false"/>
+	<count value="5" />
 	<content value="complete"/>
 	<concept>
 		<code value="PHONE"/>

--- a/input/resources/codesystem-contact-purpose.xml
+++ b/input/resources/codesystem-contact-purpose.xml
@@ -1,56 +1,61 @@
 <CodeSystem xmlns="http://hl7.org/fhir">
-	<id value="contact-purpose"/>
+	<id value="contact-purpose" />
 	<meta>
-		<profile value="http://hl7.org/fhir/StructureDefinition/shareablecodesystem"/>
+		<profile
+			value="https://healthterminologies.gov.au/fhir/StructureDefinition/complete-code-system-4" />
 	</meta>
 	<extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
-		<valueInteger value="1"/>
+		<valueInteger value="1" />
 	</extension>
-	<url value="http://terminology.hl7.org.au/CodeSystem/contact-purpose"/>
-	<identifier> 
-		<system value="urn:ietf:rfc:3986"/> 
-		<value value="urn:oid:2.16.840.1.113883.2.3.4.1.4.19"/> 
-	</identifier> 
-	<name value="ContactPurpose"/>
-	<title value="Contact Purpose"/>
-	<status value="active"/>
-	<experimental value="false"/>
-	<description value="Purpose for associated contact information."/>
-	<caseSensitive value="true"/>
+	<url value="http://terminology.hl7.org.au/CodeSystem/contact-purpose" />
+	<identifier>
+		<system value="urn:ietf:rfc:3986" />
+		<value value="urn:oid:2.16.840.1.113883.2.3.4.1.4.19" />
+	</identifier>
+	<name value="ContactPurpose" />
+	<title value="Contact Purpose" />
+	<status value="active" />
+	<experimental value="false" />
+	<description value="Purpose for associated contact information." />
+	<caseSensitive value="true" />
 	<!-- CodeSystem.valueSet element is not included at this time
-	 the value set canonically identified by http://terminology.hl7.org.au/ValueSet/contact-purpose defines a 'conformance requirements' value set 
+	 the value set canonically identified by http://terminology.hl7.org.au/ValueSet/contact-purpose
+	defines a 'conformance requirements' value set 
 	 not an 'all codes' value set and includes concepts from more than one code system -->
-	<compositional value="false"/>
-	<versionNeeded value="false"/>
-	<content value="complete"/>
+	<compositional value="false" />
+	<versionNeeded value="false" />
+	<count value="6" />
+	<content value="complete" />
 	<concept>
-		<code value="after-hours"/>
-		<display value="After Hours"/>
-		<definition value="Contact to be used during an after hours period as determined by the contact entity. An after hours period is a period of time outside of normal operating periods of the entity or service."/>
+		<code value="after-hours" />
+		<display value="After Hours" />
+		<definition
+			value="Contact to be used during an after hours period as determined by the contact entity. An after hours period is a period of time outside of normal operating periods of the entity or service." />
 	</concept>
 	<concept>
-		<code value="medical-record"/>
-		<display value="Medical Record"/>
-		<definition value="Contact for medical/clinical records including provision of results to a practitioner or the correction of a clinical record."/>
+		<code value="medical-record" />
+		<display value="Medical Record" />
+		<definition
+			value="Contact for medical/clinical records including provision of results to a practitioner or the correction of a clinical record." />
 	</concept>
 	<concept>
-		<code value="emergency"/>
-		<display value="Emergency"/>
-		<definition value="Contact to be used in an emergency."/>
+		<code value="emergency" />
+		<display value="Emergency" />
+		<definition value="Contact to be used in an emergency." />
 	</concept>
 	<concept>
-		<code value="clinical-emergency"/>
-		<display value="Clinical Emergency"/>
-		<definition value="Contact to be used in a clinical emergency."/>
+		<code value="clinical-emergency" />
+		<display value="Clinical Emergency" />
+		<definition value="Contact to be used in a clinical emergency." />
 	</concept>
 	<concept>
-		<code value="legal"/>
-		<display value="Legal"/>
-		<definition value="Contact for legal concerns or enquiries."/>
+		<code value="legal" />
+		<display value="Legal" />
+		<definition value="Contact for legal concerns or enquiries." />
 	</concept>
 	<concept>
-		<code value="privacy"/>
-		<display value="Privacy"/>
-		<definition value="Contact for concerns or enquiries relating to privacy of information."/>
+		<code value="privacy" />
+		<display value="Privacy" />
+		<definition value="Contact for concerns or enquiries relating to privacy of information." />
 	</concept>
 </CodeSystem>

--- a/input/resources/codesystem-medication-type.xml
+++ b/input/resources/codesystem-medication-type.xml
@@ -1,79 +1,88 @@
 <CodeSystem xmlns="http://hl7.org/fhir">
-	<id value="medication-type"/>
+	<id value="medication-type" />
 	<meta>
-		<profile value="http://hl7.org/fhir/StructureDefinition/shareablecodesystem"/>
+		<profile value="https://healthterminologies.gov.au/fhir/StructureDefinition/complete-code-system-4" />
 	</meta>
 	<extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
-		<valueInteger value="2"/>
+		<valueInteger value="2" />
 	</extension>
-	<url value="http://terminology.hl7.org.au/CodeSystem/medication-type"/>
+	<url value="http://terminology.hl7.org.au/CodeSystem/medication-type" />
 	<identifier>
-		<system value="urn:ietf:rfc:3986"/>
-		<value value="urn:oid:2.16.840.1.113883.2.3.4.1.4.1"/>
+		<system value="urn:ietf:rfc:3986" />
+		<value value="urn:oid:2.16.840.1.113883.2.3.4.1.4.1" />
 	</identifier>
-	<name value="MedicationType"/>
-	<title value="Medication Type"/>
-	<status value="active"/>
-	<experimental value="false"/>
-	<description value="The Medication Type code system defines concepts in a classification scheme for medication coding. The classification scheme defines the nature of the properties defined by the code e.g. branded product with no strength or form. This allows the distinction between codes provided containing container, pack, strength and form explicitly especially where terminologies supplied are unknown or terminology services are unavailable."/>
-	<caseSensitive value="true"/>
-	<valueSet value="http://terminology.hl7.org.au/ValueSet/medication-type"/>
-	<compositional value="false"/>
-	<versionNeeded value="true"/>
-	<content value="complete"/>
+	<name value="MedicationType" />
+	<title value="Medication Type" />
+	<status value="active" />
+	<experimental value="false" />
+	<description
+		value="The Medication Type code system defines concepts in a classification scheme for medication coding. The classification scheme defines the nature of the properties defined by the code e.g. branded product with no strength or form. This allows the distinction between codes provided containing container, pack, strength and form explicitly especially where terminologies supplied are unknown or terminology services are unavailable." />
+	<caseSensitive value="true" />
+	<valueSet value="http://terminology.hl7.org.au/ValueSet/medication-type" />
+	<compositional value="false" />
+	<versionNeeded value="true" />
+	<count value="11" />
+	<content value="complete" />
 	<concept>
-		<code value="UPD"/>
-		<display value="Unbranded product with no strengths or form"/>
-		<definition value="Unbranded product with no strengths or form. (For AMT this is equivalent to the MP - Medicinal Product concept)"/>
+		<code value="UPD" />
+		<display value="Unbranded product with no strengths or form" />
+		<definition
+			value="Unbranded product with no strengths or form. (For AMT this is equivalent to the MP - Medicinal Product concept)" />
 	</concept>
 	<concept>
-		<code value="UPDS"/>
-		<display value="Unbranded product with strengths but no form"/>
-		<definition value="Unbranded product with strengths but no form."/>
+		<code value="UPDS" />
+		<display value="Unbranded product with strengths but no form" />
+		<definition value="Unbranded product with strengths but no form." />
 	</concept>
 	<concept>
-		<code value="UPDF"/>
-		<display value="Unbranded product with form but no strengths"/>
-		<definition value="Unbranded product with form but no strengths."/>
+		<code value="UPDF" />
+		<display value="Unbranded product with form but no strengths" />
+		<definition value="Unbranded product with form but no strengths." />
 	</concept>
 	<concept>
-		<code value="UPDSF"/>
-		<display value="Unbranded product with strengths and form"/>
-		<definition value="Unbranded product with strengths and form. (For AMT this is equivalent to the MPUU - Medicinal Product Unit of Use concept)"/>
+		<code value="UPDSF" />
+		<display value="Unbranded product with strengths and form" />
+		<definition
+			value="Unbranded product with strengths and form. (For AMT this is equivalent to the MPUU - Medicinal Product Unit of Use concept)" />
 	</concept>
 	<concept>
-		<code value="UPG"/>
-		<display value="Unbranded package with no container"/>
-		<definition value="Unbranded package with no container. (For AMT this is equivalent to the MPP - Medicinal Product Pack concept)"/>
+		<code value="UPG" />
+		<display value="Unbranded package with no container" />
+		<definition
+			value="Unbranded package with no container. (For AMT this is equivalent to the MPP - Medicinal Product Pack concept)" />
 	</concept>
 	<concept>
-		<code value="BPD"/>
-		<display value="Branded product with no strengths or form"/>
-		<definition value="Branded product with no strengths or form. (For AMT this is equivalent to the TP - Trade Product concept)"/>
+		<code value="BPD" />
+		<display value="Branded product with no strengths or form" />
+		<definition
+			value="Branded product with no strengths or form. (For AMT this is equivalent to the TP - Trade Product concept)" />
 	</concept>
 	<concept>
-		<code value="BPDS"/>
-		<display value="Branded product with strengths but no form"/>
-		<definition value="Branded product with strengths but no form"/>
+		<code value="BPDS" />
+		<display value="Branded product with strengths but no form" />
+		<definition value="Branded product with strengths but no form" />
 	</concept>
 	<concept>
-		<code value="BPDF"/>
-		<display value="Branded product with form but no strengths"/>
-		<definition value="Branded product with form but no strengths"/>
+		<code value="BPDF" />
+		<display value="Branded product with form but no strengths" />
+		<definition value="Branded product with form but no strengths" />
 	</concept>
 	<concept>
-		<code value="BPDSF"/>
-		<display value="Branded product with strengths and form"/>
-		<definition value="Branded product with strengths and form. (For AMT this is equivalent to the TPUU - Trade Product Unit of Use concept)"/>
+		<code value="BPDSF" />
+		<display value="Branded product with strengths and form" />
+		<definition
+			value="Branded product with strengths and form. (For AMT this is equivalent to the TPUU - Trade Product Unit of Use concept)" />
 	</concept>
 	<concept>
-		<code value="BPG"/>
-		<display value="Branded package with no container"/>
-		<definition value="Branded package with no container. (For AMT this is equivalent to the TPP - Trade Product Pack concept)"/>
+		<code value="BPG" />
+		<display value="Branded package with no container" />
+		<definition
+			value="Branded package with no container. (For AMT this is equivalent to the TPP - Trade Product Pack concept)" />
 	</concept>
 	<concept>
-		<code value="BPGC"/>
-		<display value="Branded package with container"/>
-		<definition value="Branded package with container. (For AMT this is equivalent to the CTPP - Containered Trade Product Pack concept)"/>
+		<code value="BPGC" />
+		<display value="Branded package with container" />
+		<definition
+			value="Branded package with container. (For AMT this is equivalent to the CTPP - Containered Trade Product Pack concept)" />
 	</concept>
 </CodeSystem>

--- a/input/resources/codesystem-medicine-item-change.xml
+++ b/input/resources/codesystem-medicine-item-change.xml
@@ -1,117 +1,119 @@
 <CodeSystem xmlns="http://hl7.org/fhir">
-	<id value="medicine-item-change"/>
+	<id value="medicine-item-change" />
 	<meta>
-		<profile value="http://hl7.org/fhir/StructureDefinition/shareablecodesystem"/>
+		<profile value="https://healthterminologies.gov.au/fhir/StructureDefinition/complete-code-system-4" />
 	</meta>
 	<extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
-		<valueInteger value="1"/>
+		<valueInteger value="1" />
 	</extension>
-	<url value="http://terminology.hl7.org.au/CodeSystem/medicine-item-change"/>
+	<url value="http://terminology.hl7.org.au/CodeSystem/medicine-item-change" />
 	<identifier>
-		<system value="urn:ietf:rfc:3986"/>
-		<value value="urn:oid:2.16.840.1.113883.2.3.4.1.4.6"/>
+		<system value="urn:ietf:rfc:3986" />
+		<value value="urn:oid:2.16.840.1.113883.2.3.4.1.4.6" />
 	</identifier>
-	<name value="MedicineItemChange"/>
-	<title value="Medicine Item Change"/>
-	<status value="active"/>
-	<experimental value="false"/>
-	<description value="The Medicine Item Change code system defines concepts that identify a change that has been made, or is recommended to be made, to a medicine item."/>
-	<caseSensitive value="true"/>
-	<valueSet value="http://terminology.hl7.org.au/ValueSet/medicine-item-change"/>
-	<hierarchyMeaning value="is-a"/>
-	<compositional value="false"/>
-	<versionNeeded value="true"/>
-	<content value="complete"/>
+	<name value="MedicineItemChange" />
+	<title value="Medicine Item Change" />
+	<status value="active" />
+	<experimental value="false" />
+	<description
+		value="The Medicine Item Change code system defines concepts that identify a change that has been made, or is recommended to be made, to a medicine item." />
+	<caseSensitive value="true" />
+	<valueSet value="http://terminology.hl7.org.au/ValueSet/medicine-item-change" />
+	<hierarchyMeaning value="is-a" />
+	<compositional value="false" />
+	<versionNeeded value="true" />
+	<count value="15" />
+	<content value="complete" />
 	<concept>
-		<code value="nochange"/>
-		<display value="Unchanged"/>
-		<definition value="No change has been made to this medicine."/>
+		<code value="nochange" />
+		<display value="Unchanged" />
+		<definition value="No change has been made to this medicine." />
 	</concept>
 	<concept>
-		<code value="changed"/>
-		<display value="Change occurred"/>
+		<code value="changed" />
+		<display value="Change occurred" />
 		<definition
-			value="A change has been made to this medicine; for example, new medicine prescribed or dosage change."/>
+			value="A change has been made to this medicine; for example, new medicine prescribed or dosage change." />
 		<concept>
-			<code value="new"/>
-			<display value="New"/>
-			<definition value="A new medicine item is introduced."/>
+			<code value="new" />
+			<display value="New" />
+			<definition value="A new medicine item is introduced." />
 			<concept>
-				<code value="prescribed"/>
-				<display value="New prescription"/>
-				<definition value="A new medicine item has been prescribed."/>
+				<code value="prescribed" />
+				<display value="New prescription" />
+				<definition value="A new medicine item has been prescribed." />
 			</concept>
 		</concept>
 		<concept>
-			<code value="ceased"/>
-			<display value="Ceased"/>
+			<code value="ceased" />
+			<display value="Ceased" />
 			<definition
 				value="A medicine that was previously taken by the individual may actually be ceased as it required immediate attention. This cessation is anticipated to be permanent. Example uses: the medicine in question is considered ineffective or has caused serious adverse effects."
 			/>
 		</concept>
 		<concept>
-			<code value="suspended"/>
-			<display value="Suspended"/>
+			<code value="suspended" />
+			<display value="Suspended" />
 			<definition
 				value="A medicine that was previously taken by the individual may be temporarily stopped. Example uses: medication in question may reach toxicity blood level, or suspected to have caused some undesirable effects; or needs to be suspended before a surgical/diagnostic procedure."
 			/>
 		</concept>
 		<concept>
-			<code value="cancelled"/>
-			<display value="Cancelled"/>
+			<code value="cancelled" />
+			<display value="Cancelled" />
 			<definition
 				value="The prescription for this medicine item was cancelled. The patient may be advised to complete the course of the prescribed medicine. This advice is a clinical decision made based on assessment of the patients clinical condition."
 			/>
 		</concept>
 		<concept>
-			<code value="amended"/>
-			<display value="Amended"/>
+			<code value="amended" />
+			<display value="Amended" />
 			<definition
 				value="The current medicine item has been changed in some way, e.g. dose, form, route, frequency change."
 			/>
 		</concept>
 	</concept>
 	<concept>
-		<code value="recommended"/>
-		<display value="Change was recommended"/>
+		<code value="recommended" />
+		<display value="Change was recommended" />
 		<definition
-			value="A change has been recommended to this medicine but may not have occurred yet, e.g. medicine recommended to be stopped."/>
+			value="A change has been recommended to this medicine but may not have occurred yet, e.g. medicine recommended to be stopped." />
 		<concept>
-			<code value="new-recommended"/>
-			<display value="New recommended medicine"/>
-			<definition value="A new medicine item is recommended."/>
+			<code value="new-recommended" />
+			<display value="New recommended medicine" />
+			<definition value="A new medicine item is recommended." />
 			<concept>
-				<code value="prescription-recommended"/>
-				<display value="Prescription recommended"/>
+				<code value="prescription-recommended" />
+				<display value="Prescription recommended" />
 				<definition
 					value="It may be recommended that the usual GP prescribe a new medicine to be taken by the individual. The addition may not be urgent or there may be an arrangement that all medicine changes are to be enacted by the GP as the coordinator of the individual‘s overall care."
 				/>
 			</concept>
 		</concept>
 		<concept>
-			<code value="review-recommended"/>
-			<display value="Review recommended"/>
+			<code value="review-recommended" />
+			<display value="Review recommended" />
 			<definition
 				value="It may be recommended to the usual GP that a medicine that was previously taken by the individual be reviewed. The outcome of the review may be that the medicine is amended or stopped."
 			/>
 		</concept>
 		<concept>
-			<code value="cessation-recommended"/>
-			<display value="Cessation recommended"/>
+			<code value="cessation-recommended" />
+			<display value="Cessation recommended" />
 			<definition
 				value="It may be recommended to the usual GP that a medicine that was previously taken by the individual be ceased."
 			/>
 		</concept>
 		<concept>
-			<code value="suspension-recommended"/>
-			<display value="Suspension recommended"/>
+			<code value="suspension-recommended" />
+			<display value="Suspension recommended" />
 			<definition
 				value="It may be recommended to the usual GP that a medicine item that was previously taken by the individual be temporarily stopped. Example uses: medication in question may reach toxicity blood level, or suspected to have caused some undesirable effects; or needs to be suspended before a surgical/diagnostic procedure."
 			/>
 		</concept>
 		<concept>
-			<code value="cancellation-recommended"/>
-			<display value="Cancellation recommended"/>
+			<code value="cancellation-recommended" />
+			<display value="Cancellation recommended" />
 			<definition
 				value="The prescription for this medicine item is recommended to be cancelled. The patient may be advised to complete the course of the prescribed medicine. This advice is a clinical decision made based on assessment of the patients clinical condition."
 			/>

--- a/input/resources/codesystem-rsg-source-document-type.xml
+++ b/input/resources/codesystem-rsg-source-document-type.xml
@@ -2,40 +2,44 @@
 <CodeSystem xmlns="http://hl7.org/fhir">
     <id value="rsg-source-document-type" />
     <meta>
-        <profile value="http://hl7.org/fhir/StructureDefinition/shareablecodesystem" />
+        <profile value="https://healthterminologies.gov.au/fhir/StructureDefinition/complete-code-system-4" />
     </meta>
     <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
-        <valueInteger value="1"/>
+        <valueInteger value="1" />
     </extension>
     <url value="http://terminology.hl7.org.au/CodeSystem/rsg-source-document-type" />
     <identifier>
-        <system value="urn:ietf:rfc:3986"/>
-        <value value="urn:oid:2.16.840.1.113883.2.3.4.1.4.30"/>
+        <system value="urn:ietf:rfc:3986" />
+        <value value="urn:oid:2.16.840.1.113883.2.3.4.1.4.30" />
     </identifier>
     <name value="AURecordedSexOrGenderSourceDocumentType" />
     <title value="AU Recorded Sex or Gender Source Document Type" />
     <status value="active" />
-    <experimental value="false"/>
-    <description value="The AU Recorded Sex or Gender Source Document Type code system defines concepts that represent the type of document where this sex or gender value is recorded." />
+    <experimental value="false" />
+    <description
+        value="The AU Recorded Sex or Gender Source Document Type code system defines concepts that represent the type of document where this sex or gender value is recorded." />
     <caseSensitive value="true" />
-    <hierarchyMeaning value="is-a"/>
-    <valueSet value="http://terminology.hl7.org.au/ValueSet/au-recorded-sex-or-gender-source-document-type"/>
+    <hierarchyMeaning value="is-a" />
+    <valueSet
+        value="http://terminology.hl7.org.au/ValueSet/au-recorded-sex-or-gender-source-document-type" />
     <compositional value="false" />
     <versionNeeded value="false" />
-    <content value="complete" /> 
+    <count value="3" />
+    <content value="complete" />
     <concept>
-      <code value="passport"/>
-      <display value="Passport"/>
-      <definition value="A passport issued by a jurisdiction."/>
+        <code value="passport" />
+        <display value="Passport" />
+        <definition value="A passport issued by a jurisdiction." />
     </concept>
     <concept>
-        <code value="citizenship-certificate"/>
-        <display value="Citizenship Certificate"/>
-        <definition value="A citizenship certificate issued by a jurisdiction."/>
+        <code value="citizenship-certificate" />
+        <display value="Citizenship Certificate" />
+        <definition value="A citizenship certificate issued by a jurisdiction." />
     </concept>
     <concept>
-        <code value="birth-notification"/>
-        <display value="Birth Notification"/>
-        <definition value="A notification of a birth from the health service in which the birth occurred."/>
+        <code value="birth-notification" />
+        <display value="Birth Notification" />
+        <definition
+            value="A notification of a birth from the health service in which the birth occurred." />
     </concept>
 </CodeSystem>

--- a/input/resources/codesystem-rsg-type.xml
+++ b/input/resources/codesystem-rsg-type.xml
@@ -2,7 +2,7 @@
 <CodeSystem xmlns="http://hl7.org/fhir">
     <id value="rsg-type" />
     <meta>
-        <profile value="http://hl7.org/fhir/StructureDefinition/shareablecodesystem" />
+        <profile value="https://healthterminologies.gov.au/fhir/StructureDefinition/complete-code-system-4" />
     </meta>
     <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
         <valueInteger value="1"/>
@@ -22,6 +22,7 @@
     <valueSet value="http://terminology.hl7.org.au/ValueSet/au-recorded-sex-or-gender-type"/>
     <compositional value="false" />
     <versionNeeded value="false" />
+    <count value="1" />
     <content value="complete" /> 
     <concept>
        <code value="sex-gender"/>

--- a/input/resources/codesystem-service-provision-conditions.xml
+++ b/input/resources/codesystem-service-provision-conditions.xml
@@ -1,66 +1,69 @@
 <CodeSystem xmlns="http://hl7.org/fhir">
-	<id value="service-provision-conditions"/>
+	<id value="service-provision-conditions" />
 	<meta>
-		<profile value="http://hl7.org/fhir/StructureDefinition/shareablecodesystem"/>
+		<profile
+			value="https://healthterminologies.gov.au/fhir/StructureDefinition/complete-code-system-4" />
 	</meta>
 	<extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
-		<valueInteger value="2"/>
+		<valueInteger value="2" />
 	</extension>
-	<url value="http://terminology.hl7.org.au/CodeSystem/service-provision-conditions"/>
+	<url value="http://terminology.hl7.org.au/CodeSystem/service-provision-conditions" />
 	<identifier>
-		<system value="urn:ietf:rfc:3986"/>
-		<value value="urn:oid:2.16.840.1.113883.2.3.4.1.4.2"/>
+		<system value="urn:ietf:rfc:3986" />
+		<value value="urn:oid:2.16.840.1.113883.2.3.4.1.4.2" />
 	</identifier>
-	<name value="ServiceProvisionConditionsAustralianConcepts"/>
-	<title value="Service Provision Conditions Australian Concepts"/>
-	<status value="active"/>
-	<experimental value="false"/>
-	<description value="The Service Provision Conditions Australian Concepts code system defines concepts that identify the conditions under which a healthcare service is available/offered."/>
-	<caseSensitive value="true"/>
-	<valueSet value="http://terminology.hl7.org.au/ValueSet/service-provision-conditions"/>
-	<compositional value="false"/>
-	<versionNeeded value="true"/>
-	<content value="complete"/>
+	<name value="ServiceProvisionConditionsAustralianConcepts" />
+	<title value="Service Provision Conditions Australian Concepts" />
+	<status value="active" />
+	<experimental value="false" />
+	<description
+		value="The Service Provision Conditions Australian Concepts code system defines concepts that identify the conditions under which a healthcare service is available/offered." />
+	<caseSensitive value="true" />
+	<valueSet value="http://terminology.hl7.org.au/ValueSet/service-provision-conditions" />
+	<compositional value="false" />
+	<versionNeeded value="true" />
+	<count value="7" />
+	<content value="complete" />
 	<concept>
-		<code value="NFE"/>
-		<display value="No Fee"/>
-		<definition value="All or some of the services provided are offered free of charge."/>
+		<code value="NFE" />
+		<display value="No Fee" />
+		<definition value="All or some of the services provided are offered free of charge." />
 	</concept>
 	<concept>
-		<code value="NFM"/>
-		<display value="No Fee (means tested)"/>
+		<code value="NFM" />
+		<display value="No Fee (means tested)" />
 		<definition
 			value="All or some of the services provided are offered free of charge, however the decision on the costs associated with the service or procedures offered will depend on a means test outcome."
 		/>
 	</concept>
 	<concept>
-		<code value="BBO"/>
-		<display value="Bulk Billing Only"/>
-		<definition value="Bulk Billing is offered under Medicare."/>
+		<code value="BBO" />
+		<display value="Bulk Billing Only" />
+		<definition value="Bulk Billing is offered under Medicare." />
 	</concept>
 	<concept>
-		<code value="FAP"/>
-		<display value="Fees Apply"/>
+		<code value="FAP" />
+		<display value="Fees Apply" />
 		<definition
-			value="All or some of the services provided are offered at the Healthcare Service"/>
+			value="All or some of the services provided are offered at the Healthcare Service" />
 	</concept>
 	<concept>
-		<code value="DON"/>
-		<display value="By Donation"/>
+		<code value="DON" />
+		<display value="By Donation" />
 		<definition
 			value="All or some of the services provided are offered on a donation basis. The expectation on the donation is not defined."
 		/>
 	</concept>
 	<concept>
-		<code value="COP"/>
-		<display value="Co-payment"/>
+		<code value="COP" />
+		<display value="Co-payment" />
 		<definition
 			value="All or some of the services provided are subject to a co-payment, which may be in combination with Private Insurance."
 		/>
 	</concept>
 	<concept>
-		<code value="FBB"/>
-		<display value="Fees and Bulk Billing"/>
+		<code value="FBB" />
+		<display value="Fees and Bulk Billing" />
 		<definition
 			value="All or some of the services provided are offered subject to a payment in combination with Bulk Billing."
 		/>

--- a/input/resources/valueset-accession-number-type.xml
+++ b/input/resources/valueset-accession-number-type.xml
@@ -1,7 +1,7 @@
 <ValueSet xmlns="http://hl7.org/fhir">
 	<id value="accession-number-type"/>
 	<meta>
-		<profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset"/>
+		<profile value="https://healthterminologies.gov.au/fhir/StructureDefinition/composed-value-set-4"/>
 	</meta>
 	<extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
 		<valueInteger value="1"/>

--- a/input/resources/valueset-amt-mp-codes.xml
+++ b/input/resources/valueset-amt-mp-codes.xml
@@ -1,7 +1,7 @@
 <ValueSet xmlns="http://hl7.org/fhir">
 	<id value="amt-mp-codes"/>
 	<meta>
-		<profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset"/>
+		<profile value="https://healthterminologies.gov.au/fhir/StructureDefinition/composed-value-set-4"/>
 	</meta>
 	<extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
 		<valueInteger value="3"/>

--- a/input/resources/valueset-au-jurisdiction-extended.xml
+++ b/input/resources/valueset-au-jurisdiction-extended.xml
@@ -2,7 +2,7 @@
 <ValueSet xmlns="http://hl7.org/fhir">
     <id value="au-jurisdiction-extended" />
     <meta>
-        <profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset" />
+        <profile value="https://healthterminologies.gov.au/fhir/StructureDefinition/composed-value-set-4" />
     </meta>
     <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
         <valueInteger value="1"/>

--- a/input/resources/valueset-au-location-physical-type-extended.xml
+++ b/input/resources/valueset-au-location-physical-type-extended.xml
@@ -1,7 +1,7 @@
 <ValueSet xmlns="http://hl7.org/fhir">
 	<id value="au-location-physical-type-extended" />
 	<meta>
-		<profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset" />
+		<profile value="https://healthterminologies.gov.au/fhir/StructureDefinition/composed-value-set-4" />
 	</meta>
 	<extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
 		<valueInteger value="1"/>

--- a/input/resources/valueset-au-observation-category-extended.xml
+++ b/input/resources/valueset-au-observation-category-extended.xml
@@ -1,7 +1,7 @@
 <ValueSet xmlns="http://hl7.org/fhir">
 	<id value="au-observation-category-extended"/>
 	<meta>
-		<profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset"/>
+		<profile value="https://healthterminologies.gov.au/fhir/StructureDefinition/composed-value-set-4"/>
 	</meta>
 	<extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
 		<valueInteger value="1"/>

--- a/input/resources/valueset-au-timezone.xml
+++ b/input/resources/valueset-au-timezone.xml
@@ -2,7 +2,7 @@
 <ValueSet xmlns="http://hl7.org/fhir">
   <id value="au-timezone" />
   <meta>
-    <profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset"/>
+    <profile value="https://healthterminologies.gov.au/fhir/StructureDefinition/composed-value-set-4"/>
   </meta>
   <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
     <valueInteger value="1"/>

--- a/input/resources/valueset-au-v2-0203-extended.xml
+++ b/input/resources/valueset-au-v2-0203-extended.xml
@@ -1,7 +1,7 @@
 <ValueSet xmlns="http://hl7.org/fhir">
 	<id value="au-v2-0203-extended"/>
 	<meta>
-		<profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset"/>
+		<profile value="https://healthterminologies.gov.au/fhir/StructureDefinition/composed-value-set-4"/>
 	</meta>
 	<extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
 		<valueInteger value="3"/>

--- a/input/resources/valueset-au-v2-0360-extended.xml
+++ b/input/resources/valueset-au-v2-0360-extended.xml
@@ -1,7 +1,7 @@
 <ValueSet xmlns="http://hl7.org/fhir">
 	<id value="au-v2-0360-extended" />
 	<meta>
-		<profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset"/>
+		<profile value="https://healthterminologies.gov.au/fhir/StructureDefinition/composed-value-set-4"/>
 	</meta>
 	<extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
 		<valueInteger value="1"/>

--- a/input/resources/valueset-au-v2-0443-extended.xml
+++ b/input/resources/valueset-au-v2-0443-extended.xml
@@ -1,7 +1,7 @@
 <ValueSet xmlns="http://hl7.org/fhir">
 	<id value="au-v2-0443-extended"/>
 	<meta>
-		<profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset"/>
+		<profile value="https://healthterminologies.gov.au/fhir/StructureDefinition/composed-value-set-4"/>
 	</meta>
 	<extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
 		<valueInteger value="1"/>

--- a/input/resources/valueset-au-v3-ActEncounterCode-extended.xml
+++ b/input/resources/valueset-au-v3-ActEncounterCode-extended.xml
@@ -1,7 +1,7 @@
 <ValueSet xmlns="http://hl7.org/fhir">
 	<id value="au-v3-ActEncounterCode-extended"/>
 	<meta>
-		<profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset"/>
+		<profile value="https://healthterminologies.gov.au/fhir/StructureDefinition/composed-value-set-4"/>
 	</meta>
 	<extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
 		<valueInteger value="1"/>

--- a/input/resources/valueset-au-v3-ServiceDeliveryLocationRoleType-extended.xml
+++ b/input/resources/valueset-au-v3-ServiceDeliveryLocationRoleType-extended.xml
@@ -1,7 +1,7 @@
 <ValueSet xmlns="http://hl7.org/fhir">
 	<id value="au-v3-ServiceDeliveryLocationRoleType-extended" />
 	<meta>
-		<profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset" />
+		<profile value="https://healthterminologies.gov.au/fhir/StructureDefinition/composed-value-set-4" />
 	</meta>
 	<extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
 		<valueInteger value="1"/>

--- a/input/resources/valueset-contact-purpose.xml
+++ b/input/resources/valueset-contact-purpose.xml
@@ -1,7 +1,7 @@
 <ValueSet xmlns="http://hl7.org/fhir">
 	<id value="contact-purpose"/>
 	<meta>
-		<profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset"/>
+		<profile value="https://healthterminologies.gov.au/fhir/StructureDefinition/composed-value-set-4"/>
 	</meta>
 	<extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
 		<valueInteger value="1"/>

--- a/input/resources/valueset-dva-entitlement.xml
+++ b/input/resources/valueset-dva-entitlement.xml
@@ -1,7 +1,7 @@
 <ValueSet xmlns="http://hl7.org/fhir">
 	<id value="dva-entitlement"/>
 	<meta>
-		<profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset"/>
+		<profile value="https://healthterminologies.gov.au/fhir/StructureDefinition/composed-value-set-4"/>
 	</meta>
 	<extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
 		<valueInteger value="2"/>

--- a/input/resources/valueset-medication-type.xml
+++ b/input/resources/valueset-medication-type.xml
@@ -1,7 +1,7 @@
 <ValueSet xmlns="http://hl7.org/fhir">
 	<id value="medication-type"/>
 	<meta>
-		<profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset"/>
+		<profile value="https://healthterminologies.gov.au/fhir/StructureDefinition/composed-value-set-4"/>
 	</meta>
 	<extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
 		<valueInteger value="2"/>
@@ -22,4 +22,3 @@
 		</include>
 	</compose>
 </ValueSet>
-

--- a/input/resources/valueset-medicine-item-change.xml
+++ b/input/resources/valueset-medicine-item-change.xml
@@ -1,7 +1,7 @@
 <ValueSet xmlns="http://hl7.org/fhir">
 	<id value="medicine-item-change"/>
 	<meta>
-		<profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset"/>
+		<profile value="https://healthterminologies.gov.au/fhir/StructureDefinition/composed-value-set-4"/>
 	</meta>
 	<extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
 		<valueInteger value="1"/>

--- a/input/resources/valueset-order-identifier-type.xml
+++ b/input/resources/valueset-order-identifier-type.xml
@@ -1,7 +1,7 @@
 <ValueSet xmlns="http://hl7.org/fhir">
 	<id value="order-identifier-type"/>
 	<meta>
-		<profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset"/>
+		<profile value="https://healthterminologies.gov.au/fhir/StructureDefinition/composed-value-set-4"/>
 	</meta>
 	<extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
 		<valueInteger value="1"/>

--- a/input/resources/valueset-rsg-source-document-type.xml
+++ b/input/resources/valueset-rsg-source-document-type.xml
@@ -2,7 +2,7 @@
 <ValueSet xmlns="http://hl7.org/fhir">
     <id value="rsg-source-document-type" />
     <meta>
-        <profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset" />
+        <profile value="https://healthterminologies.gov.au/fhir/StructureDefinition/composed-value-set-4" />
     </meta>
     <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
         <valueInteger value="1"/>

--- a/input/resources/valueset-rsg-type.xml
+++ b/input/resources/valueset-rsg-type.xml
@@ -2,7 +2,7 @@
 <ValueSet xmlns="http://hl7.org/fhir">
     <id value="rsg-type" />
     <meta>
-        <profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset" />
+        <profile value="https://healthterminologies.gov.au/fhir/StructureDefinition/composed-value-set-4" />
     </meta>
     <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
         <valueInteger value="1"/>

--- a/input/resources/valueset-service-provision-conditions.xml
+++ b/input/resources/valueset-service-provision-conditions.xml
@@ -1,7 +1,7 @@
 <ValueSet xmlns="http://hl7.org/fhir">
 	<id value="service-provision-conditions"/>
 	<meta> 
-		<profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset"/> 
+		<profile value="https://healthterminologies.gov.au/fhir/StructureDefinition/composed-value-set-4"/> 
 	</meta>
 	<extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
 		<valueInteger value="2"/>


### PR DESCRIPTION
CodeSystem and ValueSet profile changed to align with NCTS <a href="https://healthterminologies.gov.au/fhir/StructureDefinition/complete-code-system-4">Complete CodeSystem 4</a> and <a href="https://healthterminologies.gov.au/fhir/StructureDefinition/composed-value-set-4"> Composed ValueSet 4</a> (<a href="https://jira.hl7.org/browse/FHIR-47148">FHIR-47148</a> and <a href="https://jira.hl7.org/browse/FHIR-47149">FHIR-47149</a>) 

CodeSystem properties updated to align with NCTS <a href="https://healthterminologies.gov.au/fhir/StructureDefinition/complete-code-system-4">Complete CodeSystem 4</a> (<a href="https://jira.hl7.org/browse/FHIR-47148">FHIR-47148</a>) 
