### PR TITLE
 ActEncounterCode AU Extended valueset removal of Virtual Subtypes

### DIFF
--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -121,6 +121,8 @@ To help implementers, only the more significant changes are listed here.
   </li>
   <li>Updated AU Base ValueSet resources to remove conformance to HL7 International <a href="http://hl7.org/fhir/StructureDefinition/shareablevalueset">ShareableValueSet</a> and instead claim conformance to <a href="https://healthterminologies.gov.au/fhir/StructureDefinition/composed-value-set-4"> NCTS Composed ValueSet</a> (<a href="https://jira.hl7.org/browse/FHIR-47149">FHIR-47149</a>) 
   </li>
+  <li>Removed codes from <a href="ValueSet-au-v3-ActEncounterCode-extended.html" >ActEncounterCode - AU Extended</a> (<a href="https://jira.hl7.org/browse/FHIR-47120">FHIR-47120</a>)
+  </li>
 </ul>
 
 ### Release 4.1.0

--- a/input/resources/valueset-au-v3-ActEncounterCode-extended.xml
+++ b/input/resources/valueset-au-v3-ActEncounterCode-extended.xml
@@ -19,6 +19,9 @@
 	<compose>
 		<include>
 			<system value="http://terminology.hl7.org.au/CodeSystem/v3-ActCode"/>
+			<concept>
+				<code value="RACF"/>  
+			</concept>
 		</include>
 		<include>
 			<valueSet value="http://terminology.hl7.org/ValueSet/v3-ActEncounterCode"/>


### PR DESCRIPTION
See [FHIR-47120](https://jira.hl7.org/browse/FHIR-47120) 
Removed PHONE, VIDEO, EMAIL, SMS from [ActEncounterCode - AU Extended](http://terminology.hl7.org.au/ValueSet/v3-ActEncounterCode-extended) as they are subtypes of Virtual Encounter. 