### PR TITLE
Remove DiagnosticReport.category.coding:anatomicRegionOfInterest slice; change base def of AU Base Pathology Report and AU Base Diagnostic Imaging Report(FHIR-46933, FHIR-46898, FHIR-46934)

### DIFF
--- a/input/intro-notes/StructureDefinition-au-diagnosticreport-intro.md
+++ b/input/intro-notes/StructureDefinition-au-diagnosticreport-intro.md
@@ -7,5 +7,5 @@
   - the individual component examinations are referenced by that grouping Observation in `Observation.hasMember` and not directly referenced in `DiagnosticReport.result`
   - `DiagnosticReport.code` and the study / panel Observation `Observation.code` should be the same concept if the report contains only the results of that study / panel
 - See each Identifier profile page for guidance related to that identifier type.
-- See the [AU Base Pathology Report](StructureDefinition-au-pathologyreport.html) profile for guidance on representing a pathology report issued by the diagnostic service provider.
-- See the [AU Base Diagnostic Imaging Report](StructureDefinition-au-imagingreport.html) profile for guidance on representing an imaging report issued by the diagnostic service provider.
+- See the preferred [AU Base Pathology Report](StructureDefinition-au-pathologyreport.html) profile for guidance on representing a pathology report issued by the diagnostic service provider.
+- See the preferred [AU Base Diagnostic Imaging Report](StructureDefinition-au-imagingreport.html) profile for guidance on representing an imaging report issued by the diagnostic service provider.

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -123,6 +123,8 @@ To help implementers, only the more significant changes are listed here.
   </li>
   <li>Removed codes from <a href="ValueSet-au-v3-ActEncounterCode-extended.html" >ActEncounterCode - AU Extended</a> (<a href="https://jira.hl7.org/browse/FHIR-47120">FHIR-47120</a>)
   </li>
+  <li>Removed DiagnosticReport.category.coding:anatomicRegionOfInterest slice from <a href="StructureDefinition-au-diagnosticreport.html" >AU Base Diagnostic Report</a> (<a href="https://jira.hl7.org/browse/FHIR-46933">FHIR-46933</a>)</li>
+  <li>Change base definition of <a href="StructureDefinition-au-imagingreport.html" >AU Base Diagnostic Imaging Report</a> and <a href="StructureDefinition-au-pathologyreport.html" >AU Base Pathology Report</a> to be <a href="StructureDefinition-au-diagnosticreport.html" >AU Base Diagnostic Report</a> (<a href="https://jira.hl7.org/browse/FHIR-46898">FHIR-46898</a>)</li>
 </ul>
 
 ### Release 4.1.0

--- a/input/resources/au-diagnosticreport.xml
+++ b/input/resources/au-diagnosticreport.xml
@@ -8,7 +8,7 @@
   <name value="AUBaseDiagnosticReport" />
   <title value="AU Base Diagnostic Report" />
   <status value="active" />
-  <description value="This profile defines a diagnostic report structure that localises core concepts, including identifiers and terminology, for use in an Australian context. The purpose of this profile is to provide national level agreement on core localised concepts. This profile does not force conformance to core localised concepts. It enables implementers and modellers to make their own rules, i.e. [profiling](http://hl7.org/fhir/profiling.html), about how to support these concepts for specific implementation needs." />
+  <description value="This profile defines a diagnostic report structure that localises core concepts, including identifiers and terminology, for use in an Australian context. The purpose of this profile is to provide national level agreement on core localised concepts. This profile does not force conformance to core localised concepts. It enables implementers and modellers to make their own rules, i.e. [profiling](http://hl7.org/fhir/profiling.html), about how to support these concepts for specific implementation needs.  For specific reporting of pathology or imaging services the more specific [AU Base Pathology Report](StructureDefinition-au-pathologyreport.html) or [AU Base Diagnostic Imaging Report](StructureDefinition-au-imagingreport.html) profiles would be preferred. This profile is suitable for any other diagnostic service reporting needs." />
   <kind value="resource" />
   <abstract value="false" />
   <type value="DiagnosticReport" />

--- a/input/resources/au-imagingreport.xml
+++ b/input/resources/au-imagingreport.xml
@@ -12,7 +12,7 @@
   <kind value="resource" />
   <abstract value="false" />
   <type value="DiagnosticReport" />
-  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/DiagnosticReport" />
+  <baseDefinition value="http://hl7.org.au/fhir/StructureDefinition/au-diagnosticreport" />
   <derivation value="constraint" />
   <differential>
     <element id="DiagnosticReport">
@@ -43,8 +43,8 @@
     </element>
     <element id="DiagnosticReport.category">
       <path value="DiagnosticReport.category" />
-      <short value="Relevant diagnostic imaging category: service, modality and anatomic region of interest" />
-      <comment value="A category denoting diagnostic imaging service identifies the type of report and supports macro handling of requests is required. A second category to provide the modality should be provided where possible; a value set to support this categorisation is not yet available. A third category to provide the anatomic region of interest should be provided where possible."/>
+      <short value="Relevant diagnostic imaging category: service, modality" />
+      <comment value="A category denoting diagnostic imaging service identifies the type of report and supports macro handling of requests is required. A second category to provide the modality should be provided where possible; a value set to support this categorisation is not yet available."/>
       <min value="1" />
     </element>
     <element id="DiagnosticReport.category.coding">
@@ -56,20 +56,6 @@
         </discriminator>
         <rules value="open"/>
       </slicing>
-    </element>
-    <element id="DiagnosticReport.category.coding:anatomicRegionOfInterest">
-      <path value="DiagnosticReport.category.coding"/>
-      <sliceName value="anatomicRegionOfInterest"/>
-      <short value="Anatomic Region Of Interest"/>
-      <binding>
-        <strength value="preferred"/>
-        <valueSet value="https://healthterminologies.gov.au/fhir/ValueSet/imaging-anatomic-region-of-interest-1"/>
-      </binding>
-    </element>
-    <element id="DiagnosticReport.category.coding:anatomicRegionOfInterest.system">
-      <path value="DiagnosticReport.category.coding.system"/>
-      <min value="1"/>
-      <fixedUri value="http://snomed.info/sct"/>
     </element>
     <element id="DiagnosticReport.code">
       <path value="DiagnosticReport.code" />

--- a/input/resources/au-pathologyreport.xml
+++ b/input/resources/au-pathologyreport.xml
@@ -12,7 +12,7 @@
   <kind value="resource" />
   <abstract value="false" />
   <type value="DiagnosticReport" />
-  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/DiagnosticReport" />
+  <baseDefinition value="http://hl7.org.au/fhir/StructureDefinition/au-diagnosticreport" />
   <derivation value="constraint" />
   <differential>
     <element id="DiagnosticReport">


### PR DESCRIPTION
Fix for [FHIR-46933](https://jira.hl7.org/browse/FHIR-46933)
* Remove DiagnosticReport.category.coding:anatomicRegionOfInterest slice
* Change log entry

Fix for [FHIR-46898](https://jira.hl7.org/browse/FHIR-46898)
* Change base definition of AU Base Pathology Report and AU Base Diagnostic Imaging Report to be AU Base Diagnostic Report
* Change log entry

Fix for [FHIR-46934](https://jira.hl7.org/browse/FHIR-46934)
* Amend guidance as specified for AU Base Diagnostic Report (related to change in FHIR-46898)
