### PR TITLE
FHIR-47151 Concept Maps subsection needs updating

### DIFF
--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -123,7 +123,9 @@ To help implementers, only the more significant changes are listed here.
   </li>
   <li>Removed codes from <a href="ValueSet-au-v3-ActEncounterCode-extended.html" >ActEncounterCode - AU Extended</a> (<a href="https://jira.hl7.org/browse/FHIR-47120">FHIR-47120</a>)
   </li>
+  <li>Deprecated <a href="StructureDefinition-encounter-description.html">Encounter Description</a> extension and removed reference to Encounter Description from <a href="StructureDefinition-au-encounter">AU Base Encounter</a> (<a href="https://jira.hl7.org/browse/FHIR-47121">FHIR-47121</a>)</li>
 </ul>
+
 
 ### Release 4.1.0
 - Publication date: 2023-02-22

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -123,7 +123,6 @@ To help implementers, only the more significant changes are listed here.
   </li>
   <li>Removed codes from <a href="ValueSet-au-v3-ActEncounterCode-extended.html" >ActEncounterCode - AU Extended</a> (<a href="https://jira.hl7.org/browse/FHIR-47120">FHIR-47120</a>)
   </li>
-  <li>Deprecated <a href="StructureDefinition-encounter-description.html">Encounter Description</a> extension and removed reference to Encounter Description from <a href="StructureDefinition-au-encounter">AU Base Encounter</a> (<a href="https://jira.hl7.org/browse/FHIR-47121">FHIR-47121</a>)</li>
 </ul>
 
 ### Release 4.1.0

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -126,7 +126,6 @@ To help implementers, only the more significant changes are listed here.
   <li>Deprecated <a href="StructureDefinition-encounter-description.html">Encounter Description</a> extension and removed reference to Encounter Description from <a href="StructureDefinition-au-encounter">AU Base Encounter</a> (<a href="https://jira.hl7.org/browse/FHIR-47121">FHIR-47121</a>)</li>
 </ul>
 
-
 ### Release 4.1.0
 - Publication date: 2023-02-22
 - Publication status: Trial Use

--- a/input/pagecontent/terminology.md
+++ b/input/pagecontent/terminology.md
@@ -141,7 +141,7 @@ See the [FHIR terminology section]({{site.data.fhir.path}}terminologies-systems.
 
 ### Concept Maps
 
-See the [FHIR terminology section]({{site.data.fhir.path}}terminologies-conceptmaps.html) for a complete discussion on concept maps and a list of concept map names used in FHIR.  Most concept maps relevant to this guide are defined in the base FHIR specification. The following concept maps are unique to this guide and not listed in the base FHIR specification.
+See the [FHIR terminology section]({{site.data.fhir.path}}terminologies-conceptmaps.html) for a complete discussion on concept maps and a list of concept map names used in FHIR.  Most concept maps relevant to this guide are defined in the base FHIR specification. The following Australian concept maps are unique to this guide and not listed in the base FHIR specification. These are relevant to value sets that are bound to AU Base profiles.
 
 **Concept maps published in the NCTS**
 - [Australian States and Territories v1 to Australian States and Territories v2](https://healthterminologies.gov.au/fhir/ConceptMap/australian-states-territories-v1-to-v2-1)


### PR DESCRIPTION
Fix for [FHIR-47151](https://jira.hl7.org/browse/FHIR-47151)

- Updated intro text for concept map section of [terminology page](https://build.fhir.org/ig/hl7au/au-fhir-base/terminology.html#concept-maps)