### PR TITLE
Update ig.ini

### DIFF
--- a/ig.ini
+++ b/ig.ini
@@ -1,3 +1,3 @@
 [IG]
 ig = input/ig.xml
-template = hl7.au.fhir.template#0.10.0
+template = hl7.au.fhir.template#0.11.0


### PR DESCRIPTION
Update ig.ini to set the dependency on hl7.au.fhir.template v0.11.0. 

This removes the QA Report warning "The link 'http://hl7.org.au/fhir' for "Visit the FHIR website" is a canonical link and is therefore unsafe with regard to versions".