### PR TITLE
Remove Observation.effective[x] type constraint in AU Base Diagnostic Result (FHIR-48632)

### DIFF
--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -125,6 +125,7 @@ To help implementers, only the more significant changes are listed here.
   </li>
   <li>Removed DiagnosticReport.category.coding:anatomicRegionOfInterest slice from <a href="StructureDefinition-au-diagnosticreport.html" >AU Base Diagnostic Report</a> (<a href="https://jira.hl7.org/browse/FHIR-46933">FHIR-46933</a>)</li>
   <li>Change base definition of <a href="StructureDefinition-au-imagingreport.html" >AU Base Diagnostic Imaging Report</a> and <a href="StructureDefinition-au-pathologyreport.html" >AU Base Pathology Report</a> to be <a href="StructureDefinition-au-diagnosticreport.html" >AU Base Diagnostic Report</a> (<a href="https://jira.hl7.org/browse/FHIR-46898">FHIR-46898</a>)</li>
+  <li>Changed Observation.effective[x] type in <a href="StructureDefinition-au-diagnosticresult.html"> AU Base Diagnostic Result </a> to remove type constraint (<a href="https://jira.hl7.org/browse/FHIR-48632">FHIR-48632</a>).</li>
 </ul>
 
 ### Release 4.2.2-ballot

--- a/input/resources/au-diagnosticresult.xml
+++ b/input/resources/au-diagnosticresult.xml
@@ -72,12 +72,6 @@
     <element id="Observation.effective[x]">
       <path value="Observation.effective[x]" />
       <min value="1" />
-      <type>
-        <code value="dateTime" />
-      </type>
-      <type>
-        <code value="Period" />
-      </type>
     </element>
     <element id="Observation.value[x]">
       <path value="Observation.value[x]" />


### PR DESCRIPTION
Changes for [FHIR-48632](https://jira.hl7.org/browse/FHIR-48632).

Changes include: 
- removed type constraints in AU Base Diagnostic Result
- updated change log