### PR TITLE
QA fixes

### DIFF
--- a/input/intro-notes/StructureDefinition-au-practitioner-intro.md
+++ b/input/intro-notes/StructureDefinition-au-practitioner-intro.md
@@ -8,6 +8,6 @@
 - A tertiary qualification or professional membership (non-Ahpra-sourced data) is represented by `Practitioner.qualification`
   - If none of the codes from the preferred value set are suitable then at least text should be sent in `Practitioner.qualification.code`
 
-**Potentially useful extension:**
+**Potentially useful extensions:**
 * Practitioner.qualification: [Ahpra Profession Details](StructureDefinition-ahpraprofession-details.html)
 * Practitioner.qualification: [Ahpra Registration Details](StructureDefinition-ahpraregistration-details.html)

--- a/input/intro-notes/StructureDefinition-au-procedure-intro.md
+++ b/input/intro-notes/StructureDefinition-au-procedure-intro.md
@@ -1,6 +1,6 @@
 ### Usage Notes
 
 **Profile specific implementation guidance:**
-- The [procedure-targetBodyStructure](http://hl7.org/fhir/R4/extension-procedure-targetbodystructure.html) extension may be suitable for use where
+- The [targetBodyStructure](http://hl7.org/fhir/R4/extension-procedure-targetbodystructure.html) extension may be suitable for use where
    - the body site is not implicit in the code found in `Procedure.code` and  
    - body site information is to be handled as a separate resource (e.g. to identify and track separately) instead of an inline coded element in `Procedure.bodySite`. 

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -146,7 +146,7 @@ To help implementers, only the more significant changes are listed here.
   </ul>
 </li>
 <li>Changes to <a href="StructureDefinition-au-practitioner.html">AU Base Practitioner</a>:<ul>
-    <li>Removed invariants inv-pra-0 and inv-pra-1 which makes the use of Ahpra Profession Details and Ahpra Registration Details extensions no longer mutually exclusive (<a href="https://jira.hl7.org/browse/FHIR-46718">FHIR-46718</a>).</li>
+    <li>Removed invariants inv-pra-0 (related to the Ahpra Profession Details extension) and inv-pra-1 (related to the Ahpra Registration Details extension), which makes the use of these extensions no longer mutually exclusive. Remaining invariants were renumbered, and the profile now includes new inv-pra-0 and inv-pra-1 rules (<a href="https://jira.hl7.org/browse/FHIR-46718">FHIR-46718</a>).</li>
     <li>Removed the explicit inclusion of the Ahpra Profession Details and Ahpra Registration Details extension from Practitioner.qualification(<a href="https://jira.hl7.org/browse/FHIR-46718">FHIR-46718</a>).</li>
   </ul>
 </li>

--- a/input/resources/au-practitioner.xml
+++ b/input/resources/au-practitioner.xml
@@ -19,35 +19,35 @@
       <path value="Practitioner" />
       <short value="A practitioner in an Australian healthcare context" />
       <constraint>
-        <key value="inv-pra-2" />
+        <key value="inv-pra-0" />
         <severity value="warning" />
         <human value="Individual gender identity shall be a member of the Gender Identity Response value set if any codes within that value set can apply" />
         <expression value="extension('http://hl7.org/fhir/StructureDefinition/individual-genderIdentity').empty() or extension('http://hl7.org/fhir/StructureDefinition/individual-genderIdentity').all(extension('value').value.memberOf('https://healthterminologies.gov.au/fhir/ValueSet/gender-identity-response-1'))"/>
         <source value="http://hl7.org.au/fhir/StructureDefinition/au-practitioner" />
       </constraint>
       <constraint>
-        <key value="inv-pra-3" />
+        <key value="inv-pra-1" />
         <severity value="warning" />
         <human value="Individual pronouns shall be a member of the Australian Pronouns value set if any codes within that value set can apply" />
         <expression value="extension('http://hl7.org/fhir/StructureDefinition/individual-pronouns').empty() or extension('http://hl7.org/fhir/StructureDefinition/individual-pronouns').all(extension('value').value.memberOf('https://healthterminologies.gov.au/fhir/ValueSet/australian-pronouns-1'))"/>
         <source value="http://hl7.org.au/fhir/StructureDefinition/au-practitioner" />
       </constraint>
       <constraint>
-        <key value="inv-pra-4" />
+        <key value="inv-pra-2" />
         <severity value="warning" />
         <human value="Recorded sex or gender type shall be a member of the AU Recorded Sex or Gender Type value set if any codes within that value set can apply" />
         <expression value="extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').extension('type').empty() or extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').all(extension('type').value.memberOf('http://terminology.hl7.org.au/ValueSet/rsg-type'))"/>
         <source value="http://hl7.org.au/fhir/StructureDefinition/au-practitioner" />
       </constraint>
       <constraint>
-        <key value="inv-pra-5" />
+        <key value="inv-pra-3" />
         <severity value="warning" />
         <human value="Recorded sex or gender source document type shall be a member of the AU Recorded Sex or Gender (RSG) Source Document Type value set if any codes within that value set can apply" />
         <expression value="extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').extension('sourceDocument').empty() or extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').all(extension('sourceDocument').value.memberOf('http://terminology.hl7.org.au/ValueSet/rsg-document-type'))"/>
         <source value="http://hl7.org.au/fhir/StructureDefinition/au-practitioner" />
       </constraint>
       <constraint>
-        <key value="inv-pra-6" />
+        <key value="inv-pra-4" />
         <severity value="warning" />
         <human value="Recorded sex or gender jurisdiction shall be a member of the Jurisdiction ValueSet - AU Extended value set if any codes within that value set can apply" />
         <expression value="extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').extension('jurisdiction').empty() or extension('http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender').all(extension('jurisdiction').value.memberOf('http://terminology.hl7.org.au/ValueSet/jurisdiction-extended'))"/>
@@ -73,7 +73,7 @@
         <code value="Extension" />
         <profile value="http://hl7.org/fhir/StructureDefinition/individual-genderIdentity" />
       </type>
-      <condition value="inv-pra-3"/>
+      <condition value="inv-pra-1"/>
     </element>
     <element id="Practitioner.extension:individualPronouns">
       <path value="Practitioner.extension"/>
@@ -94,9 +94,9 @@
         <code value="Extension"/>
         <profile value="http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender"/>
       </type>
+      <condition value="inv-pra-2"/>
+      <condition value="inv-pra-3"/>
       <condition value="inv-pra-4"/>
-      <condition value="inv-pra-5"/>
-      <condition value="inv-pra-6"/>
     </element>
     <element id="Practitioner.identifier">
       <path value="Practitioner.identifier" />
@@ -120,7 +120,6 @@
     </element>
     <element id="Practitioner.qualification.code">
       <path value="Practitioner.qualification.code" />
-      <condition value="inv-pat-1"/>
       <binding>
         <strength value="preferred" />
         <valueSet value="http://terminology.hl7.org.au/ValueSet/v2-0360-extended" />


### PR DESCRIPTION
- Fixes #929
  - Changes to AU Base Practitioner: 
    - removed condition inv-pat-1 as not applicable 
    - updated the invariant key numbering to start from 0
    - changed **Potentially useful extension:** to **Potentially useful extensions:**
 - Fixes https://github.com/orgs/hl7au/projects/9?pane=issue&itemId=92910784
   - In AU Base Procedure intro, updated extension hyperlink text 'procedure-targetBodyStructure' to match the extension title 'targetBodyStructure' 