### PR TITLE
AFMM update changes (FHIR-49936, FHIR-49935, FHIR-46317)

### DIFF
--- a/input/intro-notes/StructureDefinition-au-immunization-intro.md
+++ b/input/intro-notes/StructureDefinition-au-immunization-intro.md
@@ -1,4 +1,1 @@
 ### Usage Notes
-
-**Potentially useful extensions:**
-* Immunization: [Vaccine Vial Serial Number](StructureDefinition-vaccine-serial-number.html) 

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -7,16 +7,6 @@ To help implementers, only the more significant changes are listed here.
 
 ### Changes in this version
 <ul>
-<li>Changes to <a href="StructureDefinition-au-servicerequest.html" >AU Base Service Request</a>:
-  <ul>
-    <li>AU Service Request to <b>AFMM1</b> maturity level (<a href="https://jira.hl7.org/browse/FHIR-49935">FHIR-49935</a>)</li>
-  </ul>
-</li>
-<li>Changes to <a href="StructureDefinition-vaccine-serial-number.html" >Vaccine Vial Serial Number Extension</a>:
-  <ul>
-    <li>Vaccine Vial Serial Number extension to <b>AFMM1</b> maturity level (<a href="https://jira.hl7.org/browse/FHIR-49936">FHIR-49936</a>)</li>
-  </ul>
-</li>
 <li>Changes to <a href="StructureDefinition-au-immunization.html" >AU Base Immunization</a>:
   <ul>
     <li>Include Vaccine Vial Serial Number in AU Base Immunization extensions (<a href="https://jira.hl7.org/browse/FHIR-46317">FHIR-46317</a>)</li>

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -6,25 +6,24 @@
 To help implementers, only the more significant changes are listed here.
 
 ### Changes in this version
-<li>Changes to <a href="StructureDefinition-au-servicerequest.html" >AU Base Service Request</a>:
 <ul>
-<li>AU Service Request to <b>AFMM1</b> maturity level (<a href="https://jira.hl7.org/browse/FHIR-49935">FHIR-49935</a>)</li>
-</ul>
+<li>Changes to <a href="StructureDefinition-au-servicerequest.html" >AU Base Service Request</a>:
+  <ul>
+    <li>AU Service Request to <b>AFMM1</b> maturity level (<a href="https://jira.hl7.org/browse/FHIR-49935">FHIR-49935</a>)</li>
+  </ul>
 </li>
 <li>Changes to <a href="StructureDefinition-vaccine-serial-number.html" >Vaccine Vial Serial Number Extension</a>:
-<ul>
-<li>Vaccine Vial Serial Number extension to <b>AFMM1</b> maturity level (<a href="https://jira.hl7.org/browse/FHIR-49936">FHIR-49936</a>)</li>
-</ul>
+  <ul>
+    <li>Vaccine Vial Serial Number extension to <b>AFMM1</b> maturity level (<a href="https://jira.hl7.org/browse/FHIR-49936">FHIR-49936</a>)</li>
+  </ul>
 </li>
 <li>Changes to <a href="StructureDefinition-au-immunization.html" >AU Base Immunization</a>:
-<ul>
-<li>Include Vaccine Vial Serial Number in AU Base Immunization extensions (<a href="https://jira.hl7.org/browse/FHIR-46317">FHIR-46317</a>)</li>
-</ul>
+  <ul>
+    <li>Include Vaccine Vial Serial Number in AU Base Immunization extensions (<a href="https://jira.hl7.org/browse/FHIR-46317">FHIR-46317</a>)</li>
+  </ul>
 </li>
-<ul>
 <li>Added general guidance on the use of SNOMED CT (<a href="https://jira.hl7.org/browse/FHIR-48307">FHIR-48307</a>)</li>
 </ul>
-
 
 
 ### Release 5.0.0

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -13,7 +13,7 @@ To help implementers, only the more significant changes are listed here.
 </li>
 <li>Changes to <a href="StructureDefinition-vaccine-serial-number.html" >Vaccine Vial Serial Number Extension</a>:
 <ul>
-<li>Vaccine Vial Serial Number extension to <b?AFMM1</b> maturity level (<a href="https://jira.hl7.org/browse/FHIR-49936">FHIR-49936</a>)</li>
+<li>Vaccine Vial Serial Number extension to <b>AFMM1</b> maturity level (<a href="https://jira.hl7.org/browse/FHIR-49936">FHIR-49936</a>)</li>
 </ul>
 </li>
 <li>Changes to <a href="StructureDefinition-au-immunization.html" >AU Base Immunization</a>:

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -6,9 +6,25 @@
 To help implementers, only the more significant changes are listed here.
 
 ### Changes in this version
+<li>Changes to <a href="StructureDefinition-au-servicerequest.html" >AU Base Service Request</a>:
+<ul>
+<li>AU Service Request to <b>AFMM1</b> maturity level (<a href="https://jira.hl7.org/browse/FHIR-49935">FHIR-49935</a>)</li>
+</ul>
+</li>
+<li>Changes to <a href="StructureDefinition-vaccine-serial-number.html" >Vaccine Vial Serial Number Extension</a>:
+<ul>
+<li>Vaccine Vial Serial Number extension to <b?AFMM1</b> maturity level (<a href="https://jira.hl7.org/browse/FHIR-49936">FHIR-49936</a>)</li>
+</ul>
+</li>
+<li>Changes to <a href="StructureDefinition-au-immunization.html" >AU Base Immunization</a>:
+<ul>
+<li>Include Vaccine Vial Serial Number in AU Base Immunization extensions (<a href="https://jira.hl7.org/browse/FHIR-46317">FHIR-46317</a>)</li>
+</ul>
+</li>
 <ul>
 <li>Added general guidance on the use of SNOMED CT (<a href="https://jira.hl7.org/browse/FHIR-48307">FHIR-48307</a>)</li>
 </ul>
+
 
 
 ### Release 5.0.0

--- a/input/resources/au-immunization.xml
+++ b/input/resources/au-immunization.xml
@@ -19,6 +19,24 @@
       <path value="Immunization" />
       <short value="An immunisation statement in an Australian healthcare context" />
     </element>
+    <element id="Immunization.extension">
+      <path value="Immunization.extension" />
+      <slicing>
+        <discriminator>
+          <type value="value" />
+          <path value="url" />
+        </discriminator>
+        <rules value="open" />
+      </slicing>
+    </element>
+    <element id="Immunization.extension:vaccineVialSerialNumber">
+      <path value="Immunization.extension" />
+      <sliceName value="vaccineVialSerialNumber" />
+      <type>
+        <code value="Extension" />
+        <profile value="http://hl7.org.au/fhir/StructureDefinition/vaccine-serial-number" />
+      </type>
+    </element>
     <element id="Immunization.statusReason">
       <path value="Immunization.statusReason" />
       <binding>

--- a/input/resources/au-servicerequest.xml
+++ b/input/resources/au-servicerequest.xml
@@ -2,7 +2,7 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="au-servicerequest" />
   <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
-    <valueInteger value="0"/> 
+    <valueInteger value="1"/> 
   </extension>
   <url value="http://hl7.org.au/fhir/StructureDefinition/au-servicerequest" />
   <name value="AUBaseServiceRequest" />

--- a/input/resources/au-servicerequest.xml
+++ b/input/resources/au-servicerequest.xml
@@ -7,7 +7,7 @@
   <url value="http://hl7.org.au/fhir/StructureDefinition/au-servicerequest" />
   <name value="AUBaseServiceRequest" />
   <title value="AU Base Service Request" />
-  <status value="draft" />
+  <status value="active" />
   <description value="This profile defines a service request structure that localises core concepts, including terminology, for use in an Australian context. The purpose of this profile is to provide national level agreement on core localised concepts. This profile does not force conformance to core localised concepts. It enables implementers and modellers to make their own rules, i.e. [profiling](http://hl7.org/fhir/profiling.html), about how to support these concepts for specific implementation needs." />
   <kind value="resource" />
   <abstract value="false" />

--- a/input/resources/structuredefinition-vaccine-serial-number.xml
+++ b/input/resources/structuredefinition-vaccine-serial-number.xml
@@ -2,7 +2,7 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="vaccine-serial-number" />
   <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
-    <valueInteger value="0"/> 
+    <valueInteger value="1"/> 
   </extension>
   <url value="http://hl7.org.au/fhir/StructureDefinition/vaccine-serial-number" />
   <name value="VaccineSerialNumber" />

--- a/input/resources/structuredefinition-vaccine-serial-number.xml
+++ b/input/resources/structuredefinition-vaccine-serial-number.xml
@@ -7,7 +7,7 @@
   <url value="http://hl7.org.au/fhir/StructureDefinition/vaccine-serial-number" />
   <name value="VaccineSerialNumber" />
   <title value="Vaccine Vial Serial Number" />
-  <status value="draft" />
+  <status value="active" />
   <description value="This extension applies to the Immunization resource and is used to represent the serial number of the vial of vaccine. Vial serial number is part of the [Australian Immunisation Register Rule 2015](https://www.legislation.gov.au/Latest/F2021C00234) data elements to report for COVID-19 vaccines." />
   <kind value="complex-type" />
   <abstract value="false" />


### PR DESCRIPTION
Raise AU Base ServiceRequest and Vaccine Vial Serial Number Extension to AFMM1 plus agreed usage of Vaccine Vial Serial Number in AU Base Immunization

Changes as per issues:
[FHIR-49936 AU Base Vaccine Vial Serial Number Extension should be AFMM1](https://jira.hl7.org/browse/FHIR-49936) 
[FHIR-49935 AU Base Service Request should be at AFMM1](https://jira.hl7.org/browse/FHIR-49935)
[FHIR-46317 Add vaccine serial number to AU Base Immunization](https://jira.hl7.org/browse/FHIR-46317)
