### PR TITLE
QA fix to update profile titles in Sex and Gender page (FHIR-46685 follow-up)

### DIFF
--- a/input/pagecontent/sexgender.md
+++ b/input/pagecontent/sexgender.md
@@ -16,7 +16,7 @@ The table below provides an overview of the sex and gender related concepts in A
             <th style="width: 25%; text-align: center; vertical-align: middle;">Sex and Gender Concept</th>
             <th style="width: 25%; text-align: center; vertical-align: middle;"><a href="StructureDefinition-au-patient.html">AU Base Patient</a></th>
             <th style="width: 25%; text-align: center; vertical-align: middle;"><a href="StructureDefinition-au-practitioner.html">AU Base Practitioner</a></th>
-            <th style="width: 25%; text-align: center; vertical-align: middle;"><a href="StructureDefinition-au-relatedperson.html">AU Base Related Person</a></th>
+            <th style="width: 25%; text-align: center; vertical-align: middle;"><a href="StructureDefinition-au-relatedperson.html">AU Base RelatedPerson</a></th>
         </tr>
     </thead>
     <tbody>
@@ -119,7 +119,7 @@ Example: Patient resource with Patient.gender qualified with Person Recorded Sex
 AU Base supports representation and exchange of the Name to Use data element (as defined in the [HL7 Cross Paradigm Implementation Guide: Gender Harmony - Sex and Gender Representation, Edition 1](https://hl7.org/xprod/ig/uv/gender-harmony/informative1/)) in:
 - [AU Base Patient](StructureDefinition-au-patient.html)
 - [AU Base Practitioner](StructureDefinition-au-practitioner.html)
-- [AU Base Related Person](StructureDefinition-au-relatedperson.html)
+- [AU Base RelatedPerson](StructureDefinition-au-relatedperson.html)
 
 Name to Use is represented using "usual" in `name.use`. 
 
@@ -145,7 +145,7 @@ Example: RelatedPerson resource with name to use
 AU Base supports representation and exchange of the Pronouns data element (as defined in the [HL7 Cross Paradigm Implementation Guide: Gender Harmony - Sex and Gender Representation, Edition 1](https://hl7.org/xprod/ig/uv/gender-harmony/informative1/)) in:
 - [AU Base Patient](StructureDefinition-au-patient.html)
 - [AU Base Practitioner](StructureDefinition-au-practitioner.html)
-- [AU Base Related Person](StructureDefinition-au-relatedperson.html)
+- [AU Base RelatedPerson](StructureDefinition-au-relatedperson.html)
 
 Pronouns is represented with the [Individual Pronouns](http://hl7.org/fhir/StructureDefinition/individual-pronouns) extension. In AU Base the value element of the [Individual Pronouns](http://hl7.org/fhir/StructureDefinition/individual-pronouns) extension is constrained to be [Australian Pronouns](https://www.healthterminologies.gov.au/integration/R4/fhir/ValueSet/australian-pronouns-1) ([extensible](http://hl7.org/fhir/R4/terminologies.html#extensible)).
 
@@ -221,7 +221,7 @@ Example: Patient resource with prefer not to answer for pronouns
 AU Base supports representation and exchange of the Gender Identity data element (as defined in the [HL7 Cross Paradigm Implementation Guide: Gender Harmony - Sex and Gender Representation, Edition 1](https://hl7.org/xprod/ig/uv/gender-harmony/informative1/)) and aligned to [Australian Bureau of Statics Standard for Sex, Gender, Variations of Sex Characteristics and Sexual Orientation Variables, 2020](https://www.abs.gov.au/statistics/standards/standard-sex-gender-variations-sex-characteristics-and-sexual-orientation-variables/latest-release#gender) in:
 - [AU Base Patient](StructureDefinition-au-patient.html)
 - [AU Base Practitioner](StructureDefinition-au-practitioner.html)
-- [AU Base Related Person](StructureDefinition-au-relatedperson.html)
+- [AU Base RelatedPerson](StructureDefinition-au-relatedperson.html)
 
 Gender Identity is represented with the [Individual Gender Identity](http://hl7.org/fhir/StructureDefinition/individual-genderIdentity) extension. In AU Base the value element of the [Individual Gender Identity](http://hl7.org/fhir/StructureDefinition/individual-genderIdentity) extension is constrained to be [Gender Identity Response](https://healthterminologies.gov.au/fhir/ValueSet/gender-identity-response-1) value set ([extensible](http://hl7.org/fhir/R4/terminologies.html#extensible)).
 
@@ -266,7 +266,7 @@ Example: Patient resource with gender identity
 AU Base supports representation and exchange of the Recorded Sex or Gender (RSG) data element (as defined in the [HL7 Cross Paradigm Implementation Guide: Gender Harmony - Sex and Gender Representation, Edition 1](https://hl7.org/xprod/ig/uv/gender-harmony/informative1/)) in:
 - [AU Base Patient](StructureDefinition-au-patient.html)
 - [AU Base Practitioner](StructureDefinition-au-practitioner.html)
-- [AU Base Related Person](StructureDefinition-au-relatedperson.html)
+- [AU Base RelatedPerson](StructureDefinition-au-relatedperson.html)
 
 RSG is represented with the [Person Recorded Sex or Gender](https://hl7.org/fhir/extensions/StructureDefinition-individual-recordedSexOrGender.html) extension. In AU Base:
 - the type element is constrained to be [AU Recorded Sex or Gender Type](ValueSet-rsg-type.html) ([extensible](http://hl7.org/fhir/R4/terminologies.html#extensible))
@@ -349,7 +349,7 @@ Example: Patient resource with recorded gender from a passport
 AU Base supports representation and exchange of the Sex Assigned at Birth data element (as defined in the [HL7 Cross Paradigm Implementation Guide: Gender Harmony - Sex and Gender Representation, Edition 1](https://hl7.org/xprod/ig/uv/gender-harmony/informative1/)) in:
 - [AU Base Patient](StructureDefinition-au-patient.html)
 - [AU Base Practitioner](StructureDefinition-au-practitioner.html)
-- [AU Base Related Person](StructureDefinition-au-relatedperson.html)
+- [AU Base RelatedPerson](StructureDefinition-au-relatedperson.html)
 
 Sex Assigned at Birth is represented with the [Person Recorded Sex or Gender](https://hl7.org/fhir/extensions/StructureDefinition-individual-recordedSexOrGender.html) extension:
 - the type element is populated with the SNOMED CT code 1515311000168102\|Biological sex at birth\|


### PR DESCRIPTION
This PR updates profile titles in Sex and Gender page to reflect the naming changes introduced by [FHIR-46685](https://jira.hl7.org/browse/FHIR-46685), specifically updating `AU Base Related Person` to `AU Base RelatedPerson`.