### PR TITLE
Refactor invalid use of structuredefinition-standards-status-reason extension from encounter-description and au-diagnosticrequest

### DIFF
--- a/input/resources/au-diagnosticrequest.xml
+++ b/input/resources/au-diagnosticrequest.xml
@@ -2,13 +2,14 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="au-diagnosticrequest" />
   <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
-    <valueInteger value="1"/> 
+    <valueInteger value="1"/>
   </extension>
   <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
-    <valueCode value="deprecated"/>
-  </extension>
-  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status-reason">
-    <valueMarkdown value="This profile is deprecated in AU Base as work is being undertaken in the [AU eRequesting](https://build.fhir.org/ig/hl7au/au-fhir-erequesting) project to define the requirements for a diagnostic request. In AU Base this profile is replaced by [AU Base Service Request](https://build.fhir.org/ig/hl7au/au-fhir-base/StructureDefinition-au-servicerequest.html), which localises core concepts, including identifiers and terminology, for use in an Australian context and enables implementers and modellers to make their own rules, i.e. [profiling](http://hl7.org/fhir/profiling.html), about how to support these concepts for specific implementation needs."/>
+    <valueCode value="deprecated">
+      <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status-reason">
+        <valueMarkdown value="This profile is deprecated in AU Base as work is being undertaken in the [AU eRequesting](https://build.fhir.org/ig/hl7au/au-fhir-erequesting) project to define the requirements for a diagnostic request. In AU Base this profile is replaced by [AU Base Service Request](https://build.fhir.org/ig/hl7au/au-fhir-base/StructureDefinition-au-servicerequest.html), which localises core concepts, including identifiers and terminology, for use in an Australian context and enables implementers and modellers to make their own rules, i.e. [profiling](http://hl7.org/fhir/profiling.html), about how to support these concepts for specific implementation needs."/>
+      </extension>
+    </valueCode>
   </extension>
   <url value="http://hl7.org.au/fhir/StructureDefinition/au-diagnosticrequest" />
   <name value="AUBaseDiagnosticRequest" />

--- a/input/resources/structuredefinition-encounter-description.xml
+++ b/input/resources/structuredefinition-encounter-description.xml
@@ -2,13 +2,14 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="encounter-description"/>
   <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
-    <valueInteger value="1"/> 
+    <valueInteger value="1"/>
   </extension>
   <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
-    <valueCode value="deprecated"/>
-  </extension>
-  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status-reason">
-    <valueMarkdown value="This extension is deprecated as supporting clinical summary information (including clinical notes) in a resource-level extension is not in alignment with widely implemented approaches internationally and not considered best practice.&#xA;&#xA;Support for clinical notes in Australia is subject to further discussion and input is sought from the community."/>
+    <valueCode value="deprecated">
+      <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status-reason">
+        <valueMarkdown value="This extension is deprecated as supporting clinical summary information (including clinical notes) in a resource-level extension is not in alignment with widely implemented approaches internationally and not considered best practice.&#xA;&#xA;Support for clinical notes in Australia is subject to further discussion and input is sought from the community."/>
+      </extension>
+    </valueCode>
   </extension>
   <url value="http://hl7.org.au/fhir/StructureDefinition/encounter-description"/>
   <name value="EncounterDescription"/>
@@ -28,8 +29,7 @@
     <element id="Extension">
       <path value="Extension"/>
       <short value="Deprecated: Description, overview or summary of an encounter"/>
-      <definition
-        value="This extension is deprecated as supporting clinical summary information (including clinical notes) in a resource-level extension is not in alignment with widely implemented approaches internationally and not considered best practice. Support for clinical notes in Australia is subject to further discussion and input is sought from the community.&#xA;&#xA;Description, overview or summary of a clinical event and its reasons."/>
+      <definition value="This extension is deprecated as supporting clinical summary information (including clinical notes) in a resource-level extension is not in alignment with widely implemented approaches internationally and not considered best practice. Support for clinical notes in Australia is subject to further discussion and input is sought from the community.&#xA;&#xA;Description, overview or summary of a clinical event and its reasons."/>
       <max value="1" />
     </element>
     <element id="Extension.url">


### PR DESCRIPTION
This PR eliminates QA Report errors by moving the standards-status-reason extension:
> The extension http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status-reason is not allowed to be used at this point (allowed = x:http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status; this element is [StructureDefinition, http://hl7.org.au/fhir/StructureDefinition/encounter-description])

Changes in:

- Encounter Description
- AU Base Diagnostic Request