### PR TITLE
Qa fix example displays

### DIFF
--- a/input/examples/bundle-example0.xml
+++ b/input/examples/bundle-example0.xml
@@ -642,7 +642,7 @@
             </extension>
             <system value="http://snomed.info/sct"/>
             <code value="844301000168106"/>
-            <display value="fluoxetine 20 mg tablet"/>
+            <display value="Fluoxetine 20 mg tablet"/>
           </coding>
           <coding>
             <extension url="http://hl7.org.au/fhir/StructureDefinition/medication-type">
@@ -792,7 +792,7 @@
             </extension>
             <system value="http://snomed.info/sct"/>
             <code value="75561000036109"/>
-            <display value="aspirin 100 mg enteric tablet"/>
+            <display value="Aspirin 100 mg enteric tablet"/>
           </coding>
           <coding>
             <extension url="http://hl7.org.au/fhir/StructureDefinition/medication-type">
@@ -804,7 +804,7 @@
             </extension>
             <system value="http://snomed.info/sct"/>
             <code value="3338011000036100"/>
-            <display value="cartia"/>
+            <display value="Cartia"/>
           </coding>
           <text value="ASPIRIN 100mg EC TABLET, CARTIA"/>
         </medicationCodeableConcept>
@@ -918,7 +918,7 @@
             </extension>
             <system value="http://snomed.info/sct"/>
             <code value="32641000036100"/>
-            <display value="ticagrelor 90 mg tablet"/>
+            <display value="Ticagrelor 90 mg tablet"/>
           </coding>
           <coding>
             <extension url="http://hl7.org.au/fhir/StructureDefinition/medication-type">
@@ -1045,7 +1045,7 @@
             </extension>
             <system value="http://snomed.info/sct"/>
             <code value="931840011000036108"/>
-            <display value="omega-3-acid ethyl esters-90 1 g capsule"/>
+            <display value="Omega-3-acid ethyl esters-90 1 g capsule"/>
           </coding>
           <coding>
             <extension url="http://hl7.org.au/fhir/StructureDefinition/medication-type">
@@ -1170,7 +1170,7 @@
             </extension>
             <system value="http://snomed.info/sct"/>
             <code value="23369011000036100"/>
-            <display value="nifedipine 30 mg modified release tablet"/>
+            <display value="Nifedipine 30 mg modified release tablet"/>
           </coding>
           <coding>
             <extension url="http://hl7.org.au/fhir/StructureDefinition/medication-type">
@@ -1339,7 +1339,7 @@
             </extension>
             <system value="http://snomed.info/sct"/>
             <code value="82521011000036105"/>
-            <display value="glyceryl trinitrate 600 microgram sublingual tablet, 30"/>
+            <display value="Glyceryl trinitrate 600 microgram sublingual tablet, 30"/>
           </coding>
           <coding>
             <extension url="http://hl7.org.au/fhir/StructureDefinition/medication-type">
@@ -1462,7 +1462,7 @@
             </extension>
             <system value="http://snomed.info/sct"/>
             <code value="23165011000036107"/>
-            <display value="atorvastatin 80 mg tablet"/>
+            <display value="Atorvastatin 80 mg tablet"/>
           </coding>
           <coding>
             <extension url="http://hl7.org.au/fhir/StructureDefinition/medication-type">
@@ -1624,7 +1624,7 @@
             </extension>
             <system value="http://snomed.info/sct"/>
             <code value="23221011000036102"/>
-            <display value="metoprolol tartrate 50 mg tablet"/>
+            <display value="Metoprolol tartrate 50 mg tablet"/>
           </coding>
           <coding>
             <extension url="http://hl7.org.au/fhir/StructureDefinition/medication-type">

--- a/input/examples/medicationrequest-example1.xml
+++ b/input/examples/medicationrequest-example1.xml
@@ -45,7 +45,7 @@
         <coding>
             <system value="http://snomed.info/sct"/>
             <code value="86406008"/>
-            <display value="Human immunodeficiency virus infection (disorder)"/>
+            <display value="HIV infection"/>
         </coding>
     </reasonCode>
     <note>

--- a/input/examples/norelevantfinding-example0.xml
+++ b/input/examples/norelevantfinding-example0.xml
@@ -20,7 +20,7 @@
         <coding>
             <system value="http://snomed.info/sct"/>
             <code value="416128008"/>
-            <display value="No history of procedure (situation)"/>
+            <display value="No history of procedure"/>
         </coding>
     </valueCodeableConcept>
 </Observation>

--- a/input/examples/norelevantfinding-example2.xml
+++ b/input/examples/norelevantfinding-example2.xml
@@ -20,7 +20,7 @@
         <coding>
             <system value="http://snomed.info/sct"/>
             <code value="443508001"/>
-            <display value="No history of clinical finding in subject (situation)"/>
+            <display value="No history of clinical finding in subject"/>
         </coding>
     </valueCodeableConcept>
 </Observation>

--- a/input/examples/relatedperson-example1.xml
+++ b/input/examples/relatedperson-example1.xml
@@ -12,7 +12,7 @@
     <coding>
       <system value="http://snomed.info/sct"/>
       <code value="133932002"/>
-      <display value="Caregiver (person)"/>
+      <display value="Caregiver"/>
     </coding>
   </relationship>
   <name>

--- a/input/examples/relatedperson-example3.xml
+++ b/input/examples/relatedperson-example3.xml
@@ -9,7 +9,7 @@
       <coding>
         <system value="http://terminology.hl7.org/CodeSystem/v2-0203"/>
         <code value="MC"/>
-        <display value="Patient's Medicare Number"/>
+        <display value="Patient's Medicare number"/>
       </coding>
       <text value="Medicare Number"/>
     </type>

--- a/input/examples/servicerequest-path-example0.xml
+++ b/input/examples/servicerequest-path-example0.xml
@@ -42,7 +42,7 @@
         <coding>
             <system value="http://snomed.info/sct"/>
             <code value="26604007"/>
-            <display value="Complete blood count (procedure)"/>
+            <display value="Complete blood count"/>
         </coding>
         <text value="Full blood count"/>
     </code>

--- a/input/examples/specimen-serum.xml
+++ b/input/examples/specimen-serum.xml
@@ -12,7 +12,7 @@
         <coding>
             <system value="http://snomed.info/sct"/>
             <code value="119364003"/>
-            <display value="Serum specimen (specimen)"/>
+            <display value="Serum specimen"/>
         </coding>
     </type>
     <subject>


### PR DESCRIPTION
QA Fixes: #973 
- AMT v4 updates to medication displays
- Identifier type coding display for Medicare number
- Remove semantic tag / change from using SNOMED CT FSN to PT for some displays 