### PR TITLE
FHIR-51347 - AFMM 1 + Change Log Convention Change

### DIFF
--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -8,10 +8,7 @@ To help implementers, only the more significant changes are listed here.
 #### Reinstated
 This version of current build reinstates profiles not included in the AU Base 5.0.0 release:
   <ul>
-      <li>AU Base Service Request</li>
       <li>AU Base Coverage</li>
-      <li>Vaccine Vial Serial Number extension</li>
-      <li>Medication Strength extension</li>
       <li>Ethnicity extension</li>
   </ul>
 
@@ -28,6 +25,9 @@ This version of current build reinstates profiles not included in the AU Base 5.
 <ul>
   <li>New profiles:
     <ul>
+      <li><a href="StructureDefinition-au-servicerequest.html">AU Base Service Request</a> (<a href="https://jira.hl7.org/browse/FHIR-FHIR-46714">FHIR-FHIR-46714</a>)</li>
+    </ul>
+    <ul>
       <li><a href="StructureDefinition-au-pi.html">AU Patient Internal Identifier</a> (<a href="https://jira.hl7.org/browse/FHIR-48671">FHIR-48671</a>)</li>
     </ul>
     <ul>
@@ -37,6 +37,14 @@ This version of current build reinstates profiles not included in the AU Base 5.
   <li>New search parameters:
     <ul>
         <li><a href="SearchParameter-servicerequest-supporting-info.html">ServiceRequestSupportingInfo</a> (<a href="https://jira.hl7.org/browse/FHIR-51437">FHIR-51437</a>)</li>
+    </ul>
+  </li>
+   <li>New extensions:
+    <ul>
+        <li><a href="StructureDefinition-medication-strength.html">Medication Strength</a> (<a href="https://github.com/hl7au/au-fhir-base/issues/41">au-fhir-base #41</a>, <a href="https://jira.hl7.org/browse/FHIR-50945">FHIR-50945</a>)</li>
+    </ul>
+    <ul>
+        <li><a href="StructureDefinition-vaccine-serial-number.html">Vaccine Vial Serial Number</a> (<a href="https://github.com/hl7au/au-fhir-base/issues/712">au-fhir-base #712</a>)</li>
     </ul>
   </li>
   <li>Deprecated extensions:

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -25,7 +25,7 @@ This version of current build reinstates profiles not included in the AU Base 5.
 <ul>
   <li>New profiles:
     <ul>
-      <li><a href="StructureDefinition-au-servicerequest.html">AU Base Service Request</a> (<a href="https://jira.hl7.org/browse/FHIR-FHIR-46714">FHIR-FHIR-46714</a>)</li>
+      <li><a href="StructureDefinition-au-servicerequest.html">AU Base Service Request</a> (<a href="https://jira.hl7.org/browse/FHIR-46714">FHIR-46714</a>)</li>
     </ul>
     <ul>
       <li><a href="StructureDefinition-au-pi.html">AU Patient Internal Identifier</a> (<a href="https://jira.hl7.org/browse/FHIR-48671">FHIR-48671</a>)</li>

--- a/input/resources/au-pi.xml
+++ b/input/resources/au-pi.xml
@@ -2,12 +2,12 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="au-pi" />
   <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
-    <valueInteger value="0"/> 
+    <valueInteger value="1"/> 
   </extension>
   <url value="http://hl7.org.au/fhir/StructureDefinition/au-pi" />
   <name value="AUPatientInternalIdentifier" />
   <title value="AU Patient Internal Identifier" />
-  <status value="draft" />
+  <status value="active" />
   <description value="This identifier profile defines a patient internal identifier in an Australian context. A patient internal identifier is assigned to a patient by an application (e.g. practice management system or a cloud-based electronic medical record) to uniquely identify a patient within that application.&#xa;&#xa;While a patient internal identifier can be exchanged with other applications, its scope for sharing is limited and typically occurs for context-specific patient matching (e.g. a patient internal identifier included in a pathology request can be returned in the associated pathology report). This identifier is only unique within the assigning application and is not suitable for broader use as a persistent identifier, unlike a Medical Record Number (MRN), which is unique within an institution." />
   <kind value="complex-type" />
   <abstract value="false" />

--- a/input/resources/au-timezone-usage.xml
+++ b/input/resources/au-timezone-usage.xml
@@ -2,12 +2,12 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="au-timezone-usage" />
   <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
-    <valueInteger value="0"/> 
+    <valueInteger value="1"/> 
   </extension>
   <url value="http://hl7.org.au/fhir/StructureDefinition/au-timezone-usage" />
   <name value="AustralianTimeZoneUsage" />
   <title value="Australian Time Zone Usage" />
-  <status value="draft" />
+  <status value="active" />
   <description value="This profile defines specific usage of Australian time zones (states and territories) with the FHIR [Timezone Code extension](https://hl7.org/fhir/extensions/StructureDefinition-timezone.html)." />
   <kind value="complex-type" />
   <abstract value="false" />

--- a/input/resources/structuredefinition-medication-strength.xml
+++ b/input/resources/structuredefinition-medication-strength.xml
@@ -2,12 +2,12 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="medication-strength"/>
   <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
-    <valueInteger value="0"/> 
+    <valueInteger value="1"/> 
   </extension>
   <url value="http://hl7.org.au/fhir/StructureDefinition/medication-strength"/>
   <name value="MedicationStrength"/>
   <title value="Medication Strength"/>
-  <status value="draft"/>
+  <status value="active"/>
   <description value="This extension applies to the Medication resource and is used to represent the strength of a medication as text. Use this extension for text representation of a medication strength as a whole. Coded representation of medication strength as a whole uses `Medication.code`."/>
   <kind value="complex-type"/>
   <abstract value="false"/>

--- a/input/resources/valueset-au-coverage-type-extended.xml
+++ b/input/resources/valueset-au-coverage-type-extended.xml
@@ -4,7 +4,7 @@
 		<profile value="https://healthterminologies.gov.au/fhir/StructureDefinition/composed-value-set-4"/>
 	</meta>
 	<extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
-		<valueInteger value="0"/>
+		<valueInteger value="1"/>
 	</extension>
 	<url value="http://terminology.hl7.org.au/ValueSet/au-coverage-type-extended"/>
 	<identifier>
@@ -13,7 +13,7 @@
 	</identifier>
 	<name value="CoverageTypeandSelfPayCodesAUExtended"/>
 	<title value="Coverage Type and Self-Pay Codes - AU Extended"/>
-	<status value="draft"/>
+	<status value="active"/>
 	<experimental value="false"/>
 	<description value="Coverage type codes extended for use in an Australian context. Includes HL7 international codes plus Australian additions to create a complete set."/>
 	<compose>

--- a/readme.md
+++ b/readme.md
@@ -36,4 +36,3 @@ Once the issue is logged, you should discuss with the team on [chat.fhir.org in 
 ### 5. Create a pull request
 
 When everyone has agreed on a course of action, IG changes should be submitted as a pull request for review in this repository.
-


### PR DESCRIPTION
Fixes [FHIR-51347](https://jira.hl7.org/browse/FHIR-51347) AFMM1 to publish in the upcoming ballot snapshot:

- Datatype Profile: AU Patient Internal Identifier
- Profile of Extension: Australian Time Zone Usage
- ValueSet: Coverage Type and Self-Pay Codes - AU Extended
- Extension: Medication Strength (Extension)

Change Log convention change so that artefacts marked as AFMM 1 are added as 'new' in this release. Applies to:

- AU Base Service Request
- Vaccine Vial Serial Number extension
- Medication Strength extension