### PR TITLE
FHIR-49256 - Use example.com URIs instead of example.acme.com.au

### DIFF
--- a/input/examples/medication-BrandedPack0.xml
+++ b/input/examples/medication-BrandedPack0.xml
@@ -13,7 +13,7 @@
           <display value="Branded package with no container"/>
         </valueCoding>
       </extension>
-      <system value="http://example.org/generic-packages"/>
+      <system value="http://example.com/generic-packages"/>
       <code value="8246-10097"/>
       <display value="Nexium HP7 20;500;500 (1)"/>
     </coding>

--- a/input/examples/medication-GenericPack0.xml
+++ b/input/examples/medication-GenericPack0.xml
@@ -13,7 +13,7 @@
 					<display value="Unbranded package with no container"/>
 				</valueCoding>
 			</extension>
-			<system value="http://example.org/generic-packages"/>
+			<system value="http://example.com/generic-packages"/>
 			<code value="5636-24556"/>
 			<display value="Paracetamol 500mg (100)"/>
 		</coding>

--- a/input/examples/specimen-serum.xml
+++ b/input/examples/specimen-serum.xml
@@ -5,7 +5,7 @@
     </meta>
     
     <accessionIdentifier>
-        <system value="https://example.org/labs/accession-ids"/>
+        <system value="https://example.com/labs/accession-ids"/>
         <value value="1978881817"/>
     </accessionIdentifier>
     <type>
@@ -27,7 +27,7 @@
     <container>
         <type>
             <coding>
-                <system value="https://example.org/labs"/>
+                <system value="https://example.com/labs"/>
                 <code value="SST"/>
                 <display value="Serum Separator Tube"/>
             </coding>


### PR DESCRIPTION
This PR fixes [FHIR-49256](https://jira.hl7.org/browse/FHIR-49256).

Updated example resource instances to replace "http://example.acme.com.au" URIs with "http://example.org/" as per HL7 
guidance: https://build.fhir.org/ig/HL7/UTG/codesystems-fhir.html.