### PR TITLE
Terminology page - Add ParticipationType CodeSystem row

### DIFF
--- a/input/pagecontent/generalguidance.md
+++ b/input/pagecontent/generalguidance.md
@@ -268,6 +268,9 @@ Example: Patient resource with a medical record number (local identifier)
 
 
 ### Australian Health Practitioner Regulation Agency (Ahpra) Data Guidance
+
+<p class="stu-note">This section refers to deprecated material and is retained until the <a href="StructureDefinition-ahpraregistration-details.html">Ahpra Registration Details</a> and <a href="StructureDefinition-ahpraprofession-details.html">Ahpra Profession Details</a> extensions are retired.</p>
+
 This guidance on the representation of Ahpra-sourced data is taken and adapted from Ahpra's practitioner information exchange (PIE) interoperability specification: Find registration.
 
 Ahpra data items should be exchanged using a Practitioner resource.


### PR DESCRIPTION
QA fix - Add entry for [ParticipationType](https://terminology.hl7.org/5.1.0/CodeSystem-v3-ParticipationType.html) code system, which is part of the definition of Related Person Relationship Type value set.
This was incorrectly removed in https://github.com/hl7au/au-fhir-base/pull/1007