### PR TITLE
Correct .code to .medicationCodeableConcept in usage notes for AU Base MedicationStatement and AU Base MedicationRequest (FHIR-52190)

### DIFF
--- a/input/intro-notes/StructureDefinition-au-medicationrequest-intro.md
+++ b/input/intro-notes/StructureDefinition-au-medicationrequest-intro.md
@@ -2,13 +2,13 @@
 
 **Profile specific implementation guidance:**
 - When identifying a medication, this resource can use either a code or refer to a Medication resource. 
-- If making use of `MedicationRequest.code`, this profile includes coding as:
+- If making use of `MedicationRequest.medicationCodeableConcept`, this profile includes coding as:
   - [PBS Item Code](https://www.pbs.gov.au/pbs/home) - Pharmaceutical Benefits Scheme coding, claiming context is not relevant as medicine coding
   - [Medication Package Global Trade Item Number](http://terminology.hl7.org/ValueSet/v3-GTIN) - Global Trade Item Number (GTIN) physical product reference
   - [AMT Medicines](https://healthterminologies.gov.au/fhir/ValueSet/australian-medication-1) - Australian Medicines Terminology, national drug terminology
   - [MIMS Package](https://www.mims.com.au/index.php) - commonly used medicine coding
-- If a medication is compounded and is a list of ingredients, `MedicationRequest.code` is still present and may contain only the list of ingredients as text in `MedicationRequest.code.text`.
-- Where additional medicinal product information is needed, `MedicationRequest.medicationReference` is preferred to `MedicationRequest.code` and use of extensions, see guidance on [AU Base Medication](StructureDefinition-au-medication.html).
+- If a medication is compounded and is a list of ingredients, `MedicationRequest.medicationCodeableConcept` is still present and may contain only the list of ingredients as text in `MedicationRequest.medicationCodeableConcept.text`.
+- Where additional medicinal product information is needed, `MedicationRequest.medicationReference` is preferred to `MedicationRequest.medicationCodeableConcept` and use of extensions, see guidance on [AU Base Medication](StructureDefinition-au-medication.html).
 - See each Identifier profile page for guidance related to that identifier type.
 - This profile supports the sex, gender, and related concept of Sex Parameter for Clinical Use:
    - When exchanging concepts of sex or gender, refer to the guidance in [Sex and Gender](sexgender.html) and the [Gender Harmony Implementation Guide](http://hl7.org/xprod/ig/uv/gender-harmony/).

--- a/input/intro-notes/StructureDefinition-au-medicationstatement-intro.md
+++ b/input/intro-notes/StructureDefinition-au-medicationstatement-intro.md
@@ -2,13 +2,13 @@
 
 **Profile specific implementation guidance:**
 - When identifying a medication, this resource can use either a code or refer to a Medication resource. 
-- If making use of `MedicationStatement.code`, this profile includes coding as:
+- If making use of `MedicationStatement.medicationCodeableConcept`, this profile includes coding as:
   - [PBS Item Code](https://www.pbs.gov.au/pbs/home) - Pharmaceutical Benefits Scheme coding, claiming context is not relevant as medicine coding
   - [Medication Package Global Trade Item Number](http://terminology.hl7.org/ValueSet/v3-GTIN) - Global Trade Item Number (GTIN) physical product reference
   - [AMT Medicines](https://healthterminologies.gov.au/fhir/ValueSet/australian-medication-1) - Australian Medicines Terminology, national drug terminology
   - [MIMS Package](https://www.mims.com.au/index.php) - commonly used medicine coding
-- If a medication is compounded and is a list of ingredients, `MedicationStatement.code` is still present and may contain only the list of ingredients as text in `MedicationStatement.code.text`.
-- Where additional medicinal product information is needed, `MedicationStatement.medicationReference` is preferred to `MedicationStatement.code` and use of extensions, see guidance on [AU Base Medication](StructureDefinition-au-medication.html).
+- If a medication is compounded and is a list of ingredients, `MedicationStatement.medicationCodeableConcept` is still present and may contain only the list of ingredients as text in `MedicationStatement.medicationCodeableConcept.text`.
+- Where additional medicinal product information is needed, `MedicationStatement.medicationReference` is preferred to `MedicationStatement.medicationCodeableConcept` and use of extensions, see guidance on [AU Base Medication](StructureDefinition-au-medication.html).
 
 **Potentially useful extensions:**
 * MedicationStatement: [Medication Brand Name](StructureDefinition-medication-brand-name.html)


### PR DESCRIPTION
[FHIR-52190](https://jira.hl7.org/browse/FHIR-52190) MedicationStatement Usage notes narrative refers to non-existent element 'MedicationStatement.code'

Correct ".code" to ".medicationCodeableConcept" in AU Base MedicationStatement and AU Base MedicationRequest.