### PR TITLE
FHIR-52555 Removed broken hyperlink from medication.ingredient.strength[x] extension

### DIFF
--- a/input/intro-notes/StructureDefinition-au-medication-intro.md
+++ b/input/intro-notes/StructureDefinition-au-medication-intro.md
@@ -16,7 +16,7 @@
   - medication form in `Medication.form.text`
   - item form and strength as part of medication definition in `Medication.code.text`
   - manufacturer in `Medication.manufacturer.display`
-- When individual ingredient strength is unavailable as a ratio, it can be surfaced as text in `CodeableConcept.text` by using pre-adoption of the FHIR R5 [`Medication.ingredient.strength[x]`](https://www.hl7.org/fhir/R5/medication-definitions.html#Medication.ingredient) element with the extension URL [http://hl7.org/fhir/5.0/StructureDefinition/extension-Medication.ingredient.strength[x]](http://hl7.org/fhir/5.0/StructureDefinition/extension-Medication.ingredient.strength[x]). See this example of use [Tadim](Medication-IngredientStrengthExtension0.html). 
+- When individual ingredient strength is unavailable as a ratio, it can be surfaced as text in `CodeableConcept.text` by using pre-adoption of the FHIR R5 [`Medication.ingredient.strength[x]`](https://www.hl7.org/fhir/R5/medication-definitions.html#Medication.ingredient) element with the extension URL http://hl7.org/fhir/5.0/StructureDefinition/extension-Medication.ingredient.strength[x]. See this example of use [Tadim](Medication-IngredientStrengthExtension0.html). 
   - This is to be interpreted as the strength of that specific ingredient, not the strength of the medication as a whole.
   - Where possible use the existing `Medication.ingredient.strength` element in preference to pre-adopting the FHIR R5 `Medication.ingredient.strength[x]` element.
   - Details on cross version pre-adoption implementation can be found in the FHIR specification [Extensions for converting between versions](https://hl7.org/fhir/R5/versions.html#extensions) section.


### PR DESCRIPTION
[FHIR-52555](https://jira.hl7.org/browse/FHIR-52555)
The link to medication.ingredient.strength[x] extension is broken. Removed the hyperlink and retained the text in file: input/intro-notes/StructureDefinition-au-medication-intro.md