### PR TITLE
QA fixes for FHIR-51408: move change log entries to correct artefacts

### DIFF
--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -205,7 +205,6 @@ The [HL7 AU FHIR Artefact Release Publishing Policy](https://hl7.org.au/fhir/6.0
  <li><a href="https://hl7.org.au/fhir/6.0.0-ballot/StructureDefinition-au-pathologyresult.html">AU Base Pathology Result</a>:
     <ul>
       <li>Changed Observation.effective[x] type to remove type constraint (<a href="https://jira.hl7.org/browse/FHIR-49189">FHIR-49189</a>).</li>
-      <li>DiagnosticReport.extension changed to add Patient Sex Parameter For Clinical Use (<a href="https://jira.hl7.org/browse/FHIR-51408">FHIR-51408</a>).</li>
     </ul>
   </li>
   <li><a href="https://hl7.org.au/fhir/6.0.0-ballot/StructureDefinition-au-pathologyreport.html">AU Base Pathology Report</a>: 


### PR DESCRIPTION
QA fix for FHIR-51408 to move Change Log entry
"DiagnosticReport.extension changed to add Patient Sex Parameter For Clinical Use (FHIR-51408)" 

from 
- AU Base Diagnostic Imaging Result, and
- AU Base Pathology Result

to the correct artefacts:
- AU Base Diagnostic Imaging Report, and
- AU Base Pathology Report.