### PR TITLE
QA Items

### DIFF
--- a/input/intro-notes/StructureDefinition-au-encounter-intro.md
+++ b/input/intro-notes/StructureDefinition-au-encounter-intro.md
@@ -1,7 +1,7 @@
 ### Usage Notes
 
 **Profile specific implementation guidance:**
-- To associate a healthcare service with an encounter implement [FHIR R5 element pre-adoption](https://hl7.org/fhir/R5/versions.html#extensions) of [`Encounter.participant.actor`](https://hl7.org/fhir/R5/encounter-definitions.html#Encounter.participant.actor). See example [Inpatient Encounter](Encounter-example0.html).
+- To associate a healthcare service with an encounter include [FHIR R5 element pre-adoption](https://hl7.org/fhir/R5/versions.html#extensions) of [`Encounter.participant.actor`](https://hl7.org/fhir/R5/encounter-definitions.html#Encounter.participant.actor). See example [Inpatient Encounter](Encounter-example0.html).
   - Use the pre-adoption extension URL [http://hl7.org/fhir/5.0/StructureDefinition/extension-Encounter.participant.actor](http://hl7.org/fhir/5.0/StructureDefinition/extension-Encounter.participant.actor).
   - Apply the pre-adoption extension on `Encounter.participant`.
 

--- a/input/intro-notes/StructureDefinition-au-medication-intro.md
+++ b/input/intro-notes/StructureDefinition-au-medication-intro.md
@@ -16,7 +16,7 @@
   - medication form in `Medication.form.text`
   - item form and strength as part of medication definition in `Medication.code.text`
   - manufacturer in `Medication.manufacturer.display`
-  - individual ingredient strength implemented as [FHIR R5 element pre-adoption](https://hl7.org/fhir/R5/versions.html#extensions) of [`Medication.ingredient.strength[x]`](https://www.hl7.org/fhir/R5/medication-definitions.html#Medication.ingredient). See example [Tadim](Medication-IngredientStrengthExtension0.html).
+  - individual ingredient strength included as [FHIR R5 element pre-adoption](https://hl7.org/fhir/R5/versions.html#extensions) of [`Medication.ingredient.strength[x]`](https://www.hl7.org/fhir/R5/medication-definitions.html#Medication.ingredient). See example [Tadim](Medication-IngredientStrengthExtension0.html).
     - Use the element pre-adoption extension URL [http://hl7.org/fhir/5.0/StructureDefinition/extension-Medication.ingredient.strength[x]](http://hl7.org/fhir/5.0/StructureDefinition/extension-Medication.ingredient.strength[x]).
     - Apply the pre-adoption extension on `Medication.ingredient`.
 


### PR DESCRIPTION
https://github.com/hl7au/au-fhir-base/issues/1044 
items 4,10,11
for comment

-  AU Base Medication profile specific implementation guidance on individual ingredient strength is very confusing. Needs to be rewritten
-  AU Base HealthcareService intro.md "See this example of use [Inpatient Encounter](https://hl7.org.au/fhir/6.0.0-ballot/Encounter-example0.html)." change "See example [Inpatient Encounter](https://hl7.org.au/fhir/6.0.0-ballot/Encounter-example0.html)."
-  AU Base HealthcareService intro.md "To associate a HealthcareService with an encounter" change to either "To associate a healthcare service with an encounter". Also restructure this advice in line with the changes made for point 4 of this github issue.