### PR TITLE
Add AU Base FamilyMemberHistory profile Draft

### DIFF
--- a/input/ig.xml
+++ b/input/ig.xml
@@ -282,6 +282,12 @@
 		</resource>
 		<resource>
 			<reference>
+				<reference value="StructureDefinition/au-familymemberhistory"/>
+			</reference>
+			<exampleBoolean value="false"/>
+		</resource>
+		<resource>
+			<reference>
 				<reference value="StructureDefinition/au-address"/>
 			</reference>
 			<exampleBoolean value="false"/>

--- a/input/intro-notes/StructureDefinition-au-familymemberhistory-intro.md
+++ b/input/intro-notes/StructureDefinition-au-familymemberhistory-intro.md
@@ -1,0 +1,1 @@
+### Usage Notes

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -17,6 +17,7 @@ This version of current build reinstates profiles not included in the AU Base 6.
     <ul>
       <li><a href="StructureDefinition-au-hae.html">AU HAE</a> (<a href="https://jira.hl7.org/browse/FHIR-54928">FHIR-54928</a>)</li>
       <li><a href="StructureDefinition-au-hspo.html">AU HSP-O</a> (<a href="https://jira.hl7.org/browse/FHIR-54923">FHIR-54923</a>)</li>
+      <li><a href="StructureDefinition-au-familymemberhistory.html">AU Base FamilyMemberHistory</a> (<a href="https://jira.hl7.org/browse/FHIR-47163">FHIR-47163</a>)</li>
     </ul>
   </li>
   <li><a href="StructureDefinition-au-organization.html">AU Base Organization</a>:

--- a/input/resources/au-familymemberhistory.xml
+++ b/input/resources/au-familymemberhistory.xml
@@ -22,7 +22,7 @@
     <element id="FamilyMemberHistory.relationship">
       <path value="FamilyMemberHistory.relationship" />
       <binding>
-        <strength value="preferred" />
+        <strength value="extensible" />
         <valueSet value="http://terminology.hl7.org/ValueSet/v3-FamilyMember" />
       </binding>
     </element>

--- a/input/resources/au-familymemberhistory.xml
+++ b/input/resources/au-familymemberhistory.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="au-familymemberhistory" />
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
+    <valueInteger value="0"/>
+  </extension>
+  <url value="http://hl7.org.au/fhir/StructureDefinition/au-familymemberhistory" />
+  <name value="AUBaseFamilyMemberHistory" />
+  <title value="AU Base FamilyMemberHistory" />
+  <status value="active" />
+  <description value="This profile defines a family member history structure that localises core concepts, including terminology, for use in an Australian context. The purpose of this profile is to provide national level agreement on core localised concepts. This profile does not force conformance to core localised concepts. It enables implementers and modellers to make their own rules, i.e. [profiling](http://hl7.org/fhir/profiling.html), about how to support these concepts for specific implementation needs." />
+  <kind value="resource" />
+  <abstract value="false" />
+  <type value="FamilyMemberHistory" />
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/FamilyMemberHistory" />
+  <derivation value="constraint" />
+  <differential>
+    <element id="FamilyMemberHistory">
+      <path value="FamilyMemberHistory" />
+      <short value="A family member history statement in an Australian healthcare context" />
+    </element>
+    <element id="FamilyMemberHistory.relationship">
+      <path value="FamilyMemberHistory.relationship" />
+      <binding>
+        <strength value="extensible" />
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-FamilyMember" />
+      </binding>
+    </element>
+    <element id="FamilyMemberHistory.condition.code">
+      <path value="FamilyMemberHistory.condition.code" />
+      <binding>
+        <strength value="preferred" />
+        <valueSet value="https://healthterminologies.gov.au/fhir/ValueSet/clinical-condition-1" />
+      </binding>
+    </element>
+  </differential>
+</StructureDefinition>

--- a/input/resources/au-familymemberhistory.xml
+++ b/input/resources/au-familymemberhistory.xml
@@ -22,7 +22,7 @@
     <element id="FamilyMemberHistory.relationship">
       <path value="FamilyMemberHistory.relationship" />
       <binding>
-        <strength value="extensible" />
+        <strength value="preferred" />
         <valueSet value="http://terminology.hl7.org/ValueSet/v3-FamilyMember" />
       </binding>
     </element>

--- a/input/resources/au-familymemberhistory.xml
+++ b/input/resources/au-familymemberhistory.xml
@@ -26,6 +26,9 @@
         <valueSet value="http://terminology.hl7.org/ValueSet/v3-FamilyMember" />
       </binding>
     </element>
+    <element id="FamilyMemberHistory.condition">
+      <path value="FamilyMemberHistory.condition" />
+    </element>
     <element id="FamilyMemberHistory.condition.code">
       <path value="FamilyMemberHistory.condition.code" />
       <binding>


### PR DESCRIPTION
## Summary
- Add new AU Base FamilyMemberHistory profile (FHIR-47163)
- Bind `FamilyMemberHistory.relationship` to v3-FamilyMember (extensible)
- Bind `FamilyMemberHistory.condition.code` to clinical-condition-1 (preferred)

## Changes
- New `input/resources/au-familymemberhistory.xml` StructureDefinition
- New `input/intro-notes/StructureDefinition-au-familymemberhistory-intro.md`
- Updated `input/ig.xml` to register the new profile

## Test plan
- [ ] Verify IG publisher builds successfully
- [ ] Verify profile renders correctly in the built IG
- [ ] Verify terminology bindings resolve correctly

See: https://jira.hl7.org/browse/FHIR-47163

🤖 Generated with [Claude Code](https://claude.com/claude-code)