### PR TITLE
FHIR-56101 :: Created new Identifier type code for HSP-Os and used it in identifier dataType profile and example

### DIFF
--- a/input/examples/organization-example7.xml
+++ b/input/examples/organization-example7.xml
@@ -8,8 +8,8 @@
 		<type>
 			<coding>
 				<system value="http://terminology.hl7.org.au/CodeSystem/v2-0203"/>
-				<code value="NOI"/>
-				<display value="National Organisation Identifier"/>
+				<code value="HSPO"/>
+				<display value="Healthcare Support Service Provider - Organisation"/>
 			</coding>
 			<text value="HSP-O"/>
 		</type>

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -17,12 +17,14 @@ This version of current build reinstates profiles not included in the AU Base 6.
     <ul>
       <li><a href="StructureDefinition-au-hae.html">AU HAE</a> (<a href="https://jira.hl7.org/browse/FHIR-54928">FHIR-54928</a>)</li>
       <li><a href="StructureDefinition-au-hspo.html">AU HSP-O</a> (<a href="https://jira.hl7.org/browse/FHIR-54923">FHIR-54923</a>)</li>
+      <li><a href="StructureDefinition-au-hspo.html">AU HSP-O</a> (<a href="https://jira.hl7.org/browse/FHIR-56101">FHIR-56101</a>)</li>
     </ul>
   </li>
   <li><a href="StructureDefinition-au-organization.html">AU Base Organization</a>:
     <ul>
-      <li>Added AU HAE as a listed type for Patient.identifier (<a href="https://jira.hl7.org/browse/FHIR-54928">FHIR-54928</a>).</li>
-      <li>Added AU HSP-O as a listed type for Patient.identifier (<a href="https://jira.hl7.org/browse/FHIR-54923">FHIR-54923</a>).</li>
+      <li>Added AU HAE as a listed type for Organization.identifier (<a href="https://jira.hl7.org/browse/FHIR-54928">FHIR-54928</a>).</li>
+      <li>Added AU HSP-O as a listed type for Organization.identifier (<a href="https://jira.hl7.org/browse/FHIR-54923">FHIR-54923</a>).</li>
+	  <li>Edited AU HSP-O identifier profile to have HSPO as new identifier.type created in (<a href="https://hl7.org.au/fhir/CodeSystem-au-v2-0203.html">IdentifierType AU code system</a>) for Organization.identifier (<a href="https://jira.hl7.org/browse/FHIR-56101">FHIR-56101</a>).</li>
     </ul>
   </li>
 </ul>

--- a/input/resources/au-hspo.xml
+++ b/input/resources/au-hspo.xml
@@ -52,7 +52,7 @@
       <patternCodeableConcept>
         <coding>
           <system value="http://terminology.hl7.org.au/CodeSystem/v2-0203"/>
-          <code value="NOI"/>
+          <code value="HSPO"/>
         </coding>
       </patternCodeableConcept>
     </element>

--- a/input/resources/codesystem-au-v2-0203.xml
+++ b/input/resources/codesystem-au-v2-0203.xml
@@ -21,7 +21,7 @@
 	<compositional value="false"/>
 	<versionNeeded value="false"/>
 	<content value="complete"/>
-	<count value="27" />
+	<count value="28" />
 	<concept>
 		<code value="AHPRA"/>
 		<display value="Australian Health Practitioner Regulation Agency Registration Number"/>
@@ -76,6 +76,11 @@
 		<code value="GNAF"/>
 		<display value="Geocoded National Address File Identifier"/>
 		<definition value="A Geocoded National Address File (G-NAF) Identifier assigned to a location address in the G-NAF. The PSMA G-NAF is Australia’s authoritative, geocoded address file."/>
+	</concept>
+	<concept>
+		<code value="HSPO"/>
+		<display value="Healthcare Support Service Provider - Organisation"/>
+		<definition value="An identifier assigned by the Australian Healthcare Identifiers Service to a healthcare support service provider organisation:  a Healthcare Support Service Provider - Organisation identifier (HSP-O)."/>
 	</concept>
 	<concept>
 		<code value="LDI"/>


### PR DESCRIPTION
Good morning,

Please accept my pull request which is the work related to jira https://jira.hl7.org/browse/FHIR-56101

Following work has been done as part of this jira ticket:

1. Create a new HSPO code in "codesystem-au-v2-0203.xml"
2. Created new Identifier type code for HSP-O3. 
4. Use used the HSPO code in identifier dataType profile
5. Edited organization-example-7 
6. Added an entry in the change log

Thanks, 
Uday

