### PR TITLE
FHIR-56103: New identifier type code for abn, acn, arbn Identifier dataType profiles

### DIFF
--- a/input/examples/organization-example1.xml
+++ b/input/examples/organization-example1.xml
@@ -7,8 +7,9 @@
 	<identifier>
 		<type>
 			<coding>
-				<system value="http://terminology.hl7.org/CodeSystem/v2-0203"/>
-				<code value="XX"/>
+				<system value="http://terminology.hl7.org.au/CodeSystem/v2-0203"/>
+				<code value="ABN"/>
+				<display value="Australian Business Number"/>
 			</coding>
 			<text value="ABN"/>
 		</type>

--- a/input/examples/organization-example2.xml
+++ b/input/examples/organization-example2.xml
@@ -19,8 +19,9 @@
     <identifier>
         <type>
             <coding>
-                <system value="http://terminology.hl7.org/CodeSystem/v2-0203"/>
-                <code value="XX"/>
+                <system value="http://terminology.hl7.org.au/CodeSystem/v2-0203"/>
+                <code value="ABN"/>
+                <display value="Australian Business Number"/>
             </coding>
             <text value="ABN"/>
         </type>

--- a/input/examples/organization-example3.xml
+++ b/input/examples/organization-example3.xml
@@ -7,8 +7,9 @@
 	<identifier>
 		<type>
 			<coding>
-				<system value="http://terminology.hl7.org/CodeSystem/v2-0203"/>
-				<code value="XX"/>
+				<system value="http://terminology.hl7.org.au/CodeSystem/v2-0203"/>
+				<code value="ABN"/>
+				<display value="Australian Business Number"/>
 			</coding>	
 			<text value="ABN"/>
 		</type>

--- a/input/examples/organization-example5.xml
+++ b/input/examples/organization-example5.xml
@@ -3,8 +3,9 @@
 	<identifier>
 		<type>
 			<coding>
-				<system value="http://terminology.hl7.org/CodeSystem/v2-0203"/>
-				<code value="XX"/>
+				<system value="http://terminology.hl7.org.au/CodeSystem/v2-0203"/>
+				<code value="ABN"/>
+				<display value="Australian Business Number"/>
 			</coding>
 			<text value="ABN"/>
 		</type>

--- a/input/examples/organization-example6.xml
+++ b/input/examples/organization-example6.xml
@@ -25,8 +25,9 @@
     <identifier>
         <type>
             <coding>
-                <system value="http://terminology.hl7.org/CodeSystem/v2-0203"/>
-                <code value="XX"/>
+                <system value="http://terminology.hl7.org.au/CodeSystem/v2-0203"/>
+                <code value="ARBN"/>
+                <display value="Australian Registered Body Number"/>
             </coding>
             <text value="ARBN"/>
         </type>
@@ -37,8 +38,9 @@
     <identifier>
         <type>
             <coding>
-                <system value="http://terminology.hl7.org/CodeSystem/v2-0203"/>
-                <code value="XX"/>
+                <system value="http://terminology.hl7.org.au/CodeSystem/v2-0203"/>
+                <code value="ABN"/>
+                <display value="Australian Business Number"/>
             </coding>
             <text value="ABN"/>
         </type>
@@ -49,8 +51,9 @@
     <identifier>
         <type>
             <coding>
-                <system value="http://terminology.hl7.org/CodeSystem/v2-0203"/>
-                <code value="XX"/>
+                <system value="http://terminology.hl7.org.au/CodeSystem/v2-0203"/>
+                <code value="ACN"/>
+                <display value="Australian Company Number"/>
             </coding>
             <text value="ACN"/>
         </type>

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -19,6 +19,21 @@ This version introduces the following non-compatible changes.
       <li>Identifier.type.coding fixed to PAIO (<a href="https://jira.hl7.org/browse/FHIR-55738">FHIR-55738</a>).</li>
     </ul>
   </li>
+ <li><a href="StructureDefinition-au-australianbusinessnumber.html">AU Australian Business Number</a>:
+    <ul>
+      <li>Identifier.type.coding fixed to ABN (<a href="https://jira.hl7.org/browse/FHIR-56103">FHIR-56103</a>).</li>
+    </ul>
+  </li>
+ <li><a href="StructureDefinition-au-australiancompanynumber.html">AU Australian Company Number</a>:
+    <ul>
+      <li>Identifier.type.coding fixed to ACN (<a href="https://jira.hl7.org/browse/FHIR-56103">FHIR-56103</a>).</li>
+    </ul>
+  </li>
+ <li><a href="StructureDefinition-au-australianregistredbodynumber.html">AU Australian Registered Body Number</a>:
+    <ul>
+      <li>Identifier.type.coding fixed to ARBN (<a href="https://jira.hl7.org/browse/FHIR-56103">FHIR-56103</a>).</li>
+    </ul>
+  </li>
   <li><a href="CodeSystem-au-v2-0203.html">IdentifierType AU</a>:
     <ul>
       <li>Concept description changed for NOI (<a href="https://jira.hl7.org/browse/FHIR-55738">FHIR-55738</a>).</li>
@@ -56,6 +71,9 @@ This version introduces the following non-compatible changes.
       <li>Concept description changed for NOI (<a href="https://jira.hl7.org/browse/FHIR-55738">FHIR-55738</a>).</li>
       <li>Added code PAIO (<a href="https://jira.hl7.org/browse/FHIR-55738">FHIR-55738</a>).</li>
       <li>Added code HSPO (<a href="https://jira.hl7.org/browse/FHIR-56101">FHIR-56101</a>).</li>
+      <li>Added code ABN (<a href="https://jira.hl7.org/browse/FHIR-56103">FHIR-56103</a>).</li>
+      <li>Added code ACN (<a href="https://jira.hl7.org/browse/FHIR-56103">FHIR-56103</a>).</li>
+      <li>Added code ARBN (<a href="https://jira.hl7.org/browse/FHIR-56103">FHIR-56103</a>).</li>
     </ul>
   </li>
 </ul>

--- a/input/resources/au-australianbusinessnumber.xml
+++ b/input/resources/au-australianbusinessnumber.xml
@@ -30,10 +30,12 @@
     <element id="Identifier.type">
       <path value="Identifier.type" />
       <min value="1"/>
-      <binding>
-        <strength value="extensible" />
-        <valueSet value="http://terminology.hl7.org.au/ValueSet/v2-0203-extended" />
-      </binding>
+      <patternCodeableConcept>
+        <coding>
+          <system value="http://terminology.hl7.org.au/CodeSystem/v2-0203"/>
+          <code value="ABN"/>
+        </coding>
+      </patternCodeableConcept>
     </element>
     <element id="Identifier.system">
       <path value="Identifier.system" />

--- a/input/resources/au-australiancompanynumber.xml
+++ b/input/resources/au-australiancompanynumber.xml
@@ -30,10 +30,12 @@
     <element id="Identifier.type">
       <path value="Identifier.type" />
       <min value="1"/>
-      <binding>
-        <strength value="extensible" />
-        <valueSet value="http://terminology.hl7.org.au/ValueSet/v2-0203-extended" />
-      </binding>
+      <patternCodeableConcept>
+        <coding>
+          <system value="http://terminology.hl7.org.au/CodeSystem/v2-0203"/>
+          <code value="ACN"/>
+        </coding>
+      </patternCodeableConcept>
     </element>
     <element id="Identifier.system">
       <path value="Identifier.system" />

--- a/input/resources/au-australianregistredbodynumber.xml
+++ b/input/resources/au-australianregistredbodynumber.xml
@@ -30,10 +30,12 @@
     <element id="Identifier.type">
       <path value="Identifier.type" />
       <min value="1"/>
-      <binding>
-        <strength value="extensible" />
-        <valueSet value="http://terminology.hl7.org.au/ValueSet/v2-0203-extended" />
-      </binding>
+      <patternCodeableConcept>
+        <coding>
+          <system value="http://terminology.hl7.org.au/CodeSystem/v2-0203"/>
+          <code value="ARBN"/>
+        </coding>
+      </patternCodeableConcept>
     </element>
     <element id="Identifier.system">
       <path value="Identifier.system" />

--- a/input/resources/codesystem-au-v2-0203.xml
+++ b/input/resources/codesystem-au-v2-0203.xml
@@ -21,11 +21,26 @@
 	<compositional value="false"/>
 	<versionNeeded value="false"/>
 	<content value="complete"/>
-	<count value="29" />
+	<count value="32" />
+	<concept>
+		<code value="ABN"/>
+		<display value="Australian Business Number"/>
+		<definition value="An identifier issued by the Australian Securities and Investments Commission (ASIC) to an entity registered in the Australian Business Register."/>
+	</concept>
+	<concept>
+		<code value="ACN"/>
+		<display value="Australian Company Number"/>
+		<definition value="An identifier issued by the Australian Securities and Investments Commission (ASIC) when a body becomes registered as a company under Corporations Law."/>
+	</concept>
 	<concept>
 		<code value="AHPRA"/>
 		<display value="Australian Health Practitioner Regulation Agency Registration Number"/>
 		<definition value="An Australian Health Practitioner Regulation Authority (Ahpra) registration number assigned to a practitioner for each profession in which they are registered. Practitioners registered in more than one profession have one registration number for each profession."/>
+	</concept>
+	<concept>
+		<code value="ARBN"/>
+		<display value="Australian Registered Body Number"/>
+		<definition value="An identifier issued by the Australian Securities and Investments Commission (ASIC) to a registerable Australian body or foreign company."/>
 	</concept>
 	<concept>
 		<code value="CAEI"/>


### PR DESCRIPTION
Hello everyone, 

Please review and accept the pull request to add new identifier type codes for ABN, ACN and ARBN Identifier dataType profiles

Following artefacts have been edited for this pull request

- Added codes ABN, ACN and ARBN to "IdentifierType AU" codeSystem
- Identifier.type.coding fixed to ABN, ACN and ARBN to corresponding profiles
- Edited the examples to comply with the au-organization profile

https://jira.hl7.org/browse/FHIR-56103

Regards, 
Uday