### PR TITLE
FHIR-56102: New identifier type code for HAE Identifier dataType profile

### DIFF
--- a/input/examples/organization-example8.xml
+++ b/input/examples/organization-example8.xml
@@ -8,8 +8,8 @@
 		<type>
 			<coding>
 				<system value="http://terminology.hl7.org.au/CodeSystem/v2-0203"/>
-				<code value="NOI"/>
-				<display value="National Organisation Identifier"/>
+				<code value="HAE"/>
+				<display value="Health Administration Entity"/>
 			</coding>
 			<text value="HAE"/>
 		</type>

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -56,6 +56,12 @@ This version introduces the following non-compatible changes.
       <li>Concept description changed for NOI (<a href="https://jira.hl7.org/browse/FHIR-55738">FHIR-55738</a>).</li>
       <li>Added code PAIO (<a href="https://jira.hl7.org/browse/FHIR-55738">FHIR-55738</a>).</li>
       <li>Added code HSPO (<a href="https://jira.hl7.org/browse/FHIR-56101">FHIR-56101</a>).</li>
+      <li>Added code HAE (<a href="https://jira.hl7.org/browse/FHIR-56102">FHIR-56102</a>).</li>
+    </ul>
+  </li>
+  <li><a href="StructureDefinition-au-hae.html">AU HAE Identifier</a>:
+    <ul>
+      <li>Identifier.type.coding fixed to HAE (<a href="https://jira.hl7.org/browse/FHIR-56102">FHIR-56102</a>).</li>
     </ul>
   </li>
 </ul>

--- a/input/resources/au-hae.xml
+++ b/input/resources/au-hae.xml
@@ -52,7 +52,7 @@
       <patternCodeableConcept>
         <coding>
           <system value="http://terminology.hl7.org.au/CodeSystem/v2-0203"/>
-          <code value="NOI"/>
+          <code value="HAE"/>
         </coding>
       </patternCodeableConcept>
     </element>

--- a/input/resources/codesystem-au-v2-0203.xml
+++ b/input/resources/codesystem-au-v2-0203.xml
@@ -21,7 +21,7 @@
 	<compositional value="false"/>
 	<versionNeeded value="false"/>
 	<content value="complete"/>
-	<count value="29" />
+	<count value="30" />
 	<concept>
 		<code value="AHPRA"/>
 		<display value="Australian Health Practitioner Regulation Agency Registration Number"/>
@@ -76,6 +76,11 @@
 		<code value="GNAF"/>
 		<display value="Geocoded National Address File Identifier"/>
 		<definition value="A Geocoded National Address File (G-NAF) Identifier assigned to a location address in the G-NAF. The PSMA G-NAF is Australia’s authoritative, geocoded address file."/>
+	</concept>
+	<concept>
+		<code value="HAE"/>
+		<display value="Health Administration Entity"/>
+		<definition value="An identifier assigned by the Australian Healthcare Identifiers Service to a health administration entity: a Health Administration Entity number (HAE)."/>
 	</concept>
 	<concept>
 		<code value="HSPO"/>


### PR DESCRIPTION
Hello everyone,

Please review and accept the pull request to add new identifier type code for HAE Identifier dataType profile

Following artefacts have been edited for this pull request

- Added codes HAE to "IdentifierType AU" codeSystem
- Identifier.type.coding fixed to HAE to corresponding profile
- Edited the examples to comply with the au-organization profile

https://jira.hl7.org/browse/FHIR-56102

Regards,
Uday