### PR TITLE
Au base endpoint terminology (FHIR-57759, FHIR-57760, FHIR-57761, FHIR-57762)

### DIFF
--- a/input/ig.xml
+++ b/input/ig.xml
@@ -1123,6 +1123,14 @@
 		</resource>
 		<resource>
 			<reference>
+				<reference value="Endpoint/example1"/>
+			</reference>
+			<name value="Endpoint - a FHIR REST API endpoint example"/>
+			<description value="Shows an example of a FHIR REST API endpoint for an Australian hospital using the AU Base Endpoint profile."/>
+			<exampleCanonical value="http://hl7.org.au/fhir/StructureDefinition/au-endpoint"/>
+		</resource>
+		<resource>
+			<reference>
 				<reference value="Location/example3"/>
 			</reference>
 			<name value="Location - of a Practitioner as a General Practitioner"/>

--- a/input/intro-notes/StructureDefinition-au-endpoint-intro.md
+++ b/input/intro-notes/StructureDefinition-au-endpoint-intro.md
@@ -9,3 +9,9 @@
 - Endpoint: [Receiving Facility](StructureDefinition-au-receivingfacility.html)
 - Endpoint: [Receiving Application](StructureDefinition-au-receivingapplication.html)
 - Endpoint: [Encryption Certificate PEM X509](StructureDefinition-encryption-certificate-pem-x509.html)
+
+#### NEW AU-defined terminology
+- The following AU-defined value sets and code systems have been applied to `Endpoint.connectionType` and `Endpoint.payloadType`:
+- [Australian Service Interface](ValueSet-au-service-interface.html) — value set of connection type codes for Australian messaging services, including AU-defined codes from [Australian Connection Type Interface](CodeSystem-au-connection-type-interface.html) CodeSystem and [R4 defined](https://terminology.hl7.org/7.2.0/en/CodeSystem-endpoint-connection-type.html) codes.
+- [Australian Endpoint Payload Type](ValueSet-au-endpoint-payload-type.html) — value set of payload type codes for Australian endpoints, including AU-defined codes from the [Australian Endpoint Payload Type](CodeSystem-au-endpoint-payload-type.html) CodeSystem and [R4 defined](https://hl7.org/fhir/R4/valueset-endpoint-payload-type.html) codes.
+

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -50,6 +50,14 @@ This version introduces the following non-compatible changes.
       <li><a href="StructureDefinition-au-hspo.html">AU HSP-O</a> (<a href="https://jira.hl7.org/browse/FHIR-54923">FHIR-54923</a>)</li>
     </ul>
   </li>
+  <li>New terminology:
+    <ul>
+      <li><a href="CodeSystem-au-endpoint-payload-type.html">Australian Endpoint Payload Types</a> code system</li>
+      <li><a href="CodeSystem-au-connection-type-interface.html">Australian Connection Type Interfaces</a> code system</li>
+      <li><a href="ValueSet-au-endpoint-payload-type.html">Australian Endpoint Payload Type</a> value set</li>
+      <li><a href="ValueSet-au-service-interface.html">Australian Service Interface</a> value set</li>
+    </ul>
+  </li>
   <li><a href="StructureDefinition-au-organization.html">AU Base Organization</a>:
     <ul>
       <li>Added AU HAE as an option for Organization.identifier (<a href="https://jira.hl7.org/browse/FHIR-54928">FHIR-54928</a>).</li>

--- a/input/pagecontent/terminology.md
+++ b/input/pagecontent/terminology.md
@@ -82,6 +82,16 @@ The following value sets form part of localised requirements (i.e. are reference
       <td>AU Base</td>
     </tr>
     <tr>
+      <td><a href="ValueSet-au-endpoint-payload-type.html">AU Endpoint Payload Type</a></td>
+      <td><a href="StructureDefinition-au-endpoint.html">AU Base Endpoint</a></td>
+      <td>AU Base</td>
+    </tr>
+    <tr>
+      <td><a href="ValueSet-au-service-interface.html">Australian Service Interface</a></td>
+      <td><a href="StructureDefinition-au-endpoint.html">AU Base Endpoint</a></td>
+      <td>AU Base</td>
+    </tr>
+    <tr>
       <td><a href="https://healthterminologies.gov.au/fhir/ValueSet/australian-immunisation-register-vaccine-1">Australian Immunisation Register Vaccine</a></td>
       <td><a href="StructureDefinition-au-immunization.html">AU Base Immunization</a></td>
       <td>NCTS</td>
@@ -521,6 +531,18 @@ The following code systems are referenced by the value sets listed above.
         <td>HL7 Australia</td>
     </tr>
     <tr>
+        <td><a href="CodeSystem-au-endpoint-payload-type.html">Australian Endpoint Payload Type</a></td>
+        <td><a href="ValueSet-au-endpoint-payload-type.html">AU Endpoint Payload Type</a></td>
+        <td>AU Base</td>
+        <td>HL7 Australia</td>
+    </tr>
+    <tr>
+        <td><a href="CodeSystem-au-connection-type-interface.html">Australian Connection Type Interface</a></td>
+        <td><a href="ValueSet-au-service-interface.html">Australian Service Interface</a></td>
+        <td>AU Base</td>
+        <td>HL7 Australia</td>
+    </tr>   
+    <tr>
         <td><a href="https://www.humanservices.gov.au/organisations/health-professionals/enablers/air-vaccine-code-formats">Australian Immunisation Register Vaccine</a></td>
         <td><a href="https://healthterminologies.gov.au/fhir/ValueSet/australian-immunisation-register-vaccine-1">Australian Immunisation Register Vaccine</a></td>
         <td>NCTS</td>
@@ -608,6 +630,12 @@ The following code systems are referenced by the value sets listed above.
         <td><a href="ValueSet-au-v2-0360-extended.html">hl7VS-degreeLicenseCertificate - AU Extended</a></td>
         <td>AU Base</td>
         <td>HL7 Australia</td>
+    </tr>
+    <tr>
+        <td><a href="http://terminology.hl7.org/CodeSystem/endpoint-connection-type">endpoint connection type</a></td>
+        <td><a href="ValueSet-au-service-interface.html">Australian Service Interface</a></td>
+        <td>HL7 Terminology (THO)</td>
+        <td>Health Level Seven International</td>
     </tr>
     <tr>
         <td><a href="http://terminology.hl7.org/CodeSystem/v2-0074">DiagnosticServiceSectionId</a></td>

--- a/input/resources/au-endpoint.xml
+++ b/input/resources/au-endpoint.xml
@@ -30,5 +30,21 @@
         <profile value="http://hl7.org/fhir/5.0/StructureDefinition/extension-Endpoint.environmentType" />
       </type>
     </element>
+    <element id="Endpoint.connectionType">
+      <path value="Endpoint.connectionType" />
+      <binding>
+        <strength value="extensible" />
+        <description value="Australian Service Interface value set for connectionType" />
+        <valueSet value="http://hl7.org.au/fhir/ValueSet/au-service-interface" />
+      </binding>
+    </element>
+    <element id="Endpoint.payloadType">
+      <path value="Endpoint.payloadType" />
+      <binding>
+        <strength value="preferred" />
+        <description value="Australian Endpoint Payload Type value set for payloadType" />
+        <valueSet value="http://hl7.org.au/fhir/ValueSet/au-endpoint-payload-type" />
+      </binding>
+    </element>
   </differential>
 </StructureDefinition>

--- a/input/resources/codesystem-au-connection-type-interface.xml
+++ b/input/resources/codesystem-au-connection-type-interface.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<CodeSystem xmlns="http://hl7.org/fhir">
+  <id value="au-connection-type-interface"/>
+    <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
+    <valueInteger value="0"/> 
+  </extension>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
+    <valueCode value="draft">
+    </valueCode>
+  </extension>
+  <meta>
+    <profile value="https://healthterminologies.gov.au/fhir/StructureDefinition/complete-code-system-4" />
+  </meta>
+  <url value="http://hl7.org.au/fhir/CodeSystem/au-connection-type-interface"/>
+  <identifier>
+    <system value="urn:ietf:rfc:3986" />
+    <value value="urn:oid:2.16.840.1.113883.2.3.4.1.4.50" />
+  </identifier>
+  <name value="AUConnectionTypeInterfaces"/>
+  <title value="Australian Connection Type Interfaces"/>
+  <publisher value="HL7 Australia"/>
+  <copyright value="HL7 Australia. Licensed under Creative Commons No Rights Reserved (CC0)."/>
+  <status value="draft"/>
+  <experimental value="false"/>
+  <description value="Connection type interfaces for endpoints in the Australian healthcare context. This CodeSystem supports current and future interface patterns for interoperable endpoint connectivity."/>
+  <caseSensitive value="true"/>
+  <valueSet value="http://hl7.org.au/fhir/ValueSet/au-connection-type-interface" />
+  <compositional value="false" />
+  <versionNeeded value="false" />
+  <count value="5" />
+  <content value="complete"/>
+  <concept>
+    <code value="http://ns.electronichealth.net.au/smd/intf/SealedImmediateMessageDelivery/TLS/2010"/>
+    <display value="Sealed Immediate Message Delivery"/>
+    <definition value="Service interface for secure message delivery (immediate mode)"/>
+  </concept>
+  <concept>
+    <code value="http://ns.electronichealth.net.au/smd/intf/SealedMessageDelivery/TLS/2010"/>
+    <display value="Sealed Message Delivery"/>
+    <definition value="Service interface for secure message delivery (deferred mode)"/>
+  </concept>
+  <concept>
+    <code value="http://ns.electronichealth.net.au/smd/intf/SealedMessageRetrieval/TLS/2010"/>
+    <display value="Sealed Message Retrieval"/>
+    <definition value="Service interface for secure message retrieval (deferred mode)"/>
+  </concept>
+  <concept>
+    <code value="http://ns.electronichealth.net.au/smd/intf/TransportResponseDelivery/TLS/2010"/>
+    <display value="Transport Response Delivery"/>
+    <definition value="Service interface for secure message delivery (deliver acknowledgement)"/>
+  </concept>
+  <concept>
+    <code value="http://ns.electronichealth.net.au/smd/intf/TransportResponseRetrieval/TLS/2010"/>
+    <display value="Transport Response Retrieval"/>
+    <definition value="Service interface for secure message delivery (retrieve acknowledgement)"/>
+  </concept>
+</CodeSystem>

--- a/input/resources/valueset-au-connection-type-interface.xml
+++ b/input/resources/valueset-au-connection-type-interface.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ValueSet xmlns="http://hl7.org/fhir">
+  <id value="au-connection-type-interface" />
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
+    <valueInteger value="0"/>
+  </extension>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
+    <valueCode value="draft">
+    </valueCode>
+  </extension>
+  <url value="http://hl7.org.au/fhir/ValueSet/au-connection-type-interface" />
+  <name value="AUConnectionTypeInterface" />
+  <title value="Australian Connection Type Interface" />
+  <status value="draft" />
+  <experimental value="false" />
+  <date value="2024-04-01" />
+  <publisher value="HL7 Australia" />
+  <contact>
+    <name value="HL7 Australia" />
+    <telecom>
+      <system value="url" />
+      <value value="http://hl7.org.au" />
+    </telecom>
+  </contact>
+  <description value="All codes from the Australian Connection Type Interface code system." />
+  <jurisdiction>
+    <coding>
+      <system value="urn:iso:std:iso:3166" />
+      <code value="AU" />
+      <display value="Australia" />
+    </coding>
+  </jurisdiction>
+  <copyright value="HL7 Australia. Licensed under Creative Commons No Rights Reserved (CC0)." />
+  <compose>
+    <include>
+      <system value="http://hl7.org.au/fhir/CodeSystem/au-connection-type-interface" />
+    </include>
+  </compose>
+</ValueSet>

--- a/input/resources/valueset-au-endpoint-payload-type.xml
+++ b/input/resources/valueset-au-endpoint-payload-type.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ValueSet xmlns="http://hl7.org/fhir">
+  <id value="au-endpoint-payload-type"/>
+    <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
+    <valueInteger value="0"/> 
+  </extension>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
+    <valueCode value="draft">
+    </valueCode>
+  </extension>
+  <meta>
+    <profile value="https://healthterminologies.gov.au/fhir/StructureDefinition/composed-value-set-4" />
+  </meta>
+  <url value="http://hl7.org.au/fhir/ValueSet/au-endpoint-payload-type" />
+  <identifier>
+    <system value="urn:ietf:rfc:3986"/>
+    <value value="urn:oid:2.16.840.1.113883.2.3.4.2.4.52"/>
+  </identifier>
+  <name value="AUEndpointPayloadType" />
+  <title value="Australian Endpoint Payload Type" />
+  <status value="draft" />
+  <experimental value="false" />
+  <date value="2026-04-01" />
+  <publisher value="HL7 Australia" />
+  <contact>
+    <name value="HL7 Australia" />
+    <telecom>
+      <system value="url" />
+      <value value="http://hl7.org.au" />
+    </telecom>
+  </contact>
+  <description value="Enumeration of well known endpoint payload types" />
+  <jurisdiction>
+    <coding>
+      <system value="urn:iso:std:iso:3166" />
+      <code value="AU" />
+      <display value="Australia" />
+    </coding>
+  </jurisdiction>
+  <copyright value="HL7 Australia© 2018+; Licensed under Creative Commons No Rights Reserved." />
+  <compose>
+    <include>
+      <system value="http://hl7.org.au/fhir/CodeSystem/au-endpoint-payload-type" />
+    </include>
+    <include>
+      <valueSet value="http://hl7.org/fhir/ValueSet/endpoint-payload-type" />
+    </include>
+  </compose>
+</ValueSet>

--- a/input/resources/valueset-service-interface.xml
+++ b/input/resources/valueset-service-interface.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ValueSet xmlns="http://hl7.org/fhir">
+  <id value="au-service-interface" />
+    <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
+    <valueInteger value="0"/> 
+  </extension>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
+    <valueCode value="draft">
+    </valueCode>
+  </extension>
+  <meta>
+    <profile value="https://healthterminologies.gov.au/fhir/StructureDefinition/composed-value-set-4" />
+  </meta>
+  <url value="http://hl7.org.au/fhir/ValueSet/au-service-interface" />
+  <identifier>
+    <system value="urn:ietf:rfc:3986" />
+    <value value="urn:oid:2.16.840.1.113883.2.3.4.2.4.51" />
+  </identifier>
+  <name value="AUServiceInterfaces" />
+  <title value="Australian Service Interface" />
+  <status value="draft" />
+  <experimental value="false" />
+  <date value="2024-04-01" />
+  <publisher value="HL7 Australia" />
+  <contact>
+    <name value="HL7 Australia" />
+    <telecom>
+      <system value="url" />
+      <value value="http://hl7.org.au" />
+    </telecom>
+  </contact>
+  <description value="The Australian Connection Type Interfaces value set enumerates well known interface codes that can be used for specifying endpoint connection types." />
+  <jurisdiction>
+    <coding>
+      <system value="urn:iso:std:iso:3166" />
+      <code value="AU" />
+      <display value="Australia" />
+    </coding>
+  </jurisdiction>
+  <copyright value="HL7 Australia© 2018+; Licensed under Creative Commons No Rights Reserved." />
+  <compose>
+    <include>
+      <system value="http://terminology.hl7.org/CodeSystem/endpoint-connection-type" />
+    </include>
+    <include>
+      <system value="http://hl7.org.au/fhir/CodeSystem/au-connection-type-interface" />
+    </include>
+  </compose>
+</ValueSet>


### PR DESCRIPTION
Adds terminology resources for AU Base Endpoint, sourced from AU Provider Directory (AU PD), with binding strengths applied to the AU Endpoint profile.

New resources:
CodeSystem/au-connection-type-interface — Australian connection type interfaces (currently SMD/TLS codes); renamed from smd-interfaces to allow for future interface types beyond SMD
ValueSet/au-connection-type-interface — value set pointing to the above code system
ValueSet/au-service-interface — value set for Endpoint.connectionType, including both the standard R4 endpoint-connection-type codes and the AU-specific au-connection-type-interface codes
ValueSet/au-endpoint-payload-type — value set for Endpoint.payloadType, referencing the R4 endpoint-payload-type value set and the AU-specific au-endpoint-payload-type code system

Strengths of bindings:
extensible binding applied to connectionType; 
preferred binding applied to payloadType