### PR TITLE
Forward release-* tags to the centralized pipeline

### DIFF
--- a/.github/workflows/build-review-publish.yml
+++ b/.github/workflows/build-review-publish.yml
@@ -11,7 +11,7 @@ name: AU Base — build / preview / gated publish
 on:
   push:
     branches: [master]
-    tags: ['v*']
+    tags: ['v*', 'release-*']   # release-<version> is the established AU tagging convention
   pull_request:
     branches: [master]
   workflow_dispatch:


### PR DESCRIPTION
Forward `release-*` tags (the established AU convention — `release-6.0.0`, `release-6.1.0-draft`, …) to the centralized hl7au/publications pipeline; previously only `v*` was forwarded, so a conventional release tag would not have triggered it at all.

**The legacy self-hosted pipeline (`pipeline-build.yml`) intentionally stays tag-triggered alongside.** It renders into the EC2 webroot and pushing to prod remains a manual copy, so the two release methods coexist: a release tag runs both, the legacy one stops at the webroot, and the centralized one publishes per the flow below.

## Release flow (with hl7au/publications#7)

Push `release-<version>` on the release commit:
- **working status** (draft/ballot/preview — the frequent case) → publishes to prod **automatically** as a versioned snapshot (`current` untouched, additive only)
- **milestone status** (release/trial-use/normative — rewrites `current`) → waits for one `production`-environment approval

Both paths enforce tag↔version match against `publication-request.json` and end with CloudFront invalidation + post-publish verify.

## Background: the 2026-07-03 build blowout (5 → 33 min)

Not caused by the pipeline redesign or IG content: **tx.fhir.org began hanging 3–6.5+ min on any terminology request carrying a `cache-id` parameter**, and the pinned combined publisher.jar (2.2.10-SNAPSHOT of 2026-06-19) always sends one. The jar on the `au-pipeline-combined` release has been rebuilt on the v2.2.10 release (core 6.9.11), which avoids the hang — verified locally (3:23 render, was 31 min) and in CI ([28637923270](https://github.com/hl7au/au-fhir-base/actions/runs/28637923270): render 6:05, build job 8m28s).