### PR TITLE
Prepare 6.1.1-draft release

### DIFF
--- a/input/ig.xml
+++ b/input/ig.xml
@@ -5,7 +5,7 @@
 		<valueCode value="trial-use"/>
 	</extension>
 	<url value="http://hl7.org.au/fhir/ImplementationGuide/hl7.fhir.au.base"/>
-	<version value="6.0.1-ci-build"/>
+	<version value="6.1.1-draft"/>
 	<name value="AUBaseImplementationGuide"/>
 	<title value="AU Base Implementation Guide"/>
 	<status value="active"/>
@@ -2048,7 +2048,7 @@
 		<!-- releaselabel should be the ballot status for HL7-published IGs. -->
 		<parameter>
 			<code value="releaselabel"/>
-			<value value="CI Build"/>
+			<value value="Draft"/>
 		</parameter>
 		<parameter>
 			<code value="fmm-definition"/>

--- a/input/ig.xml
+++ b/input/ig.xml
@@ -2062,14 +2062,6 @@
 			<code value="shownav"/>
 			<value value="false"/>
 		</parameter>
-		<!-- A3: render json/xml/ttl "view source" pages client-side from the raw files (Prism),
-		     instead of baking large escaped-source HTML. Opt-in; ~86% smaller viewer pages.
-		     Requires the dynamic-source-viewers code registered in hl7.fhir.uv.tools (else 4
-		     cosmetic QA "code not in value set" warnings). -->
-		<parameter>
-			<code value="dynamic-source-viewers"/>
-			<value value="true"/>
-		</parameter>
 		<parameter>
 			<code value="apply-version"/>
 			<value value="true"/>

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -1,9 +1,9 @@
-### Release TBD
-- Publication date: TBD
-- Publication status: TBD
+### Release 6.1.1-draft
+- Publication date: 2026-07-03
+- Publication status: Draft
 - Based on FHIR version: 4.0.1
  
-This change log documents the significant updates and resolutions implemented from version <a href="https://hl7.org.au/fhir/6.0.0/index.html">6.0.0</a> to TBD. 
+This change log documents the significant updates and resolutions implemented from version <a href="https://hl7.org.au/fhir/6.0.0/index.html">6.0.0</a> to 6.1.1-draft. 
 
 #### Reinstated
 This version of current build reinstates profiles not included in the AU Base 6.0.0 release:

--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -1,3 +1,5 @@
+{% include testing-note.md -%}
+
 ### Introduction
 This implementation guide is provided to support the use of HL7<sup>&reg;</sup> FHIR<sup>&reg;&copy;</sup> in an Australian context.  
 

--- a/input/pagecontent/testing-note.md
+++ b/input/pagecontent/testing-note.md
@@ -1,0 +1,9 @@
+<div class="stu-note" markdown="1">
+
+#### AU Base 6.1.1-draft for testing 
+
+This draft snapshot supports the July 2026 Sparked Testing Event.
+
+Testing plays a crucial role in the development of standards and helps ensure content that is fit for purpose. AU Base is typically referenced by other AU specifications and this publication supports their associated testing activity.
+
+</div>

--- a/publication-request.json
+++ b/publication-request.json
@@ -1,10 +1,10 @@
 {
     "package-id" : "hl7.fhir.au.base",
-    "version" : "6.0.1-ci-build",
-    "path" : "http://hl7.org.au/fhir/6.0.1-ci-build",
+    "version" : "6.1.1-draft",
+    "path" : "http://hl7.org.au/fhir/6.1.1-draft",
     "mode" : "working",
-    "status" : "preview",
-    "sequence" : "R6",
-    "desc" : "This MONTH YEAR [preview|ballot|draft] snapshot supports the [testing|MONTH YEAR Ballot|MONTH YEAR Connectathon] of AU Base",
+    "status" : "draft",
+    "sequence" : "R7",
+    "desc" : "This draft snapshot supports the July 2026 Sparked Testing Event",
     "first" : false
- } 
+ }


### PR DESCRIPTION
Release metadata for **6.1.1-draft** (draft snapshot supporting the July 2026 Sparked Testing Event; supersedes `6.1.0-draft1`):

- `input/ig.xml`: version → `6.1.1-draft`, releaselabel → `Draft`
- `publication-request.json`: version/path → `6.1.1-draft`, status `draft`, sequence `R7`, desc updated
- `input/pagecontent/changes.md`: release header filled in (6.1.1-draft, 2026-07-03)
- `input/pagecontent/testing-note.md` (+ include on index): testing-event banner, as on 6.1.0-draft1

Unlike the `6.1.0-draft1` release commit, no `package-list.json`/`package-feed.xml` are checked in (the pipeline sources those from live prod; master deleted the stray copy in c830255b).

## Release steps after merge

1. Merge → the pipeline auto-deploys the working build to **preprod** — validate content and `qa.html` at preprod.hl7.org.au/fhir/6.1.1-draft/ (this build includes the publications#9 package-cache fix).
2. Tag `release-6.1.1-draft` on the merge commit → publishes to prod automatically (draft = working snapshot), then the ~4-hourly registry crawl picks it up.