### PR TITLE
Pass deploy_preprod through to the centralized pipeline

### DIFF
--- a/.github/workflows/build-review-publish.yml
+++ b/.github/workflows/build-review-publish.yml
@@ -27,6 +27,10 @@ on:
         description: "Publish the WORKING build to prod S3 (versioned snapshot, NOT current; gated)"
         type: boolean
         default: false
+      deploy_preprod:
+        description: "Deploy this build to preprod (staging behind the real CloudFront setup)"
+        type: boolean
+        default: false
 
 permissions:
   id-token: write
@@ -40,4 +44,5 @@ jobs:
       ref: ${{ inputs.ref || '' }}
       publish_milestone: ${{ inputs.publish_milestone || false }}
       publish_working: ${{ inputs.publish_working || false }}
+      deploy_preprod: ${{ inputs.deploy_preprod || false }}
     secrets: inherit


### PR DESCRIPTION
Companion to hl7au/publications#10: dispatch with `ref=<branch>` + `deploy_preprod=true` stages that branch's build on preprod (real CloudFront, so qa.html/publish-box behave as on prod). First use case: staging #1081 (6.1.1-draft) before merge.