### PR TITLE
Disable the dynamic-source-viewers IG parameter

### DIFF
--- a/input/ig.xml
+++ b/input/ig.xml
@@ -2062,14 +2062,6 @@
 			<code value="shownav"/>
 			<value value="false"/>
 		</parameter>
-		<!-- A3: render json/xml/ttl "view source" pages client-side from the raw files (Prism),
-		     instead of baking large escaped-source HTML. Opt-in; ~86% smaller viewer pages.
-		     Requires the dynamic-source-viewers code registered in hl7.fhir.uv.tools (else 4
-		     cosmetic QA "code not in value set" warnings). -->
-		<parameter>
-			<code value="dynamic-source-viewers"/>
-			<value value="true"/>
-		</parameter>
 		<parameter>
 			<code value="apply-version"/>
 			<value value="true"/>


### PR DESCRIPTION
The `dynamic-source-viewers` parameter in `input/ig.xml` is opt-in, but its code is not registered in `hl7.fhir.uv.tools`'s ig-parameters value set, so every build of the IG emits 4 "code not in value set" errors for it. That includes the build.fhir.org CI build, not just our pipeline.

The client-side source rendering it enables is not worth that QA noise until the code is registered upstream, so this removes the parameter to turn it off.

Effect: the 4 dynamic-source-viewers errors drop out of QA; source pages fall back to the standard baked rendering. Targets `release-6.1.1-draft-prep` so the 6.1.1-draft build is clean, and reaches `master` via #1081.