### PR TITLE
Add Endpoint examples for the HL7 AU reference and terminology servers

### DIFF
--- a/input/examples/endpoint-example2.xml
+++ b/input/examples/endpoint-example2.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Endpoint xmlns="http://hl7.org/fhir">
+  <id value="example2"/>
+  <meta>
+    <profile value="http://hl7.org.au/fhir/StructureDefinition/au-endpoint"/>
+  </meta>
+  <extension url="http://hl7.org/fhir/5.0/StructureDefinition/extension-Endpoint.environmentType">
+    <valueCodeableConcept>
+      <coding>
+        <system value="http://hl7.org/fhir/endpoint-environment"/>
+        <code value="test"/>
+        <display value="Test"/>
+      </coding>
+    </valueCodeableConcept>
+  </extension>
+  <status value="active"/>
+  <connectionType>
+    <system value="http://terminology.hl7.org/CodeSystem/endpoint-connection-type"/>
+    <code value="hl7-fhir-rest"/>
+    <display value="HL7 FHIR"/>
+  </connectionType>
+  <name value="HL7 AU Reference FHIR Server"/>
+  <managingOrganization>
+    <display value="HL7 Australia"/>
+  </managingOrganization>
+  <contact>
+    <system value="url"/>
+    <value value="https://hl7.org.au/"/>
+    <use value="work"/>
+  </contact>
+  <payloadType>
+    <coding>
+      <system value="http://terminology.hl7.org/CodeSystem/endpoint-payload-type"/>
+      <code value="any"/>
+      <display value="Any"/>
+    </coding>
+  </payloadType>
+  <payloadMimeType value="application/fhir+json"/>
+  <payloadMimeType value="application/fhir+xml"/>
+  <address value="https://fhir.hl7.org.au/aucore/fhir/default"/>
+</Endpoint>

--- a/input/examples/endpoint-example3.xml
+++ b/input/examples/endpoint-example3.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Endpoint xmlns="http://hl7.org/fhir">
+  <id value="example3"/>
+  <meta>
+    <profile value="http://hl7.org.au/fhir/StructureDefinition/au-endpoint"/>
+  </meta>
+  <extension url="http://hl7.org/fhir/5.0/StructureDefinition/extension-Endpoint.environmentType">
+    <valueCodeableConcept>
+      <coding>
+        <system value="http://hl7.org/fhir/endpoint-environment"/>
+        <code value="prod"/>
+        <display value="Production"/>
+      </coding>
+    </valueCodeableConcept>
+  </extension>
+  <status value="active"/>
+  <connectionType>
+    <system value="http://terminology.hl7.org/CodeSystem/endpoint-connection-type"/>
+    <code value="hl7-fhir-rest"/>
+    <display value="HL7 FHIR"/>
+  </connectionType>
+  <name value="HL7 AU Terminology Server"/>
+  <managingOrganization>
+    <display value="HL7 Australia"/>
+  </managingOrganization>
+  <contact>
+    <system value="url"/>
+    <value value="https://hl7.org.au/"/>
+    <use value="work"/>
+  </contact>
+  <payloadType>
+    <coding>
+      <system value="http://terminology.hl7.org/CodeSystem/endpoint-payload-type"/>
+      <code value="any"/>
+      <display value="Any"/>
+    </coding>
+  </payloadType>
+  <payloadMimeType value="application/fhir+json"/>
+  <payloadMimeType value="application/fhir+xml"/>
+  <address value="https://tx.hl7.org.au/fhir"/>
+</Endpoint>

--- a/input/ig.xml
+++ b/input/ig.xml
@@ -1155,6 +1155,22 @@
 		</resource>
 		<resource>
 			<reference>
+				<reference value="Endpoint/example2"/>
+			</reference>
+			<name value="Endpoint - the HL7 AU reference FHIR server"/>
+			<description value="Shows an example of a FHIR RESTful API endpoint for the HL7 AU reference FHIR server, where the supported payload is discovered from the server's CapabilityStatement rather than declared in the endpoint."/>
+			<exampleCanonical value="http://hl7.org.au/fhir/StructureDefinition/au-endpoint"/>
+		</resource>
+		<resource>
+			<reference>
+				<reference value="Endpoint/example3"/>
+			</reference>
+			<name value="Endpoint - the HL7 AU terminology server"/>
+			<description value="Shows an example of a FHIR RESTful API endpoint for the HL7 AU terminology server, where the supported payload and terminology capability are discovered from the server's CapabilityStatement and terminology capabilities rather than declared in the endpoint."/>
+			<exampleCanonical value="http://hl7.org.au/fhir/StructureDefinition/au-endpoint"/>
+		</resource>
+		<resource>
+			<reference>
 				<reference value="Location/example3"/>
 			</reference>
 			<name value="Location - of a Practitioner as a General Practitioner"/>


### PR DESCRIPTION
Adds two Endpoint examples requested for the ballot snapshot:

- `Endpoint/example2` HL7 AU reference FHIR server, `https://fhir.hl7.org.au/aucore/fhir/default`
- `Endpoint/example3` HL7 AU terminology server, `https://tx.hl7.org.au/fhir`

Both are registered in `ig.xml` with `exampleCanonical` set to the AU Base Endpoint profile.

Modelling notes for review:

- `connectionType` is `hl7-fhir-rest` from `http://terminology.hl7.org/CodeSystem/endpoint-connection-type`, which is in the extensible binding via Endpoint Connection Type - AU Extended.
- `payloadType` is `any` from `http://terminology.hl7.org/CodeSystem/endpoint-payload-type`, which is in the preferred binding via Endpoint Payload Type - AU Extended. This follows the position that for a FHIR RESTful endpoint the actual capability is discovered from the server's CapabilityStatement (and terminology capabilities for the tx server), rather than being enumerated on the Endpoint.
- `environmentType` (R5 cross-version extension, as already used by `example1`) is `test` for the reference server and `prod` for the terminology server.
- No `identifier` is asserted, since there is no established identifier namespace for these endpoints. Happy to add one if there is a preferred system.
- `managingOrganization` is a display-only reference to HL7 Australia, as there is no HL7 AU Organization example in the IG to point at.

Open question raised in discussion but not implemented here: an extension to reference the supported IG / actor so that conformance can be determined without visiting the endpoint. There is no standard extension for this yet (US NDH has a custom one), so it is left out pending a decision.